### PR TITLE
refactor: 공통 모듈 의존성 분리 및 api-gateway 테스트 완료

### DIFF
--- a/api-gateway/build.gradle
+++ b/api-gateway/build.gradle
@@ -7,13 +7,15 @@ dependencies {
     implementation 'org.springframework.cloud:spring-cloud-starter-gateway-server-webflux'
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
 
-    // [Redis]
-    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
-
     // [JWT]
     implementation 'io.jsonwebtoken:jjwt-api:0.13.0'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.13.0'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.13.0'
+
+    // [DB - Redis]
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    testImplementation 'org.springframework.boot:spring-boot-starter-data-redis-test'
+
 }
 
 dependencyManagement {

--- a/api-gateway/src/main/resources/application.yml
+++ b/api-gateway/src/main/resources/application.yml
@@ -10,13 +10,13 @@ spring:
             - id: auth-jwt
               uri: http://localhost:8081
               predicates:
-                - Path=/auth/logout
+                - Path=/api/auth/logout
               filters:
                 - JwtAuthenticationFilter
             - id: auth
               uri: http://localhost:8081
               predicates:
-                - Path=/auth/**
+                - Path=/api/auth/**
 
 
 jwt:

--- a/auth-server/build.gradle
+++ b/auth-server/build.gradle
@@ -1,6 +1,13 @@
 dependencies {
 	implementation project(':common')
 
+    // [Core]
+    api 'org.springframework.boot:spring-boot-starter-web'
+    api 'org.springframework.boot:spring-boot-starter-validation'
+    testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    // [Security]
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 	testImplementation 'org.springframework.boot:spring-boot-starter-security-test'
@@ -8,4 +15,15 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-api:0.13.0'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.13.0'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.13.0'
+
+    // [DB - JPA, MySQL, Redis]
+    api 'org.springframework.boot:spring-boot-starter-data-jpa'
+    testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
+    api 'com.mysql:mysql-connector-j'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    testImplementation 'org.springframework.boot:spring-boot-starter-data-redis-test'
+
+    // [Mail]
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
+
 }

--- a/auth-server/src/main/java/com/truve/platform/user/service/controller/EmailController.java
+++ b/auth-server/src/main/java/com/truve/platform/user/service/controller/EmailController.java
@@ -13,11 +13,11 @@ import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/email")
+@RequestMapping("/api/auth/email")
 public class EmailController {
 	private final EmailService emailService;
 
-	@PostMapping
+	@PostMapping("/send-code")
 	public ApiResult<Void> sendMail(
 		@RequestBody EmailRequest.SendVerificationCode request
 	) {

--- a/auth-server/src/main/resources/application.yml
+++ b/auth-server/src/main/resources/application.yml
@@ -1,5 +1,5 @@
 server:
-  port: 8080
+  port: 8081
 
 spring:
   datasource:

--- a/build.gradle
+++ b/build.gradle
@@ -36,21 +36,7 @@ subprojects {
         compileOnly 'org.projectlombok:lombok'
         annotationProcessor 'org.projectlombok:lombok'
 
-        // [Core]
-        api 'org.springframework.boot:spring-boot-starter-web'
-        api 'org.springframework.boot:spring-boot-starter-validation'
-        testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
-        testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
-        // [DB - JPA, MySQL, Redis]
-        api 'org.springframework.boot:spring-boot-starter-data-jpa'
-        testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
-        api 'com.mysql:mysql-connector-j'
-        implementation 'org.springframework.boot:spring-boot-starter-data-redis'
-        testImplementation 'org.springframework.boot:spring-boot-starter-data-redis-test'
-
-        // [Mail]
-        implementation 'org.springframework.boot:spring-boot-starter-mail'
     }
 
     tasks.named('test') {

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -1,2 +1,17 @@
 bootJar { enabled = false }
 jar { enabled = true }
+
+dependencies {
+
+    // [Core]
+    api 'org.springframework.boot:spring-boot-starter-web'
+    api 'org.springframework.boot:spring-boot-starter-validation'
+    testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    // [DB - JPA, MySQL]
+    api 'org.springframework.boot:spring-boot-starter-data-jpa'
+    testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
+    api 'com.mysql:mysql-connector-j'
+
+}


### PR DESCRIPTION
## 변경 사항

api-gateway는 서블릿 기반이 아닌 리액티브 기반이기 때문에 mvc관련 의존성이 작동되면
빌드가 실패해 공통으로 관리되던 의존성을 사용 목적에 따라 분리했습니다.

또한 api-gateway에서 라우팅 일관성을 위해 auth-server 내 엔드포인트 /auth로 시작하도록 변경했습니다.

- [x] 주요 API 포스트맨 테스트
 
>POST /api/email
POST /api/email/verify
POST /api/auth/sign-up
POST /api/auth/login

## 관련 이슈

#6: [Refactor] 공통 build.gradle 의존성 분리

## 참고사항 (선택)

1. 새로운 서비스 추가 시
- 서비스 포트번호 유의하여 세팅
- api-gateway application.yml에 uri 추가 이후 외부 api통신은 전부 8080포트로 전송하여 라우팅
