### PR TITLE
feat(swagger): Swagger(OpenAPI) 설정 및 서비스별 API 문서 통합

### DIFF
--- a/api-gateway/build.gradle
+++ b/api-gateway/build.gradle
@@ -16,6 +16,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     testImplementation 'org.springframework.boot:spring-boot-starter-data-redis-test'
 
+    // [OpenApi]
+    implementation 'org.springdoc:springdoc-openapi-starter-webflux-ui'
 }
 
 dependencyManagement {

--- a/api-gateway/src/main/java/com/truve/platform/apigateway/config/CorsConfig.java
+++ b/api-gateway/src/main/java/com/truve/platform/apigateway/config/CorsConfig.java
@@ -1,0 +1,37 @@
+package com.truve.platform.apigateway.config;
+
+import java.util.List;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.reactive.CorsWebFilter;
+import org.springframework.web.cors.reactive.UrlBasedCorsConfigurationSource;
+
+@Configuration
+public class CorsConfig {
+
+	private static final List<String> ALLOWED_ORIGIN_PATTERNS = List.of(
+		"http://localhost:[*]",
+		"http://127.0.0.1:[*]"
+	);
+	private static final List<String> ALLOWED_HEADERS = List.of("*");
+	private static final List<String> ALLOWED_METHODS = List.of("*");
+
+	@Bean
+	public CorsWebFilter corsWebFilter() {
+		UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+		source.registerCorsConfiguration("/**", getCorsConfiguration());
+		return new CorsWebFilter(source);
+	}
+
+	private CorsConfiguration getCorsConfiguration() {
+		CorsConfiguration config = new CorsConfiguration();
+		config.setAllowCredentials(true);
+		config.setAllowedOriginPatterns(ALLOWED_ORIGIN_PATTERNS);
+		config.setAllowedHeaders(ALLOWED_HEADERS);
+		config.setAllowedMethods(ALLOWED_METHODS);
+		config.setMaxAge(3600L);
+		return config;
+	}
+}

--- a/api-gateway/src/main/resources/application.yml
+++ b/api-gateway/src/main/resources/application.yml
@@ -17,9 +17,23 @@ spring:
               uri: http://localhost:8081
               predicates:
                 - Path=/api/auth/**
+            - id: payment
+              uri: http://localhost:8082
+              predicates:
+                - Path=/api/payment/**
 
 
 jwt:
   secret: ${kt.jwt.secret:kt-cloud-tech-up-final-project-2026020201010101}
   access-token-expiration: ${kt.jwt.access-token-expiration:300000} # 5
   refresh-token-expiration: ${kt.jwt.refresh-token-expiration:43200000} # 12
+
+springdoc:
+  swagger-ui:
+    enabled: true
+    disable-swagger-default-url: true
+    urls:
+      - name: "01-Auth Service"
+        url: /api/auth/v3/api-docs
+      - name: "02-Payment Service"
+        url: /api/payment/v3/api-docs

--- a/auth-server/build.gradle
+++ b/auth-server/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
-	implementation project(':common')
+    implementation project(':common')
 
     // [Core]
     api 'org.springframework.boot:spring-boot-starter-web'
@@ -8,9 +8,9 @@ dependencies {
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
     // [Security]
-	implementation 'org.springframework.boot:spring-boot-starter-security'
-	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
-	testImplementation 'org.springframework.boot:spring-boot-starter-security-test'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+    testImplementation 'org.springframework.boot:spring-boot-starter-security-test'
 
     implementation 'io.jsonwebtoken:jjwt-api:0.13.0'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.13.0'
@@ -25,5 +25,8 @@ dependencies {
 
     // [Mail]
     implementation 'org.springframework.boot:spring-boot-starter-mail'
+
+    // [OpenApi]
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui'
 
 }

--- a/auth-server/src/main/resources/application.yml
+++ b/auth-server/src/main/resources/application.yml
@@ -38,3 +38,7 @@ jwt:
   secret: ${kt.jwt.secret:kt-cloud-tech-up-final-project-2026020201010101}
   access-token-expiration: ${kt.jwt.access-token-expiration:300000} # 5
   refresh-token-expiration: ${kt.jwt.refresh-token-expiration:43200000} # 12
+
+springdoc:
+  api-docs:
+    path: /api/auth/v3/api-docs

--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,7 @@ subprojects {
         compileOnly 'org.projectlombok:lombok'
         annotationProcessor 'org.projectlombok:lombok'
 
+        implementation platform('org.springdoc:springdoc-openapi-bom:3.0.1')
 
     }
 

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -14,4 +14,6 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
     api 'com.mysql:mysql-connector-j'
 
+    // [OpenApi]
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-api'
 }

--- a/common/src/main/java/com/truve/platform/common/config/OpenApiConfig.java
+++ b/common/src/main/java/com/truve/platform/common/config/OpenApiConfig.java
@@ -8,7 +8,7 @@ import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.servers.Server;
 
 @Configuration
-public class OpenApiConfig { // 명칭 변경!
+public class OpenApiConfig {
 
 	@Bean
 	public OpenAPI customOpenAPI() {

--- a/common/src/main/java/com/truve/platform/common/config/OpenApiConfig.java
+++ b/common/src/main/java/com/truve/platform/common/config/OpenApiConfig.java
@@ -1,0 +1,22 @@
+package com.truve.platform.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.servers.Server;
+
+@Configuration
+public class OpenApiConfig { // 명칭 변경!
+
+	@Bean
+	public OpenAPI customOpenAPI() {
+		return new OpenAPI()
+			.addServersItem(new Server().url("/").description("Default Server"))
+			.info(new Info()
+				.title("Truve Platform API")
+				.description("API 문서")
+				.version("v1.0.0"));
+	}
+}

--- a/payment/build.gradle
+++ b/payment/build.gradle
@@ -12,4 +12,7 @@ dependencies {
     api 'org.springframework.boot:spring-boot-starter-data-jpa'
     testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
     api 'com.mysql:mysql-connector-j'
+
+    // [OpenApi]
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui'
 }

--- a/payment/src/main/resources/application.yml
+++ b/payment/src/main/resources/application.yml
@@ -1,3 +1,7 @@
 spring:
   profiles:
     default: local
+
+springdoc:
+  api-docs:
+    path: /api/payment/v3/api-docs


### PR DESCRIPTION
## 변경 사항

---

기능 테스트에 필요해서 Swagger 세팅을 했습니다.

**1. 의존성 관리**

루트 build.gradle에 `springdoc-openapi-bom`을 추가하여 모든 모듈의 Swagger 버전 관리

api-gateway: Webflux 기반 Swagger 설정 적용

auth-server, payment: 서비스별 문서 확인을 위한 Swagger UI 적용 

common 설정 및 데이터 모델 공유를 위한 기본 API 적용

**2. OpenAPI 기본 설정 정의**

common 모듈에 `OpenApiConfig` 클래스를 작성하여 각 서비스에서 공통으로 사용할 OpenAPI 기본 설정을 정의했습니다.

**3. API Gateway 중심의 문서 통합**

API Gateway의 Swagger UI에서 auth-server와 payment 서비스의 API 문서를 한곳에서 볼 수 있도록 경로(/v3/api-docs)를 통합 설정했습니다.

라우팅 및 CORS: 로컬 개발 환경에서의 원활한 접근을 위해 CORS 설정을 적용했습니다. (`/apigateway/config/CorsConfig.java`)

## 관련 이슈

---
- Notion Ticket: #17

## 참고사항 (선택)

---

- 기존 기능과 앞으로의 기능에 대해 Swagger 문서 관리 부탁드립니다!

- 기능이 얼마 없는 상태에서 세팅해서 타 기능, 모듈 추가시 에러 발생할 수 있습니다. Payment 모듈 내에서 테스트 진행하고 바로바로 수정해보겠습니다.. 😭

- Swagger 링크: `localhost:{port}/swagger-ui.html`
