### PR TITLE
feat(payment): 결제 생성 및 승인 비즈니스 로직 및 API 구현

### DIFF
--- a/api-gateway/src/main/resources/application.yml
+++ b/api-gateway/src/main/resources/application.yml
@@ -20,7 +20,7 @@ spring:
             - id: payment
               uri: ${PAYMENT_SERVER_URI:http://localhost:8082}
               predicates:
-                - Path=/api/payment/**
+                - Path=/api/payments/**
 
 
 jwt:
@@ -36,4 +36,4 @@ springdoc:
       - name: "01-Auth Service"
         url: /api/auth/v3/api-docs
       - name: "02-Payment Service"
-        url: /api/payment/v3/api-docs
+        url: /api/payments/v3/api-docs

--- a/common/src/main/java/com/truve/platform/common/exception/ApiAdvice.java
+++ b/common/src/main/java/com/truve/platform/common/exception/ApiAdvice.java
@@ -31,7 +31,7 @@ public class ApiAdvice {
 
 	@ExceptionHandler(CustomException.class)
 	public ResponseEntity<ErrorResponse.ErrorData> customException(CustomException e) {
-		return ErrorResponse.error(e.getErrorCode().getStatus(), e.getErrorCode().getMessage());
+		return ErrorResponse.error(e.getErrorCode().getStatus(), e.getMessage());
 	}
 
 	@ExceptionHandler(MethodArgumentNotValidException.class)

--- a/common/src/main/java/com/truve/platform/common/exception/CustomException.java
+++ b/common/src/main/java/com/truve/platform/common/exception/CustomException.java
@@ -7,9 +7,18 @@ public class CustomException extends RuntimeException {
 
 	private final ErrorCode errorCode;
 
+	private final String message;
+
 	public CustomException(ErrorCode errorCode) {
 		super(errorCode.getMessage());
 		this.errorCode = errorCode;
+		this.message = errorCode.getMessage();
+	}
+
+	public CustomException(ErrorCode errorCode, String message) {
+		super(message);
+		this.errorCode = errorCode;
+		this.message = message;
 	}
 
 }

--- a/common/src/main/java/com/truve/platform/common/exception/ErrorCode.java
+++ b/common/src/main/java/com/truve/platform/common/exception/ErrorCode.java
@@ -26,7 +26,8 @@ public enum ErrorCode {
 	INVALID_PAYMENT_STATUS(HttpStatus.BAD_REQUEST, "처리할 수 없는 결제 상태입니다."),
 	INVALID_PAYMENT_KEY(HttpStatus.BAD_REQUEST, "유효하지 않은 결제 키입니다."),
 	MUST_CANCEL_FULL(HttpStatus.BAD_REQUEST, "전액 취소만 가능한 건입니다."),
-	ALREADY_EXIST_PAYMENT(HttpStatus.BAD_REQUEST, "이미 존재하는 결제입니다.");
+	ALREADY_EXIST_PAYMENT(HttpStatus.BAD_REQUEST, "이미 존재하는 결제입니다."),
+	EXTERNAL_PAYMENT_ERROR(HttpStatus.BAD_REQUEST, "결제 대행사 오류가 발생했습니다.");
 
 	private final HttpStatus status;
 	private final String message;

--- a/common/src/main/java/com/truve/platform/common/exception/ErrorCode.java
+++ b/common/src/main/java/com/truve/platform/common/exception/ErrorCode.java
@@ -23,7 +23,8 @@ public enum ErrorCode {
 	INVALID_CANCEL_AMOUNT(HttpStatus.BAD_REQUEST, "유효하지 않은 취소 금액입니다."),
 	INVALID_PAYMENT_STATUS(HttpStatus.BAD_REQUEST, "처리할 수 없는 결제 상태입니다."),
 	INVALID_PAYMENT_KEY(HttpStatus.BAD_REQUEST, "유효하지 않은 결제 키입니다."),
-	MUST_CANCEL_FULL(HttpStatus.BAD_REQUEST, "전액 취소만 가능한 건입니다.");
+	MUST_CANCEL_FULL(HttpStatus.BAD_REQUEST, "전액 취소만 가능한 건입니다."),
+	ALREADY_EXIST_PAYMENT(HttpStatus.BAD_REQUEST, "이미 존재하는 결제입니다.");
 
 	private final HttpStatus status;
 	private final String message;

--- a/common/src/main/java/com/truve/platform/common/exception/ErrorCode.java
+++ b/common/src/main/java/com/truve/platform/common/exception/ErrorCode.java
@@ -18,6 +18,8 @@ public enum ErrorCode {
 	ALREADY_VERIFIED_EMAIL(HttpStatus.BAD_REQUEST, "이미 인증된 이메일입니다."),
 	INVALID_REFRESH_TOKEN(HttpStatus.BAD_REQUEST, "리프레시 토큰이 올바르지 않습니다."),
 
+	NOT_FOUND_PAYMENT(HttpStatus.BAD_REQUEST, "존재하지 않는 결제입니다."),
+	INVALID_PAYMENT_AMOUNT(HttpStatus.BAD_REQUEST, "유효하지 않은 결제 금액입니다."),
 	NOT_ENOUGH_CANCELABLE_AMOUNT(HttpStatus.BAD_REQUEST, "취소 가능 잔액이 부족합니다."),
 	ALREADY_CANCELED_PAYMENT(HttpStatus.BAD_REQUEST, "이미 전액 취소된 결제입니다."),
 	INVALID_CANCEL_AMOUNT(HttpStatus.BAD_REQUEST, "유효하지 않은 취소 금액입니다."),

--- a/common/src/main/java/com/truve/platform/common/support/RestClientConfig.java
+++ b/common/src/main/java/com/truve/platform/common/support/RestClientConfig.java
@@ -1,0 +1,13 @@
+package com.truve.platform.common.support;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestClient;
+
+@Configuration
+public class RestClientConfig {
+	@Bean
+	public RestClient restClient() {
+		return RestClient.create();
+	}
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -88,6 +88,7 @@ services:
       - PAYMENT_MYSQL_USERNAME=root
       - PAYMENT_MYSQL_PASSWORD=1234
       - SPRING_PROFILES_ACTIVE=local
+      - TOSS_SECRET_KEY=${TOSS_SECRET_KEY}
     depends_on:
       db:
         condition: service_healthy

--- a/payment/build.gradle
+++ b/payment/build.gradle
@@ -5,6 +5,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
+    testImplementation 'org.springframework.boot:spring-boot-starter-restclient-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     testRuntimeOnly 'com.h2database:h2'
 

--- a/payment/src/main/java/com/truve/platform/payment/service/controller/PaymentController.java
+++ b/payment/src/main/java/com/truve/platform/payment/service/controller/PaymentController.java
@@ -1,9 +1,17 @@
 package com.truve.platform.payment.service.controller;
 
+import java.net.URI;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.util.UriComponentsBuilder;
 
 import com.truve.platform.common.response.ApiResult;
 import com.truve.platform.payment.service.dto.PaymentRequest;
@@ -18,11 +26,49 @@ import lombok.RequiredArgsConstructor;
 public class PaymentController {
 	private final PaymentService paymentService;
 
+	@Value("${app.frontend.success-url}")
+	private String successUrl;
+
+	@Value("${app.frontend.fail-url}")
+	private String failUrl;
+
 	@PostMapping
 	public ApiResult<PaymentResponse.Create> create(@RequestBody PaymentRequest.Create request) {
 		Long paymentId = paymentService.create(request);
 		var response = new PaymentResponse.Create(paymentId);
 
 		return ApiResult.ok(response);
+	}
+
+	@GetMapping("/confirm")
+	public ResponseEntity<Void> confirm(
+		@RequestParam String paymentType,
+		@RequestParam String orderId,
+		@RequestParam String paymentKey,
+		@RequestParam Long amount
+	) {
+		paymentService.confirm(orderId, paymentKey, amount);
+
+		return ResponseEntity.status(HttpStatus.FOUND)
+			.location(URI.create(successUrl + "?orderId=" + orderId))
+			.build();
+	}
+
+	@GetMapping("/fail")
+	public ResponseEntity<Void> fail(
+		@RequestParam String code,
+		@RequestParam String message,
+		@RequestParam String orderId
+	) {
+		String redirectUrl = UriComponentsBuilder.fromPath(failUrl)
+			.queryParam("code", code)
+			.queryParam("message", message)
+			.queryParam("orderId", orderId)
+			.build()
+			.toUriString();
+
+		return ResponseEntity.status(HttpStatus.FOUND)
+			.location(URI.create(redirectUrl))
+			.build();
 	}
 }

--- a/payment/src/main/java/com/truve/platform/payment/service/controller/PaymentController.java
+++ b/payment/src/main/java/com/truve/platform/payment/service/controller/PaymentController.java
@@ -1,0 +1,28 @@
+package com.truve.platform.payment.service.controller;
+
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.truve.platform.common.response.ApiResult;
+import com.truve.platform.payment.service.dto.PaymentRequest;
+import com.truve.platform.payment.service.dto.PaymentResponse;
+import com.truve.platform.payment.service.service.PaymentService;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/payments")
+public class PaymentController {
+	private final PaymentService paymentService;
+
+	@PostMapping
+	public ApiResult<PaymentResponse.Create> create(@RequestBody PaymentRequest.Create request) {
+		Long paymentId = paymentService.create(request);
+		var response = new PaymentResponse.Create(paymentId);
+
+		return ApiResult.ok(response);
+	}
+}

--- a/payment/src/main/java/com/truve/platform/payment/service/controller/PaymentController.java
+++ b/payment/src/main/java/com/truve/platform/payment/service/controller/PaymentController.java
@@ -18,6 +18,9 @@ import com.truve.platform.payment.service.dto.PaymentRequest;
 import com.truve.platform.payment.service.dto.PaymentResponse;
 import com.truve.platform.payment.service.service.PaymentService;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -32,15 +35,19 @@ public class PaymentController {
 	@Value("${app.frontend.fail-url}")
 	private String failUrl;
 
+	@Operation(summary = "결제 생성", description = "Toss Payments에 결제를 요청하기 전에 호출해 주세요")
 	@PostMapping
-	public ApiResult<PaymentResponse.Create> create(@RequestBody PaymentRequest.Create request) {
+	public ApiResult<PaymentResponse.Create> create(@RequestBody @Valid PaymentRequest.Create request) {
 		Long paymentId = paymentService.create(request);
 		var response = new PaymentResponse.Create(paymentId);
 
 		return ApiResult.ok(response);
 	}
 
+	@Operation(summary = "결제 승인",
+		description = "Toss Payments에서 결제 요청 승인 후 successUrl로 호출하는 API입니다. 프론트엔드의 성공 페이지로 orderId를 담아 리다이렉트 합니다.")
 	@GetMapping("/confirm")
+	@ApiResponse(responseCode = "302")
 	public ResponseEntity<Void> confirm(
 		@RequestParam String paymentType,
 		@RequestParam String orderId,
@@ -54,7 +61,10 @@ public class PaymentController {
 			.build();
 	}
 
+	@Operation(summary = "결제 실패",
+		description = "Toss Payments에서 결제 요청이 실패했을 때 failUrl로 호출하는 API입니다. 프론트엔드의 실패 페이지로 code, message, orderId를 담아 리다이렉트합니다.")
 	@GetMapping("/fail")
+	@ApiResponse(responseCode = "302")
 	public ResponseEntity<Void> fail(
 		@RequestParam String code,
 		@RequestParam String message,

--- a/payment/src/main/java/com/truve/platform/payment/service/domain/entity/Payment.java
+++ b/payment/src/main/java/com/truve/platform/payment/service/domain/entity/Payment.java
@@ -67,18 +67,30 @@ public class Payment extends BaseEntity {
 		this.status = PaymentStatus.READY;
 	}
 
-	public void waitDeposit(String paymentKey) {
-		validateWaitDepositStatus();
-
-		this.paymentKey = paymentKey;
-		this.status = PaymentStatus.WAITING_FOR_DEPOSIT;
-	}
-
 	public void expire() {
 		validateExpireStatus();
 
 		this.status = PaymentStatus.EXPIRED;
 		this.cancelableAmount = 0L;
+	}
+
+	public void validateAmount(Long amount) {
+		Preconditions.validate(this.amount.equals(amount), ErrorCode.INVALID_PAYMENT_AMOUNT);
+	}
+
+	public void processConfirm(String paymentKey) {
+		if (this.method == PaymentMethod.TRANSFER) {
+			waitDeposit(paymentKey);
+		} else {
+			complete(paymentKey);
+		}
+	}
+
+	public void waitDeposit(String paymentKey) {
+		validateWaitDepositStatus();
+
+		this.paymentKey = paymentKey;
+		this.status = PaymentStatus.WAITING_FOR_DEPOSIT;
 	}
 
 	public void complete(String paymentKey) {

--- a/payment/src/main/java/com/truve/platform/payment/service/domain/entity/Payment.java
+++ b/payment/src/main/java/com/truve/platform/payment/service/domain/entity/Payment.java
@@ -78,11 +78,11 @@ public class Payment extends BaseEntity {
 		Preconditions.validate(this.amount.equals(amount), ErrorCode.INVALID_PAYMENT_AMOUNT);
 	}
 
-	public void processConfirm(String paymentKey) {
+	public void processConfirm(String paymentKey, LocalDateTime approvedAt) {
 		if (this.method == PaymentMethod.TRANSFER) {
 			waitDeposit(paymentKey);
 		} else {
-			complete(paymentKey);
+			complete(paymentKey, approvedAt);
 		}
 	}
 
@@ -93,13 +93,13 @@ public class Payment extends BaseEntity {
 		this.status = PaymentStatus.WAITING_FOR_DEPOSIT;
 	}
 
-	public void complete(String paymentKey) {
+	public void complete(String paymentKey, LocalDateTime approvedAt) {
 		validateCompleteStatus();
 		verifyPaymentKey(paymentKey);
 
 		this.paymentKey = paymentKey;
 		this.status = PaymentStatus.DONE;
-		this.approvedAt = LocalDateTime.now();
+		this.approvedAt = approvedAt;
 	}
 
 	public void applyCancel(Long cancelAmount, String reason, CancelType type) {

--- a/payment/src/main/java/com/truve/platform/payment/service/dto/PaymentRequest.java
+++ b/payment/src/main/java/com/truve/platform/payment/service/dto/PaymentRequest.java
@@ -1,0 +1,24 @@
+package com.truve.platform.payment.service.dto;
+
+import com.truve.platform.payment.service.domain.constant.PaymentMethod;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+public class PaymentRequest {
+
+	@Getter
+	@AllArgsConstructor
+	public static class Create {
+		@NotBlank
+		private String orderId;
+		@NotNull
+		@Positive
+		private Long amount;
+		@NotNull
+		private PaymentMethod method;
+	}
+}

--- a/payment/src/main/java/com/truve/platform/payment/service/dto/PaymentResponse.java
+++ b/payment/src/main/java/com/truve/platform/payment/service/dto/PaymentResponse.java
@@ -1,0 +1,13 @@
+package com.truve.platform.payment.service.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+public class PaymentResponse {
+
+	@Getter
+	@AllArgsConstructor
+	public static class Create {
+		Long paymentId;
+	}
+}

--- a/payment/src/main/java/com/truve/platform/payment/service/repository/PaymentRepository.java
+++ b/payment/src/main/java/com/truve/platform/payment/service/repository/PaymentRepository.java
@@ -1,9 +1,22 @@
 package com.truve.platform.payment.service.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import com.truve.platform.common.exception.CustomException;
+import com.truve.platform.common.exception.ErrorCode;
 import com.truve.platform.payment.service.domain.entity.Payment;
 
 public interface PaymentRepository extends JpaRepository<Payment, Long> {
+
+	Optional<Payment> findByOrderId(String orderId);
+
 	boolean existsByOrderId(String orderId);
+
+	default Payment findByOrderIdOrThrow(String orderId) {
+		return findByOrderId(orderId).orElseThrow(
+			() -> new CustomException(ErrorCode.NOT_FOUND_PAYMENT)
+		);
+	}
 }

--- a/payment/src/main/java/com/truve/platform/payment/service/repository/PaymentRepository.java
+++ b/payment/src/main/java/com/truve/platform/payment/service/repository/PaymentRepository.java
@@ -1,0 +1,9 @@
+package com.truve.platform.payment.service.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.truve.platform.payment.service.domain.entity.Payment;
+
+public interface PaymentRepository extends JpaRepository<Payment, Long> {
+	boolean existsByOrderId(String orderId);
+}

--- a/payment/src/main/java/com/truve/platform/payment/service/service/PaymentService.java
+++ b/payment/src/main/java/com/truve/platform/payment/service/service/PaymentService.java
@@ -1,0 +1,32 @@
+package com.truve.platform.payment.service.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.truve.platform.common.exception.ErrorCode;
+import com.truve.platform.common.support.Preconditions;
+import com.truve.platform.payment.service.domain.entity.Payment;
+import com.truve.platform.payment.service.dto.PaymentRequest;
+import com.truve.platform.payment.service.repository.PaymentRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class PaymentService {
+
+	private final PaymentRepository paymentRepository;
+
+	@Transactional
+	public Long create(PaymentRequest.Create request) {
+		Preconditions.validate(!paymentRepository.existsByOrderId(request.getOrderId()), ErrorCode.ALREADY_EXIST_PAYMENT);
+
+		Payment payment = Payment.builder()
+			.orderId(request.getOrderId())
+			.amount(request.getAmount())
+			.method(request.getMethod())
+			.build();
+
+		return paymentRepository.save(payment).getId();
+	}
+}

--- a/payment/src/main/java/com/truve/platform/payment/service/service/PaymentService.java
+++ b/payment/src/main/java/com/truve/platform/payment/service/service/PaymentService.java
@@ -29,4 +29,15 @@ public class PaymentService {
 
 		return paymentRepository.save(payment).getId();
 	}
+
+	@Transactional
+	public void confirm(String orderId, String paymentKey, Long amount) {
+		Payment payment = paymentRepository.findByOrderIdOrThrow(orderId);
+
+		payment.validateAmount(amount);
+
+		// TODO Toss 결제 승인 API 호출
+
+		payment.processConfirm(paymentKey);
+	}
 }

--- a/payment/src/main/java/com/truve/platform/payment/service/service/external/TossClient.java
+++ b/payment/src/main/java/com/truve/platform/payment/service/service/external/TossClient.java
@@ -1,0 +1,42 @@
+package com.truve.platform.payment.service.service.external;
+
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+import com.truve.platform.payment.service.service.external.dto.TossRequest;
+import com.truve.platform.payment.service.service.external.dto.TossResponse;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class TossClient {
+
+	private final RestClient restClient;
+
+	@Value("${toss.payment.base-url}")
+	private String baseUrl;
+
+	@Value("${toss.payment.secret-key}")
+	private String secretKey;
+
+	public TossResponse.Payment confirm(TossRequest.Confirm request) {
+		return restClient.post()
+			.uri(URI.create(baseUrl + "confirm"))
+			.header("Authorization", getAuthorizations())
+			.contentType(MediaType.APPLICATION_JSON)
+			.body(request)
+			.retrieve()
+			.body(TossResponse.Payment.class);
+	}
+
+	private String getAuthorizations() {
+		return "Basic " + Base64.getEncoder().encodeToString((secretKey + ":").getBytes(StandardCharsets.UTF_8));
+	}
+}

--- a/payment/src/main/java/com/truve/platform/payment/service/service/external/dto/TossRequest.java
+++ b/payment/src/main/java/com/truve/platform/payment/service/service/external/dto/TossRequest.java
@@ -1,0 +1,18 @@
+package com.truve.platform.payment.service.service.external.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class TossRequest {
+
+	@Getter
+	@AllArgsConstructor
+	@NoArgsConstructor
+	public static class Confirm {
+		private String orderId;
+		private Long amount;
+		private String paymentKey;
+	}
+
+}

--- a/payment/src/main/java/com/truve/platform/payment/service/service/external/dto/TossResponse.java
+++ b/payment/src/main/java/com/truve/platform/payment/service/service/external/dto/TossResponse.java
@@ -47,4 +47,20 @@ public class TossResponse {
 		private String provider;
 		private Long amount;
 	}
+
+	@Getter
+	@NoArgsConstructor
+	public static class Error {
+		private String version;
+		private String traceId;
+		private ErrorDetail error;
+	}
+
+	@Getter
+	@NoArgsConstructor
+	public static class ErrorDetail {
+		private String code;
+		private String message;
+	}
+
 }

--- a/payment/src/main/java/com/truve/platform/payment/service/service/external/dto/TossResponse.java
+++ b/payment/src/main/java/com/truve/platform/payment/service/service/external/dto/TossResponse.java
@@ -1,0 +1,50 @@
+package com.truve.platform.payment.service.service.external.dto;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class TossResponse {
+
+	@Getter
+	@NoArgsConstructor
+	public static class Payment {
+		private String paymentKey;
+		private String orderId;
+		private Long totalAmount;
+		private String status;
+		private String approvedAt;
+
+		private Receipt receipt;
+		private Card card;
+		private EasyPay easyPay;
+
+		@JsonAnySetter
+		private Map<String, Object> others = new HashMap<>();
+	}
+
+	@Getter
+	@NoArgsConstructor
+	public static class Receipt {
+		private String url;
+	}
+
+	@Getter
+	@NoArgsConstructor
+	public static class Card {
+		private String issuerCode;
+		private String number;
+		private Integer installmentPlanMonths;
+	}
+
+	@Getter
+	@NoArgsConstructor
+	public static class EasyPay {
+		private String provider;
+		private Long amount;
+	}
+}

--- a/payment/src/main/resources/application-local.yml
+++ b/payment/src/main/resources/application-local.yml
@@ -15,3 +15,8 @@ spring:
       hibernate:
         format_sql: true
         dialect: org.hibernate.dialect.MySQLDialect
+
+app:
+  frontend:
+    success-url: /success-temp.html
+    fail-url: /fail-temp.html

--- a/payment/src/main/resources/application-prod.yml
+++ b/payment/src/main/resources/application-prod.yml
@@ -15,3 +15,9 @@ spring:
       hibernate:
         format_sql: true
         dialect: org.hibernate.dialect.MySQLDialect
+
+# TODO 프론트 URL 나온 후 수정 필요. 그 전까지 임시 html 사용
+app:
+  frontend:
+    success-url: /success-temp.html
+    fail-url: /fail-temp.html

--- a/payment/src/main/resources/application.yml
+++ b/payment/src/main/resources/application.yml
@@ -5,3 +5,8 @@ spring:
 springdoc:
   api-docs:
     path: /api/payment/v3/api-docs
+
+toss:
+  payment:
+    secret-key: ${TOSS_SECRET_KEY}
+    base-url: https://api.tosspayments.com/v1/payments/

--- a/payment/src/main/resources/application.yml
+++ b/payment/src/main/resources/application.yml
@@ -4,7 +4,7 @@ spring:
 
 springdoc:
   api-docs:
-    path: /api/payment/v3/api-docs
+    path: /api/payments/v3/api-docs
 
 toss:
   payment:

--- a/payment/src/main/resources/application.yml
+++ b/payment/src/main/resources/application.yml
@@ -8,5 +8,5 @@ springdoc:
 
 toss:
   payment:
-    secret-key: ${TOSS_SECRET_KEY}
+    secret-key: ${TOSS_SECRET_KEY:test_sk_tempKey}
     base-url: https://api.tosspayments.com/v1/payments/

--- a/payment/src/main/resources/static/fail-temp.html
+++ b/payment/src/main/resources/static/fail-temp.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>결제 실패</title>
+    <style>
+        body {
+            font-family: sans-serif;
+            text-align: center;
+            padding-top: 50px;
+            background-color: #fffafa;
+        }
+
+        .card {
+            border: 1px solid #ffcccb;
+            padding: 20px;
+            display: inline-block;
+            border-radius: 10px;
+            background-color: white;
+        }
+
+        .punch {
+            color: #e74c3c;
+            font-size: 50px;
+            margin-bottom: 10px;
+        }
+
+        .error-info {
+            text-align: left;
+            background: #f8f9fa;
+            padding: 15px;
+            border-radius: 8px;
+            margin-top: 15px;
+            font-size: 14px;
+        }
+
+        .error-info p {
+            margin: 5px 0;
+            color: #333;
+        }
+
+        .highlight {
+            font-weight: bold;
+            color: #e74c3c;
+        }
+    </style>
+</head>
+<body>
+<div class="card">
+    <div class="punch">( ✋˙࿁˙ )</div>
+    <h1>결제에 실패했습니다!</h1>
+    <p>무언가 잘못된 것 같아요...</p>
+
+    <div class="error-info">
+        <p><strong>주문 번호:</strong> <span id="orderId"></span></p>
+        <p><strong>에러 코드:</strong> <span id="code" class="highlight"></span></p>
+        <p><strong>에러 메시지:</strong> <span id="message"></span></p>
+    </div>
+
+    <p style="margin-top: 20px; font-size: 13px; color: #888;">
+        프론트엔드 연동 전까지 사용되는 임시 페이지입니다.
+    </p>
+</div>
+
+<script>
+    const urlParams = new URLSearchParams(window.location.search);
+
+    document.getElementById('orderId').innerText = urlParams.get('orderId') || '없음';
+    document.getElementById('code').innerText = urlParams.get('code') || 'UNKNOWN';
+    document.getElementById('message').innerText = urlParams.get('message') || '상세 사유가 전달되지 않았습니다.';
+</script>
+</body>
+</html>

--- a/payment/src/main/resources/static/success-temp.html
+++ b/payment/src/main/resources/static/success-temp.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>결제 성공</title>
+    <style>
+        body {
+            font-family: sans-serif;
+            text-align: center;
+            padding-top: 50px;
+            background-color: #fffafa;
+        }
+
+        .card {
+            border: 1px solid #ffcccb;
+            padding: 20px;
+            display: inline-block;
+            border-radius: 10px;
+            background-color: white;
+        }
+
+        .punch {
+            color: #41d32f;
+            font-size: 50px;
+            margin-bottom: 10px;
+        }
+
+        .error-info {
+            text-align: left;
+            background: #f8f9fa;
+            padding: 15px;
+            border-radius: 8px;
+            margin-top: 15px;
+            font-size: 14px;
+        }
+
+        .error-info p {
+            margin: 5px 0;
+            color: #333;
+        }
+
+        .highlight {
+            font-weight: bold;
+            color: #e74c3c;
+        }
+    </style>
+</head>
+<body>
+<div class="card">
+    <div class="punch">(៸៸¯ᗜ¯៸៸)</div>
+    <h1>결제에 성공했습니다.</h1>
+    <p>결제가 승인됐어요!</p>
+
+    <div class="error-info">
+        <p><strong>주문 번호:</strong> <span id="orderId"></span></p>
+    </div>
+
+    <p style="margin-top: 20px; font-size: 13px; color: #888;">
+        프론트엔드 연동 전까지 사용되는 임시 페이지입니다.
+    </p>
+</div>
+
+<script>
+    const urlParams = new URLSearchParams(window.location.search);
+
+    document.getElementById('orderId').innerText = urlParams.get('orderId') || '없음';
+</script>
+</body>
+</html>

--- a/payment/src/test/java/com/truve/platform/payment/service/controller/PaymentControllerTest.java
+++ b/payment/src/test/java/com/truve/platform/payment/service/controller/PaymentControllerTest.java
@@ -1,0 +1,71 @@
+package com.truve.platform.payment.service.controller;
+
+import static org.mockito.BDDMockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+import com.truve.platform.common.exception.CustomException;
+import com.truve.platform.common.exception.ErrorCode;
+import com.truve.platform.payment.service.domain.constant.PaymentMethod;
+import com.truve.platform.payment.service.dto.PaymentRequest;
+import com.truve.platform.payment.service.service.PaymentService;
+
+import tools.jackson.databind.ObjectMapper;
+
+@WebMvcTest(controllers = PaymentController.class)
+public class PaymentControllerTest {
+	@Autowired
+	private MockMvc mockMvc;
+	@Autowired
+	private ObjectMapper objectMapper;
+	@MockitoBean
+	private PaymentService paymentService;
+	@MockitoBean
+	private JpaMetamodelMappingContext jpaMetamodelMappingContext;
+
+	@Test
+	@DisplayName("결제 생성에 성공하면 200 OK와 생성된 paymentId를 응답한다.")
+	void 결제_생성() throws Exception {
+		// given
+		var request = new PaymentRequest.Create("orderId", 100L, PaymentMethod.CARD);
+		given(paymentService.create(any())).willReturn(1L);
+
+		// when
+		ResultActions resultActions = mockMvc.perform(post("/api/payments")
+			.contentType(MediaType.APPLICATION_JSON)
+			.content(objectMapper.writeValueAsString(request)));
+
+		// then
+		resultActions.andExpect(status().isOk());
+		verify(paymentService).create(any(PaymentRequest.Create.class));
+	}
+
+	@Test
+	@DisplayName("중복된 orderId로 요청한 경우, 400과 ALREADY_EXIST_PAYMENT를 응답한다. ")
+	void 결제_생성_중복_에러_테스트() throws Exception {
+		// given
+		var request = new PaymentRequest.Create("orderId", 100L, PaymentMethod.CARD);
+		given(paymentService.create(any()))
+			.willThrow(new CustomException(ErrorCode.ALREADY_EXIST_PAYMENT));
+
+		// when
+		ResultActions resultActions = mockMvc.perform(post("/api/payments")
+			.contentType(MediaType.APPLICATION_JSON)
+			.content(objectMapper.writeValueAsString(request)));
+
+		// then
+		resultActions.andExpect(status().isBadRequest()) // 400 에러가 나는지 확인
+			.andExpect(jsonPath("$.code").value("CLIENT_ERROR"))
+			.andExpect(jsonPath("$.message").exists());
+	}
+}

--- a/payment/src/test/java/com/truve/platform/payment/service/domain/entity/PaymentTest.java
+++ b/payment/src/test/java/com/truve/platform/payment/service/domain/entity/PaymentTest.java
@@ -400,4 +400,31 @@ class PaymentTest {
 			}
 		}
 	}
+
+	@Nested
+	@DisplayName("결제 금액 검증 테스트")
+	class ValidateAmountTest {
+
+		@Test
+		@DisplayName("기존 금액과 요청 금액이 다르면 INVALID_PAYMENT_AMOUNT 예외를 던진다")
+		void 결제금액_검증_예외() {
+			// given
+			Payment payment = createDefaultPayment();
+
+			// when & then
+			assertThatThrownBy(() -> payment.validateAmount(5000L))
+				.isInstanceOf(CustomException.class)
+				.hasFieldOrPropertyWithValue("errorCode", ErrorCode.INVALID_PAYMENT_AMOUNT);
+		}
+
+		@Test
+		@DisplayName("기존 금액과 요청 금액이 일치하면 예외를 던지지 않는다")
+		void it_does_not_throw_when_amount_matches() {
+			// given
+			Payment payment = createDefaultPayment();
+
+			// when & then
+			assertDoesNotThrow(() -> payment.validateAmount(DEFAULT_AMOUNT));
+		}
+	}
 }

--- a/payment/src/test/java/com/truve/platform/payment/service/domain/entity/PaymentTest.java
+++ b/payment/src/test/java/com/truve/platform/payment/service/domain/entity/PaymentTest.java
@@ -3,6 +3,8 @@ package com.truve.platform.payment.service.domain.entity;
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
 
+import java.time.LocalDateTime;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -41,7 +43,7 @@ class PaymentTest {
 
 	private Payment createCompletePayment() {
 		Payment payment = createDefaultPayment();
-		payment.complete(DEFAULT_PAYMENT_KEY);
+		payment.complete(DEFAULT_PAYMENT_KEY, LocalDateTime.now());
 		return payment;
 	}
 
@@ -147,7 +149,7 @@ class PaymentTest {
 				Payment payment = createDefaultPayment();
 
 				// when
-				payment.complete(DEFAULT_PAYMENT_KEY);
+				payment.complete(DEFAULT_PAYMENT_KEY, LocalDateTime.now());
 
 				// then
 				assertAll(
@@ -164,7 +166,7 @@ class PaymentTest {
 				payment.waitDeposit(DEFAULT_PAYMENT_KEY);
 
 				// when
-				payment.complete(DEFAULT_PAYMENT_KEY);
+				payment.complete(DEFAULT_PAYMENT_KEY, LocalDateTime.now());
 
 				// then
 				assertAll(
@@ -190,7 +192,7 @@ class PaymentTest {
 				Payment payment = createPaymentWithStatus(status);
 
 				// when & then
-				assertThatThrownBy(() -> payment.complete(DEFAULT_PAYMENT_KEY))
+				assertThatThrownBy(() -> payment.complete(DEFAULT_PAYMENT_KEY, LocalDateTime.now()))
 					.isInstanceOf(CustomException.class)
 					.hasFieldOrPropertyWithValue("errorCode", ErrorCode.INVALID_PAYMENT_STATUS);
 			}
@@ -203,7 +205,7 @@ class PaymentTest {
 				payment.waitDeposit(DEFAULT_PAYMENT_KEY);
 
 				// when & then
-				assertThatThrownBy(() -> payment.complete("임의의 결제 키"))
+				assertThatThrownBy(() -> payment.complete("임의의 결제 키", LocalDateTime.now()))
 					.isInstanceOf(CustomException.class)
 					.hasFieldOrPropertyWithValue("errorCode", ErrorCode.INVALID_PAYMENT_KEY);
 			}
@@ -248,7 +250,7 @@ class PaymentTest {
 			void 결제취소_성공_완료상태_전액환불() {
 				// given
 				Payment payment = createDefaultPayment();
-				payment.complete("테스트 결제 키");
+				payment.complete("테스트 결제 키", LocalDateTime.now());
 				Long cancelAmount = DEFAULT_AMOUNT;
 				String reason = "테스트 결제 사유";
 				CancelType type = CancelType.FULL;
@@ -273,7 +275,7 @@ class PaymentTest {
 			void 결제취소_성공_완료상태_부분환불() {
 				// given
 				Payment payment = createDefaultPayment();
-				payment.complete("테스트 결제 키");
+				payment.complete("테스트 결제 키", LocalDateTime.now());
 				Long cancelAmount = 6000L;
 				String reason = "테스트 결제 사유";
 				CancelType type = CancelType.PARTIAL;
@@ -298,7 +300,7 @@ class PaymentTest {
 			void 결제취소_성공_완료상태_부분환불_여러_번() {
 				// given
 				Payment payment = createDefaultPayment();
-				payment.complete("테스트 결제 키");
+				payment.complete("테스트 결제 키", LocalDateTime.now());
 				Long firstCancelAmount = 6000L;
 				Long secondCancelAmount = 3000L;
 				Long thirdCancelAmount = 1000L;

--- a/payment/src/test/java/com/truve/platform/payment/service/service/PaymentServiceTest.java
+++ b/payment/src/test/java/com/truve/platform/payment/service/service/PaymentServiceTest.java
@@ -1,0 +1,70 @@
+package com.truve.platform.payment.service.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.truve.platform.common.exception.CustomException;
+import com.truve.platform.common.exception.ErrorCode;
+import com.truve.platform.payment.service.domain.constant.PaymentMethod;
+import com.truve.platform.payment.service.domain.entity.Payment;
+import com.truve.platform.payment.service.dto.PaymentRequest;
+import com.truve.platform.payment.service.repository.PaymentRepository;
+
+@ExtendWith(MockitoExtension.class)
+class PaymentServiceTest {
+	@Mock
+	private PaymentRepository paymentRepository;
+
+	@InjectMocks
+	private PaymentService paymentService;
+
+	@Nested
+	@DisplayName("결제 생성 테스트")
+	class createPaymentTest {
+
+		private final PaymentRequest.Create request = new PaymentRequest.Create("orderId", 100L, PaymentMethod.CARD);
+
+		@Test
+		@DisplayName("새로운 결제를 요청하면 전달받은 결제 정보를 저장한다.")
+		void 결제_생성_성공() {
+			// given
+			var savedPayment = new Payment(request.getOrderId(), request.getAmount(), request.getMethod());
+			ReflectionTestUtils.setField(savedPayment, "id", 1L);
+
+			given(paymentRepository.save(any(Payment.class))).willReturn(savedPayment);
+
+			// when
+			Long paymentId = paymentService.create(request);
+
+			// then
+			assertThat(paymentId).isEqualTo(1L);
+			verify(paymentRepository).save(any(Payment.class));
+		}
+
+		@Test
+		@DisplayName("이미 동일한 주문 ID로 결제가 존재하면 예외가 발생한다.")
+		void 결제_생성_실패_중복_주문() {
+			// given
+			given(paymentRepository.existsByOrderId(request.getOrderId())).willReturn(true);
+
+			// when
+			CustomException exception = assertThrows(CustomException.class, () -> {
+				paymentService.create(request);
+			});
+
+			// then
+			verify(paymentRepository, never()).save(any(Payment.class));
+			assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.ALREADY_EXIST_PAYMENT);
+		}
+	}
+}

--- a/payment/src/test/java/com/truve/platform/payment/service/service/external/TossClientTest.java
+++ b/payment/src/test/java/com/truve/platform/payment/service/service/external/TossClientTest.java
@@ -1,0 +1,82 @@
+package com.truve.platform.payment.service.service.external;
+
+import static org.assertj.core.api.AssertionsForClassTypes.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.*;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.*;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.restclient.test.autoconfigure.RestClientTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestClient;
+
+import com.truve.platform.payment.service.service.external.dto.TossRequest;
+import com.truve.platform.payment.service.service.external.dto.TossResponse;
+
+@RestClientTest(TossClient.class)
+@TestPropertySource(properties = {
+	"toss.payment.base-url=https://api.tosspayments.com/v1/payments/",
+	"toss.payment.secret-key=test_sk_123456789"
+})
+class TossClientTest {
+
+	@Autowired
+	private TossClient tossClient;
+
+	@Autowired
+	private MockRestServiceServer mockServer;
+
+	@MockitoBean
+	private JpaMetamodelMappingContext jpaMetamodelMappingContext;
+
+	@TestConfiguration
+	static class TestConfig {
+		@Bean
+		public RestClient restClient(RestClient.Builder builder) {
+			return builder.build();
+		}
+	}
+
+	@Test
+	@DisplayName("토스 결제 승인 API를 호출하여 결과 결제 정보를 응답받는다.")
+	void 결제승인_호출_성공() {
+		// given
+		TossRequest.Confirm request = new TossRequest.Confirm("orderId", 100L, "paymentKey");
+		String expectedHeader =
+			"Basic " + Base64.getEncoder().encodeToString(("test_sk_123456789" + ":").getBytes(StandardCharsets.UTF_8));
+		String expectedResponse = """
+			{
+					"paymentKey": "paymentKey",
+			    "status": "DONE",
+			    "totalAmount": 100
+			}
+			""";
+
+		mockServer.expect(requestTo("https://api.tosspayments.com/v1/payments/confirm"))
+			.andExpect(header("Authorization", expectedHeader))
+			.andRespond(withSuccess(expectedResponse, MediaType.APPLICATION_JSON));
+
+		// when
+		TossResponse.Payment response = tossClient.confirm(request);
+
+		// then
+		assertAll(
+			() -> assertThat(response.getPaymentKey()).isEqualTo("paymentKey"),
+			() -> assertThat(response.getStatus()).isEqualTo("DONE"),
+			() -> assertThat(response.getTotalAmount()).isEqualTo(100L)
+		);
+		mockServer.verify();
+	}
+
+}


### PR DESCRIPTION
## 변경 사항

---

**결제 생성 및 승인 비즈니스 로직 및 API 구현**

- 결제 생성 API: Toss Payment 결제 요청 API 호출 전, 위변조 방지를 위해 주문 번호, 결제 금액, 결제 방식을 저장하는 기능
- 결제 승인 API: 결제 금액 검증 후 Toss Payment 승인 요청 API 호출, 프론트엔드의 성공 페이지 URL로 리다이렉트
- 결제 실패 API: 프론트엔드 실패 페이지 URL로 리다이렉트

**외부 API 호출을 위한 설정**

- common 모듈  `RestClientConfig` 클래스 추가
- payment 모듈 `TossClient` 클래스에 Toss 통신 코드 추가

**Payment 엔티티 개선**

Toss Payment 응답의 승인 시간을 저장하도록 confirm 파라미터 변경

**Custom Exception 커스텀 메세지 지원**

before: ErrorCode에 정의된 기본 메세지만 반환
after: 오버로딩으로 ErrorCode, Custom Message를 파라미터로 받는 커스텀 예외 메서드 재정의

**테스트 코드 작성**

추가한 기능에 대한 Entity, Service, Controller 테스트 코드 작성

- [x] 전체 테스트 코드 성공 여부

## 관련 이슈

---
- Notion Ticket: # 12

## 참고사항 (선택)

---
승인 API 테스트할 때 임의의 payment key 생성이 어려워서 추후 프론트엔드와 연동하거나 로컬 환경에서 토스 페이먼츠 UI 구현해 테스트해야 할 거 같습니다. 😭 시간 상의 문제로 간단한 테스트 후 PR 올립니다.

현재 카드 결제 READY -> DONE까지 구현됐고, 주중으로 웹훅 연동 후 무통장입금, 토스페이 결제 반영 예정입니다!