### PR TITLE
feat(infra): 개발 서버 CD 추가

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -37,3 +37,16 @@ jobs:
           tags: ${{ secrets.DOCKERHUB_USERNAME }}/${{ matrix.service }}:latest
           build-args: |
             SERVICE_NAME=${{ matrix.service }}
+
+  deploy:
+    needs: build-and-push
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Run scripts in server
+        uses: appleboy/ssh-action@master
+        with:
+          key: ${{ secrets.PRIVATE_KEY }}
+          host: ${{ secrets.HOST }}
+          username: ${{ secrets.USERNAME }}
+          script: ${{ secrets.DEPLOY_DEVELOP_SCRIPT }}


### PR DESCRIPTION
## 변경 사항

---
개발 서버용 CD 파이프라인 구축
- AWS EC2 서버에 ssh 접근하여 docker-compose.yml 재배포 실행

결과:     
http://13.124.107.32:8080/swagger-ui/index.html 

## 관련 이슈

---
- Notion Ticket: #

## 참고사항 (선택)

---

현재는 임시 CI/CD 환경이며, 개발 후 dev 브랜치 merge 시 자동화 빌드 & 배포가 수행됩니다.
추후 운영 서버가 구축되는대로 prod 파이프라인도 작성하겠습니다 :)