### PR TITLE
refactor(common): JPA Auditing 설정 제거 및 common 모듈 이관

### DIFF
--- a/auth-server/src/main/java/com/truve/platform/auth/service/AuthApplication.java
+++ b/auth-server/src/main/java/com/truve/platform/auth/service/AuthApplication.java
@@ -3,10 +3,8 @@ package com.truve.platform.auth.service;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication(scanBasePackages = "com.truve.platform")
-@EnableJpaAuditing
 @ConfigurationPropertiesScan
 
 public class AuthApplication {

--- a/common/src/main/java/com/truve/platform/common/config/JpaAuditConfig.java
+++ b/common/src/main/java/com/truve/platform/common/config/JpaAuditConfig.java
@@ -1,0 +1,9 @@
+package com.truve.platform.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditConfig {
+}

--- a/payment/src/main/java/com/truve/platform/payment/service/PaymentApplication.java
+++ b/payment/src/main/java/com/truve/platform/payment/service/PaymentApplication.java
@@ -3,10 +3,8 @@ package com.truve.platform.payment.service;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication(scanBasePackages = "com.truve.platform")
-@EnableJpaAuditing
 @ConfigurationPropertiesScan
 public class PaymentApplication {
 	public static void main(String[] args) {


### PR DESCRIPTION
## 변경 사항

---
메인 클래스의 @EnableJpaAuditing을 제거하고 common 모듈 내에 별도의 설정 클래스로 관리하여 자동 스캔되도록 변경

- [x] 전체 테스트 코드 성공 여부

변경 후 createdAt, updatedAt 정상적으로 작성되는 점 확인했습니다.

## 관련 이슈

---
- #25 

## 참고사항 (선택)

---
간단한 작업이라 PR 먼저 업로드했는데 이슈 읽어보시고 추가적인 의견 있으시면 편히 주세요~!