### PR TITLE
refactor(common): Error response 내 code 추가

### DIFF
--- a/common/src/main/java/com/truve/platform/common/exception/ApiAdvice.java
+++ b/common/src/main/java/com/truve/platform/common/exception/ApiAdvice.java
@@ -26,12 +26,12 @@ public class ApiAdvice {
 			e.getMessage()
 		);
 
-		return ErrorResponse.error(HttpStatus.INTERNAL_SERVER_ERROR, "서버에러입니다. 백엔드팀에 문의하세요.");
+		return ErrorResponse.error(HttpStatus.INTERNAL_SERVER_ERROR, "서버에러입니다. 백엔드팀에 문의하세요.", "C01");
 	}
 
 	@ExceptionHandler(CustomException.class)
 	public ResponseEntity<ErrorResponse.ErrorData> customException(CustomException e) {
-		return ErrorResponse.error(e.getErrorCode().getStatus(), e.getMessage());
+		return ErrorResponse.error(e.getErrorCode().getStatus(), e.getMessage(), e.getErrorCode().getCode());
 	}
 
 	@ExceptionHandler(MethodArgumentNotValidException.class)
@@ -39,7 +39,7 @@ public class ApiAdvice {
 		var details = Arrays.toString(e.getDetailMessageArguments());
 		var message = details.split(",", 2)[1].replace("]", "").trim();
 
-		return ErrorResponse.error(HttpStatus.BAD_REQUEST, message);
+		return ErrorResponse.error(HttpStatus.BAD_REQUEST, message, "C02");
 	}
 
 }

--- a/common/src/main/java/com/truve/platform/common/exception/CustomException.java
+++ b/common/src/main/java/com/truve/platform/common/exception/CustomException.java
@@ -25,4 +25,8 @@ public class CustomException extends RuntimeException {
 		this.code = code;
 	}
 
+	public CustomException(ErrorCode errorCode, String message) {
+		this(errorCode, message, errorCode.getCode());
+	}
+
 }

--- a/common/src/main/java/com/truve/platform/common/exception/CustomException.java
+++ b/common/src/main/java/com/truve/platform/common/exception/CustomException.java
@@ -9,16 +9,20 @@ public class CustomException extends RuntimeException {
 
 	private final String message;
 
+	private final String code;
+
 	public CustomException(ErrorCode errorCode) {
 		super(errorCode.getMessage());
 		this.errorCode = errorCode;
 		this.message = errorCode.getMessage();
+		this.code =  errorCode.getCode();
 	}
 
-	public CustomException(ErrorCode errorCode, String message) {
+	public CustomException(ErrorCode errorCode, String message, String code) {
 		super(message);
 		this.errorCode = errorCode;
 		this.message = message;
+		this.code = code;
 	}
 
 }

--- a/common/src/main/java/com/truve/platform/common/exception/ErrorCode.java
+++ b/common/src/main/java/com/truve/platform/common/exception/ErrorCode.java
@@ -9,43 +9,46 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum ErrorCode {
 
-	NOT_FOUND_USER(HttpStatus.NOT_FOUND, "존재하지 않는 회원입니다."),
-	ALREADY_EXISTS_EMAIL(HttpStatus.BAD_REQUEST, "중복된 이메일입니다."),
-	NOT_FOUND_EMAIL(HttpStatus.BAD_REQUEST, "이메일을 찾을 수 없습니다."),
-	NOT_CORRECT_EMAIL_CODE(HttpStatus.BAD_REQUEST, "이메일 인증 코드가 다릅니다."),
-	NOT_CORRECT_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호가 틀렸습니다."),
-	NOT_VERIFIED_EMAIL(HttpStatus.BAD_REQUEST, "인증되지 않은 이메일입니다."),
-	ALREADY_VERIFIED_EMAIL(HttpStatus.BAD_REQUEST, "이미 인증된 이메일입니다."),
-	INVALID_REFRESH_TOKEN(HttpStatus.BAD_REQUEST, "리프레시 토큰이 올바르지 않습니다."),
-	KAKAO_USERINFO_FAILED(HttpStatus.BAD_REQUEST, "카카오 사용자 정보를 가져오지 못했습니다."),
+	NOT_FOUND_USER(HttpStatus.NOT_FOUND, "존재하지 않는 회원입니다.", "A01"),
+	ALREADY_EXISTS_EMAIL(HttpStatus.BAD_REQUEST, "중복된 이메일입니다.", "A02"),
+	NOT_FOUND_EMAIL(HttpStatus.BAD_REQUEST, "이메일을 찾을 수 없습니다.", "A03"),
+	NOT_CORRECT_EMAIL_CODE(HttpStatus.BAD_REQUEST, "이메일 인증 코드가 다릅니다.", "A04"),
+	NOT_CORRECT_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호가 틀렸습니다.", "A05"),
+	NOT_VERIFIED_EMAIL(HttpStatus.BAD_REQUEST, "인증되지 않은 이메일입니다.", "A06"),
+	ALREADY_VERIFIED_EMAIL(HttpStatus.BAD_REQUEST, "이미 인증된 이메일입니다.", "A07"),
+	INVALID_REFRESH_TOKEN(HttpStatus.BAD_REQUEST, "리프레시 토큰이 올바르지 않습니다.", "A08"),
+	KAKAO_USERINFO_FAILED(HttpStatus.BAD_REQUEST, "카카오 사용자 정보를 가져오지 못했습니다.", "A09"),
 
-	NOT_FOUND_PAYMENT(HttpStatus.BAD_REQUEST, "존재하지 않는 결제입니다."),
-	INVALID_PAYMENT_AMOUNT(HttpStatus.BAD_REQUEST, "유효하지 않은 결제 금액입니다."),
-	NOT_ENOUGH_CANCELABLE_AMOUNT(HttpStatus.BAD_REQUEST, "취소 가능 잔액이 부족합니다."),
-	ALREADY_CANCELED_PAYMENT(HttpStatus.BAD_REQUEST, "이미 전액 취소된 결제입니다."),
-	INVALID_CANCEL_AMOUNT(HttpStatus.BAD_REQUEST, "유효하지 않은 취소 금액입니다."),
-	INVALID_PAYMENT_STATUS(HttpStatus.BAD_REQUEST, "처리할 수 없는 결제 상태입니다."),
-	INVALID_PAYMENT_KEY(HttpStatus.BAD_REQUEST, "유효하지 않은 결제 키입니다."),
-	MUST_CANCEL_FULL(HttpStatus.BAD_REQUEST, "전액 취소만 가능한 건입니다."),
-	ALREADY_EXIST_PAYMENT(HttpStatus.BAD_REQUEST, "이미 존재하는 결제입니다."),
-	EXTERNAL_PAYMENT_ERROR(HttpStatus.BAD_REQUEST, "결제 대행사 오류가 발생했습니다."),
-  
-	INVALID_BANK_CODE(HttpStatus.BAD_REQUEST, "유효하지 않은 은행 코드입니다."),
-	INVALID_CARD_COMPANY_CODE(HttpStatus.BAD_REQUEST, "유효하지 않은 카드사 코드입니다."),
-	ALREADY_DONE_PAYMENT(HttpStatus.BAD_REQUEST, "이미 처리된 결제입니다."),
-	INVALID_PAYMENT_METHOD_DETAILS(HttpStatus.BAD_REQUEST, "유효하지 않은 결제 수단 정보입니다."),
+	NOT_FOUND_PAYMENT(HttpStatus.BAD_REQUEST, "존재하지 않는 결제입니다.", "P01"),
+	INVALID_PAYMENT_AMOUNT(HttpStatus.BAD_REQUEST, "유효하지 않은 결제 금액입니다.", "P02"),
+	NOT_ENOUGH_CANCELABLE_AMOUNT(HttpStatus.BAD_REQUEST, "취소 가능 잔액이 부족합니다.", "P03"),
+	ALREADY_CANCELED_PAYMENT(HttpStatus.BAD_REQUEST, "이미 전액 취소된 결제입니다.", "P04"),
+	INVALID_CANCEL_AMOUNT(HttpStatus.BAD_REQUEST, "유효하지 않은 취소 금액입니다.", "P05"),
+	INVALID_PAYMENT_STATUS(HttpStatus.BAD_REQUEST, "처리할 수 없는 결제 상태입니다.", "P06"),
+	INVALID_PAYMENT_KEY(HttpStatus.BAD_REQUEST, "유효하지 않은 결제 키입니다.", "P07"),
+	MUST_CANCEL_FULL(HttpStatus.BAD_REQUEST, "전액 취소만 가능한 건입니다.", "P08"),
+	ALREADY_EXIST_PAYMENT(HttpStatus.BAD_REQUEST, "이미 존재하는 결제입니다.", "P09"),
+	EXTERNAL_PAYMENT_ERROR(HttpStatus.BAD_REQUEST, "결제 대행사 오류가 발생했습니다.", "P10"),
 
-	JSON_PARSE_ERROR(HttpStatus.BAD_REQUEST, "JSON 파싱 중 오류가 발생했습니다."),
-	INVALID_ADMISSION_TOKEN(HttpStatus.BAD_REQUEST, "입장 토큰이 유효하지 않습니다."),
-	EXPIRED_ADMISSION_TOKEN(HttpStatus.BAD_REQUEST, "입장 토큰이 만료되었습니다."),
-	ADMISSION_TOKEN_MISMATCH(HttpStatus.BAD_REQUEST, "입장 토큰 정보가 요청과 일치하지 않습니다."),
-	INVALID_SESSION_TOKEN(HttpStatus.BAD_REQUEST, "세션 토큰이 유효하지 않습니다."),
-	SESSION_TOKEN_MISMATCH(HttpStatus.BAD_REQUEST, "세션 토큰 정보가 요청과 일치하지 않습니다."),
-  
-	NOT_FOUND_SHOW(HttpStatus.NOT_FOUND, "존재하지 않는 공연입니다.");
+	INVALID_BANK_CODE(HttpStatus.BAD_REQUEST, "유효하지 않은 은행 코드입니다.", "P11"),
+	INVALID_CARD_COMPANY_CODE(HttpStatus.BAD_REQUEST, "유효하지 않은 카드사 코드입니다.", "P12"),
+	ALREADY_DONE_PAYMENT(HttpStatus.BAD_REQUEST, "이미 처리된 결제입니다.", "P13"),
+	INVALID_PAYMENT_METHOD_DETAILS(HttpStatus.BAD_REQUEST, "유효하지 않은 결제 수단 정보입니다.", "P14"),
+
+
+	JSON_PARSE_ERROR(HttpStatus.BAD_REQUEST, "JSON 파싱 중 오류가 발생했습니다.", "T01"),
+	INVALID_ADMISSION_TOKEN(HttpStatus.BAD_REQUEST, "입장 토큰이 유효하지 않습니다.", "T02"),
+	EXPIRED_ADMISSION_TOKEN(HttpStatus.BAD_REQUEST, "입장 토큰이 만료되었습니다.", "T03"),
+	ADMISSION_TOKEN_MISMATCH(HttpStatus.BAD_REQUEST, "입장 토큰 정보가 요청과 일치하지 않습니다.", "T04"),
+	INVALID_SESSION_TOKEN(HttpStatus.BAD_REQUEST, "세션 토큰이 유효하지 않습니다.", "T05"),
+	SESSION_TOKEN_MISMATCH(HttpStatus.BAD_REQUEST, "세션 토큰 정보가 요청과 일치하지 않습니다.", "T06"),
+
+	NOT_FOUND_SHOW(HttpStatus.NOT_FOUND, "존재하지 않는 공연입니다.", "M01");
 	;
+
 
 	private final HttpStatus status;
 	private final String message;
+	private final String code;
 
 }

--- a/common/src/main/java/com/truve/platform/common/response/ErrorResponse.java
+++ b/common/src/main/java/com/truve/platform/common/response/ErrorResponse.java
@@ -20,11 +20,13 @@ public class ErrorResponse {
 	@Getter
 	@AllArgsConstructor
 	public static class ErrorData {
-		private String code;
+
+		private String errorType;
 		private String message;
-		private String errorCode;
-		public static ErrorData of(String code, String message, String errorCode) {
-			return new ErrorData(code, message, errorCode);
+		private String code;
+
+		public static ErrorData of(String errorType, String message, String code) {
+			return new ErrorData(errorType, message, code);
 		}
 	}
 }

--- a/common/src/main/java/com/truve/platform/common/response/ErrorResponse.java
+++ b/common/src/main/java/com/truve/platform/common/response/ErrorResponse.java
@@ -13,8 +13,8 @@ public class ErrorResponse {
 	private HttpStatus status;
 	private String message;
 
-	public static ResponseEntity<ErrorData> error(HttpStatus status, String message) {
-		return ResponseEntity.status(status).body(ErrorData.of(status.series().name(), message));
+	public static ResponseEntity<ErrorData> error(HttpStatus status, String message, String errorCode) {
+		return ResponseEntity.status(status).body(ErrorData.of(status.series().name(), message, errorCode));
 	}
 
 	@Getter
@@ -22,9 +22,9 @@ public class ErrorResponse {
 	public static class ErrorData {
 		private String code;
 		private String message;
-
-		public static ErrorData of(String code, String message) {
-			return new ErrorData(code, message);
+		private String errorCode;
+		public static ErrorData of(String code, String message, String errorCode) {
+			return new ErrorData(code, message, errorCode);
 		}
 	}
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -141,6 +141,9 @@ services:
     ports:
       - "8084:8084"
     environment:
+      - TICKETING_MYSQL_URL=jdbc:mysql://db:3306/ticketing_db
+      - TICKETING_MYSQL_USERNAME=root
+      - TICKETING_MYSQL_PASSWORD=1234
       - SPRING_PROFILES_ACTIVE=local
       - USER_REDIS_HOST=user-redis
       - USER_REDIS_PORT=6379
@@ -165,6 +168,9 @@ services:
       - "8085:8085"
     environment:
       - SPRING_PROFILES_ACTIVE=local
+      - MUSICAL_MYSQL_URL=jdbc:mysql://db:3306/musical_db
+      - MUSICAL_MYSQL_USERNAME=root
+      - MUSICAL_MYSQL_PASSWORD=1234
     depends_on:
       db:
         condition: service_healthy

--- a/musical/src/main/java/com/truve/platform/show/MusicalApplication.java
+++ b/musical/src/main/java/com/truve/platform/show/MusicalApplication.java
@@ -4,9 +4,9 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication(scanBasePackages = "com.truve.platform")
-public class ShowApplication {
+public class MusicalApplication {
 
     public static void main(String[] args) {
-        SpringApplication.run(ShowApplication.class, args);
+        SpringApplication.run(MusicalApplication.class, args);
     }
 }

--- a/musical/src/main/java/com/truve/platform/show/service/domain/entity/Show.java
+++ b/musical/src/main/java/com/truve/platform/show/service/domain/entity/Show.java
@@ -20,10 +20,8 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "show")
-@AttributeOverrides({
-	@AttributeOverride(name = "id", column = @Column(name = "show_id"))
-})
+@Table(name = "shows")
+
 public class Show extends BaseEntity {
 
 	@ManyToOne(fetch = FetchType.LAZY)

--- a/musical/src/main/resources/application-local.yml
+++ b/musical/src/main/resources/application-local.yml
@@ -9,9 +9,9 @@ spring:
       force: true
 
   datasource:
-    url: ${SHOW_MYSQL_URL:jdbc:mysql://localhost:3306/musical_db}
-    username: ${SHOW_MYSQL_USERNAME:root}
-    password: ${SHOW_MYSQL_PASSWORD:1234}
+    url: ${MUSICAL_MYSQL_URL:jdbc:mysql://localhost:3306/musical_db}
+    username: ${MUSICAL_MYSQL_USERNAME:root}
+    password: ${MUSICAL_MYSQL_PASSWORD:1234}
     driver-class-name: com.mysql.cj.jdbc.Driver
 
   jpa:

--- a/musical/src/main/resources/application.yml
+++ b/musical/src/main/resources/application.yml
@@ -1,5 +1,5 @@
 spring:
   application:
-    name: show
+    name: musical
   profiles:
     active: ${SPRING_PROFILES_ACTIVE:local}


### PR DESCRIPTION
## 변경 사항
추가/변경 사항과 사유를 작성해 주세요.

- [x] 전체 테스트 코드 성공 여부
- ErrorResponse.ErrorData 형식 변경
- CustomException 형식 변경
- 그에 따른 핸들러 ApiAdvice 사용 방식 변경 
 
**기존 에러 형식**
```
  {
    "code": "CLIENT_ERROR",
    "message": "중복된 이메일입니다."
  }
```

**변경 후 에러 형식**
```
  {
    "errorType": "CLIENT_ERROR",
    "message": "중복된 이메일입니다.",
    "code": "A02"
  }
```

현재 Enum 내 넘버링은 작성되어있는 코드 순서대로 진행했습니다!

## 관련 이슈

- resolves: #28 

## 참고사항 (선택)

간단하게 노션 문서 만들어놓았습니다! 
현재 구현하셨던 에러, 앞으로 에러가 추가된다면 해당 노션문서에 추가 부탁드려요!
AI시켜서 템플릿도 만들었었는데, 작성 시 복잡해지면 저부터 번거롭다고 느껴져서
간단하게 유지해도 좋을 것 같은데, 템플릿 적용해도 좋을 것 같기는 합니다😃
문서 관련 의견 언제든 주세요 감사합니다!

[Error code 노션 가이드](https://www.notion.so/Error-code-3149e3e335cc807d962de354ee714dd7?source=copy_link)
현재 공통만 추가해놓았습니다.

`CustomException` 내 httpstatus, message, code까지 다 받는 생성자까지 추가해놓긴 했습니다!


<img width="1332" height="679" alt="image" src="https://github.com/user-attachments/assets/7111ee80-032b-419a-832c-a34dc6d3df90" />

