### PR TITLE
feat(ticketing): 티켓팅 서비스 필요 도메인 및 좌석 선점 로직 구현

### DIFF
--- a/musical/src/main/java/com/truve/platform/musical/MusicalApplication.java
+++ b/musical/src/main/java/com/truve/platform/musical/MusicalApplication.java
@@ -1,0 +1,12 @@
+package com.truve.platform.musical;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class MusicalApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(MusicalApplication.class, args);
+    }
+}

--- a/musical/src/main/java/com/truve/platform/musical/MusicalApplication.java
+++ b/musical/src/main/java/com/truve/platform/musical/MusicalApplication.java
@@ -2,8 +2,10 @@ package com.truve.platform.musical;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class MusicalApplication {
 
     public static void main(String[] args) {

--- a/musical/src/main/java/com/truve/platform/musical/service/controller/MusicalController.java
+++ b/musical/src/main/java/com/truve/platform/musical/service/controller/MusicalController.java
@@ -1,0 +1,27 @@
+package com.truve.platform.musical.service.controller;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.truve.platform.common.response.ApiResult;
+import com.truve.platform.musical.service.dto.MusicalResponse;
+import com.truve.platform.musical.service.service.MusicalService;
+
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/musicals")
+public class MusicalController {
+
+	private final MusicalService musicalService;
+
+	@Operation(summary = "뮤지컬 상세 조회", description = "뮤지컬 상세 정보를 조회합니다.")
+	@GetMapping("/{musicalId}")
+	public ApiResult<MusicalResponse.Detail> getDetail(@PathVariable Long musicalId) {
+		return ApiResult.ok(musicalService.getDetail(musicalId));
+	}
+}

--- a/musical/src/main/java/com/truve/platform/musical/service/domain/constant/ActorRole.java
+++ b/musical/src/main/java/com/truve/platform/musical/service/domain/constant/ActorRole.java
@@ -1,0 +1,41 @@
+package com.truve.platform.musical.service.domain.constant;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public enum ActorRole {
+	LEAD("주연", 0),
+	SUPPORTING("조연", 1);
+
+	private static final Map<String, ActorRole> BY_LABEL = new HashMap<>();
+
+	static {
+		for (ActorRole role : values()) {
+			BY_LABEL.put(role.label, role);
+		}
+	}
+
+	private final String label;
+	private final int order;
+
+	ActorRole(String label, int order) {
+		this.label = label;
+		this.order = order;
+	}
+
+	public static ActorRole fromLabel(String label) {
+		ActorRole role = BY_LABEL.get(label);
+		if (role == null) {
+			throw new IllegalArgumentException("Unknown actor role: " + label);
+		}
+		return role;
+	}
+
+	public String getLabel() {
+		return label;
+	}
+
+	public int getOrder() {
+		return order;
+	}
+}

--- a/musical/src/main/java/com/truve/platform/musical/service/domain/constant/SeatGrade.java
+++ b/musical/src/main/java/com/truve/platform/musical/service/domain/constant/SeatGrade.java
@@ -1,0 +1,44 @@
+package com.truve.platform.musical.service.domain.constant;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public enum SeatGrade {
+	VIP("VIP", 0),
+	R("R", 1),
+	S("S", 2),
+	A("A", 3),
+	OP("OP", 4);
+
+	private static final Map<String, SeatGrade> BY_LABEL = new HashMap<>();
+
+	static {
+		for (SeatGrade grade : values()) {
+			BY_LABEL.put(grade.label, grade);
+		}
+	}
+
+	private final String label;
+	private final int order;
+
+	SeatGrade(String label, int order) {
+		this.label = label;
+		this.order = order;
+	}
+
+	public static SeatGrade fromLabel(String label) {
+		SeatGrade grade = BY_LABEL.get(label);
+		if (grade == null) {
+			throw new IllegalArgumentException("Unknown seat grade: " + label);
+		}
+		return grade;
+	}
+
+	public String getLabel() {
+		return label;
+	}
+
+	public int getOrder() {
+		return order;
+	}
+}

--- a/musical/src/main/java/com/truve/platform/musical/service/domain/entity/Musical.java
+++ b/musical/src/main/java/com/truve/platform/musical/service/domain/entity/Musical.java
@@ -2,11 +2,14 @@ package com.truve.platform.musical.service.domain.entity;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 import com.truve.platform.common.support.BaseEntity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -63,6 +66,12 @@ public class Musical extends BaseEntity {
 
 	@Column(nullable = false)
 	private String detailsUrl;
+
+	@OneToMany(mappedBy = "musical")
+	private List<MusicalSchedule> schedules = new ArrayList<>();
+
+	@OneToMany(mappedBy = "musical")
+	private List<MusicalSeatPrice> seatPrices = new ArrayList<>();
 
 	@Builder
 	private Musical(

--- a/musical/src/main/java/com/truve/platform/musical/service/domain/entity/Musical.java
+++ b/musical/src/main/java/com/truve/platform/musical/service/domain/entity/Musical.java
@@ -1,0 +1,101 @@
+package com.truve.platform.musical.service.domain.entity;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import com.truve.platform.common.support.BaseEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "musicals")
+public class Musical extends BaseEntity {
+
+	@Column(nullable = false)
+	private String title;
+
+	@Column(nullable = false)
+	private String posterUrl;
+
+	@Column(nullable = false)
+	private String stage;
+
+	@Column(nullable = false)
+	private String runningTime;
+
+	@Column(nullable = false)
+	private String ageLimit;
+
+	@Column(nullable = false)
+	private String priceInfo;
+
+	@Column(nullable = false)
+	private LocalDate startDate;
+
+	@Column(nullable = false)
+	private LocalDate endDate;
+
+	@Column(nullable = false)
+	private LocalDateTime openAt;
+
+	@Column(nullable = false)
+	private Double ratingAverage;
+
+	@Column(nullable = false)
+	private Integer weeklyRank;
+
+	@Column(nullable = false)
+	private Integer reviewCount;
+
+	@Column(nullable = false)
+	private String timeInfo;
+
+	@Column(nullable = false)
+	private String noticeUrl;
+
+	@Column(nullable = false)
+	private String detailsUrl;
+
+	@Builder
+	private Musical(
+		String title,
+		String posterUrl,
+		String stage,
+		String runningTime,
+		String ageLimit,
+		String priceInfo,
+		LocalDate startDate,
+		LocalDate endDate,
+		LocalDateTime openAt,
+		Double ratingAverage,
+		Integer weeklyRank,
+		Integer reviewCount,
+		String timeInfo,
+		String noticeUrl,
+		String detailsUrl
+	) {
+		this.title = title;
+		this.posterUrl = posterUrl;
+		this.stage = stage;
+		this.runningTime = runningTime;
+		this.ageLimit = ageLimit;
+		this.priceInfo = priceInfo;
+		this.startDate = startDate;
+		this.endDate = endDate;
+		this.openAt = openAt;
+		this.ratingAverage = ratingAverage;
+		this.weeklyRank = weeklyRank;
+		this.reviewCount = reviewCount;
+		this.timeInfo = timeInfo;
+		this.noticeUrl = noticeUrl;
+		this.detailsUrl = detailsUrl;
+	}
+}

--- a/musical/src/main/java/com/truve/platform/musical/service/domain/entity/MusicalActor.java
+++ b/musical/src/main/java/com/truve/platform/musical/service/domain/entity/MusicalActor.java
@@ -1,0 +1,46 @@
+package com.truve.platform.musical.service.domain.entity;
+
+import com.truve.platform.common.support.BaseEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "musical_schedule_actors")
+public class MusicalActor extends BaseEntity {
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "schedule_id", nullable = false)
+	private MusicalSchedule schedule;
+
+	@Column(nullable = false)
+	private Long actorId;
+
+	@Column(nullable = false)
+	private String role;
+
+	@Column(nullable = false)
+	private String name;
+
+	@Column(nullable = false)
+	private Boolean isLiked;
+
+	@Builder
+	private MusicalActor(MusicalSchedule schedule, Long actorId, String role, String name, Boolean isLiked) {
+		this.schedule = schedule;
+		this.actorId = actorId;
+		this.role = role;
+		this.name = name;
+		this.isLiked = isLiked;
+	}
+}

--- a/musical/src/main/java/com/truve/platform/musical/service/domain/entity/MusicalActor.java
+++ b/musical/src/main/java/com/truve/platform/musical/service/domain/entity/MusicalActor.java
@@ -1,9 +1,12 @@
 package com.truve.platform.musical.service.domain.entity;
 
 import com.truve.platform.common.support.BaseEntity;
+import com.truve.platform.musical.service.domain.constant.ActorRole;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
@@ -27,7 +30,8 @@ public class MusicalActor extends BaseEntity {
 	private Long actorId;
 
 	@Column(nullable = false)
-	private String role;
+	@Enumerated(EnumType.STRING)
+	private ActorRole role;
 
 	@Column(nullable = false)
 	private String name;
@@ -36,7 +40,7 @@ public class MusicalActor extends BaseEntity {
 	private Boolean isLiked;
 
 	@Builder
-	private MusicalActor(MusicalSchedule schedule, Long actorId, String role, String name, Boolean isLiked) {
+	private MusicalActor(MusicalSchedule schedule, Long actorId, ActorRole role, String name, Boolean isLiked) {
 		this.schedule = schedule;
 		this.actorId = actorId;
 		this.role = role;

--- a/musical/src/main/java/com/truve/platform/musical/service/domain/entity/MusicalActor.java
+++ b/musical/src/main/java/com/truve/platform/musical/service/domain/entity/MusicalActor.java
@@ -16,7 +16,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "musical_schedule_actors")
+@Table(name = "musical_actors")
 public class MusicalActor extends BaseEntity {
 
 	@ManyToOne(fetch = FetchType.LAZY)

--- a/musical/src/main/java/com/truve/platform/musical/service/domain/entity/MusicalSchedule.java
+++ b/musical/src/main/java/com/truve/platform/musical/service/domain/entity/MusicalSchedule.java
@@ -1,0 +1,40 @@
+package com.truve.platform.musical.service.domain.entity;
+
+import java.time.LocalDateTime;
+
+import com.truve.platform.common.support.BaseEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "musical_schedules")
+public class MusicalSchedule extends BaseEntity {
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "musical_id", nullable = false)
+	private Musical musical;
+
+	@Column(nullable = false)
+	private LocalDateTime dateTime;
+
+	@Column(nullable = false)
+	private Boolean isAvailable;
+
+	@Builder
+	private MusicalSchedule(Musical musical, LocalDateTime dateTime, Boolean isAvailable) {
+		this.musical = musical;
+		this.dateTime = dateTime;
+		this.isAvailable = isAvailable;
+	}
+}

--- a/musical/src/main/java/com/truve/platform/musical/service/domain/entity/MusicalSchedule.java
+++ b/musical/src/main/java/com/truve/platform/musical/service/domain/entity/MusicalSchedule.java
@@ -1,6 +1,8 @@
 package com.truve.platform.musical.service.domain.entity;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 import com.truve.platform.common.support.BaseEntity;
 
@@ -9,6 +11,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -30,6 +33,9 @@ public class MusicalSchedule extends BaseEntity {
 
 	@Column(nullable = false)
 	private Boolean isAvailable;
+
+	@OneToMany(mappedBy = "schedule")
+	private List<MusicalActor> actors = new ArrayList<>();
 
 	@Builder
 	private MusicalSchedule(Musical musical, LocalDateTime dateTime, Boolean isAvailable) {

--- a/musical/src/main/java/com/truve/platform/musical/service/domain/entity/MusicalSeatPrice.java
+++ b/musical/src/main/java/com/truve/platform/musical/service/domain/entity/MusicalSeatPrice.java
@@ -1,9 +1,12 @@
 package com.truve.platform.musical.service.domain.entity;
 
 import com.truve.platform.common.support.BaseEntity;
+import com.truve.platform.musical.service.domain.constant.SeatGrade;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
@@ -24,13 +27,14 @@ public class MusicalSeatPrice extends BaseEntity {
 	private Musical musical;
 
 	@Column(nullable = false)
-	private String seatGrade;
+	@Enumerated(EnumType.STRING)
+	private SeatGrade seatGrade;
 
 	@Column(nullable = false)
 	private Integer price;
 
 	@Builder
-	private MusicalSeatPrice(Musical musical, String seatGrade, Integer price) {
+	private MusicalSeatPrice(Musical musical, SeatGrade seatGrade, Integer price) {
 		this.musical = musical;
 		this.seatGrade = seatGrade;
 		this.price = price;

--- a/musical/src/main/java/com/truve/platform/musical/service/domain/entity/MusicalSeatPrice.java
+++ b/musical/src/main/java/com/truve/platform/musical/service/domain/entity/MusicalSeatPrice.java
@@ -1,0 +1,38 @@
+package com.truve.platform.musical.service.domain.entity;
+
+import com.truve.platform.common.support.BaseEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "musical_seat_prices")
+public class MusicalSeatPrice extends BaseEntity {
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "musical_id", nullable = false)
+	private Musical musical;
+
+	@Column(nullable = false)
+	private String seatGrade;
+
+	@Column(nullable = false)
+	private Integer price;
+
+	@Builder
+	private MusicalSeatPrice(Musical musical, String seatGrade, Integer price) {
+		this.musical = musical;
+		this.seatGrade = seatGrade;
+		this.price = price;
+	}
+}

--- a/musical/src/main/java/com/truve/platform/musical/service/dto/MusicalResponse.java
+++ b/musical/src/main/java/com/truve/platform/musical/service/dto/MusicalResponse.java
@@ -1,0 +1,59 @@
+package com.truve.platform.musical.service.dto;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+public class MusicalResponse {
+
+	@Getter
+	@AllArgsConstructor
+	public static class Detail {
+		private Long musicalId;
+		private String title;
+		private String posterUrl;
+		private String stage;
+		private String runningTime;
+		private String ageLimit;
+		private String priceInfo;
+		private LocalDate startDate;
+		private LocalDate endDate;
+		private LocalDateTime openAt;
+		private Double ratingAverage;
+		private Integer weeklyRank;
+		private Integer reviewCount;
+		private String timeInfo;
+		private String noticeUrl;
+		private String detailsUrl;
+		private List<Schedule> schedules;
+		private List<SeatPrice> seatPrices;
+	}
+
+	@Getter
+	@AllArgsConstructor
+	public static class Schedule {
+		private Long scheduleId;
+		private LocalDateTime dateTime;
+		private Boolean isAvailable;
+		private List<Actor> actors;
+	}
+
+	@Getter
+	@AllArgsConstructor
+	public static class Actor {
+		private Long actorId;
+		private String role;
+		private String name;
+		private Boolean isLiked;
+	}
+
+	@Getter
+	@AllArgsConstructor
+	public static class SeatPrice {
+		private String seatGrade;
+		private Integer price;
+	}
+}

--- a/musical/src/main/java/com/truve/platform/musical/service/dto/MusicalResponse.java
+++ b/musical/src/main/java/com/truve/platform/musical/service/dto/MusicalResponse.java
@@ -5,12 +5,14 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 
 public class MusicalResponse {
 
 	@Getter
 	@AllArgsConstructor
+	@Builder
 	public static class Detail {
 		private Long musicalId;
 		private String title;
@@ -34,6 +36,7 @@ public class MusicalResponse {
 
 	@Getter
 	@AllArgsConstructor
+	@Builder
 	public static class Schedule {
 		private Long scheduleId;
 		private LocalDateTime dateTime;
@@ -43,6 +46,7 @@ public class MusicalResponse {
 
 	@Getter
 	@AllArgsConstructor
+	@Builder
 	public static class Actor {
 		private Long actorId;
 		private String role;
@@ -52,6 +56,7 @@ public class MusicalResponse {
 
 	@Getter
 	@AllArgsConstructor
+	@Builder
 	public static class SeatPrice {
 		private String seatGrade;
 		private Integer price;

--- a/musical/src/main/java/com/truve/platform/musical/service/repository/MusicalRepository.java
+++ b/musical/src/main/java/com/truve/platform/musical/service/repository/MusicalRepository.java
@@ -1,0 +1,16 @@
+package com.truve.platform.musical.service.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.truve.platform.common.exception.CustomException;
+import com.truve.platform.common.exception.ErrorCode;
+import com.truve.platform.musical.service.domain.entity.Musical;
+
+public interface MusicalRepository extends JpaRepository<Musical, Long> {
+
+	default Musical findByIdOrThrow(Long musicalId) {
+		return findById(musicalId).orElseThrow(
+			() -> new CustomException(ErrorCode.NOT_FOUND_MUSICAL)
+		);
+	}
+}

--- a/musical/src/main/java/com/truve/platform/musical/service/service/MusicalService.java
+++ b/musical/src/main/java/com/truve/platform/musical/service/service/MusicalService.java
@@ -25,15 +25,13 @@ public class MusicalService {
 	public MusicalResponse.Detail getDetail(Long musicalId) {
 		Musical musical = musicalRepository.findByIdOrThrow(musicalId);
 
-		// 컬렉션은 LAZY 로딩이므로 조회 후 DTO 매핑 단계에서 정렬해 안정적인 응답을 만든다.
 		List<MusicalResponse.Schedule> schedules = musical.getSchedules().stream()
 			.sorted(Comparator.comparing(MusicalSchedule::getDateTime))
 			.map(this::toScheduleResponse)
 			.toList();
 
-		// 좌석 등급은 응답 정렬을 고정하기 위해 정렬한다.
 		List<MusicalResponse.SeatPrice> seatPrices = musical.getSeatPrices().stream()
-			.sorted(Comparator.comparing(MusicalSeatPrice::getSeatGrade))
+			.sorted(Comparator.comparing(seatPrice -> seatPrice.getSeatGrade().getOrder()))
 			.map(this::toSeatPriceResponse)
 			.toList();
 
@@ -59,10 +57,10 @@ public class MusicalService {
 			.build();
 	}
 
+    // 회차별 배우 목록을 정렬해 응답 순서를 고정한다.
 	private MusicalResponse.Schedule toScheduleResponse(MusicalSchedule schedule) {
-		// 회차별 배우 목록을 정렬해 응답 순서를 고정한다.
 		List<MusicalResponse.Actor> actors = schedule.getActors().stream()
-			.sorted(Comparator.comparing(MusicalActor::getId))
+			.sorted(Comparator.comparing(actor -> actor.getRole().getOrder()))
 			.map(this::toActorResponse)
 			.toList();
 
@@ -74,20 +72,20 @@ public class MusicalService {
 			.build();
 	}
 
+    // 엔티티를 API 응답용 배우 DTO로 변환한다.
 	private MusicalResponse.Actor toActorResponse(MusicalActor actor) {
-		// 엔티티를 API 응답용 배우 DTO로 변환한다.
 		return MusicalResponse.Actor.builder()
 			.actorId(actor.getActorId())
-			.role(actor.getRole())
+			.role(actor.getRole().getLabel())
 			.name(actor.getName())
 			.isLiked(actor.getIsLiked())
 			.build();
 	}
 
+    // 좌석 등급/가격을 응답 DTO로 변환한다.
 	private MusicalResponse.SeatPrice toSeatPriceResponse(MusicalSeatPrice seatPrice) {
-		// 좌석 등급/가격을 응답 DTO로 변환한다.
 		return MusicalResponse.SeatPrice.builder()
-			.seatGrade(seatPrice.getSeatGrade())
+			.seatGrade(seatPrice.getSeatGrade().getLabel())
 			.price(seatPrice.getPrice())
 			.build();
 	}

--- a/musical/src/main/java/com/truve/platform/musical/service/service/MusicalService.java
+++ b/musical/src/main/java/com/truve/platform/musical/service/service/MusicalService.java
@@ -1,0 +1,94 @@
+package com.truve.platform.musical.service.service;
+
+import java.util.Comparator;
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.truve.platform.musical.service.domain.entity.Musical;
+import com.truve.platform.musical.service.domain.entity.MusicalActor;
+import com.truve.platform.musical.service.domain.entity.MusicalSchedule;
+import com.truve.platform.musical.service.domain.entity.MusicalSeatPrice;
+import com.truve.platform.musical.service.dto.MusicalResponse;
+import com.truve.platform.musical.service.repository.MusicalRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class MusicalService {
+
+	private final MusicalRepository musicalRepository;
+
+	@Transactional(readOnly = true)
+	public MusicalResponse.Detail getDetail(Long musicalId) {
+		Musical musical = musicalRepository.findByIdOrThrow(musicalId);
+
+		// 컬렉션은 LAZY 로딩이므로 조회 후 DTO 매핑 단계에서 정렬해 안정적인 응답을 만든다.
+		List<MusicalResponse.Schedule> schedules = musical.getSchedules().stream()
+			.sorted(Comparator.comparing(MusicalSchedule::getDateTime))
+			.map(this::toScheduleResponse)
+			.toList();
+
+		// 좌석 등급은 응답 정렬을 고정하기 위해 정렬한다.
+		List<MusicalResponse.SeatPrice> seatPrices = musical.getSeatPrices().stream()
+			.sorted(Comparator.comparing(MusicalSeatPrice::getSeatGrade))
+			.map(this::toSeatPriceResponse)
+			.toList();
+
+		return MusicalResponse.Detail.builder()
+			.musicalId(musical.getId())
+			.title(musical.getTitle())
+			.posterUrl(musical.getPosterUrl())
+			.stage(musical.getStage())
+			.runningTime(musical.getRunningTime())
+			.ageLimit(musical.getAgeLimit())
+			.priceInfo(musical.getPriceInfo())
+			.startDate(musical.getStartDate())
+			.endDate(musical.getEndDate())
+			.openAt(musical.getOpenAt())
+			.ratingAverage(musical.getRatingAverage())
+			.weeklyRank(musical.getWeeklyRank())
+			.reviewCount(musical.getReviewCount())
+			.timeInfo(musical.getTimeInfo())
+			.noticeUrl(musical.getNoticeUrl())
+			.detailsUrl(musical.getDetailsUrl())
+			.schedules(schedules)
+			.seatPrices(seatPrices)
+			.build();
+	}
+
+	private MusicalResponse.Schedule toScheduleResponse(MusicalSchedule schedule) {
+		// 회차별 배우 목록을 정렬해 응답 순서를 고정한다.
+		List<MusicalResponse.Actor> actors = schedule.getActors().stream()
+			.sorted(Comparator.comparing(MusicalActor::getId))
+			.map(this::toActorResponse)
+			.toList();
+
+		return MusicalResponse.Schedule.builder()
+			.scheduleId(schedule.getId())
+			.dateTime(schedule.getDateTime())
+			.isAvailable(schedule.getIsAvailable())
+			.actors(actors)
+			.build();
+	}
+
+	private MusicalResponse.Actor toActorResponse(MusicalActor actor) {
+		// 엔티티를 API 응답용 배우 DTO로 변환한다.
+		return MusicalResponse.Actor.builder()
+			.actorId(actor.getActorId())
+			.role(actor.getRole())
+			.name(actor.getName())
+			.isLiked(actor.getIsLiked())
+			.build();
+	}
+
+	private MusicalResponse.SeatPrice toSeatPriceResponse(MusicalSeatPrice seatPrice) {
+		// 좌석 등급/가격을 응답 DTO로 변환한다.
+		return MusicalResponse.SeatPrice.builder()
+			.seatGrade(seatPrice.getSeatGrade())
+			.price(seatPrice.getPrice())
+			.build();
+	}
+}

--- a/musical/src/test/java/com/truve/platform/musical/service/controller/MusicalControllerTest.java
+++ b/musical/src/test/java/com/truve/platform/musical/service/controller/MusicalControllerTest.java
@@ -1,0 +1,106 @@
+package com.truve.platform.musical.service.controller;
+
+import static org.mockito.BDDMockito.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.truve.platform.common.exception.CustomException;
+import com.truve.platform.common.exception.ApiAdvice;
+import com.truve.platform.common.exception.ErrorCode;
+import com.truve.platform.musical.service.dto.MusicalResponse;
+import com.truve.platform.musical.service.service.MusicalService;
+
+@WebMvcTest(controllers = MusicalController.class)
+@org.springframework.context.annotation.Import(ApiAdvice.class)
+class MusicalControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+	@MockitoBean
+	private MusicalService musicalService;
+	@MockitoBean
+	private JpaMetamodelMappingContext jpaMetamodelMappingContext;
+
+	@Test
+	@DisplayName("뮤지컬 상세 조회에 성공하면 200 OK와 상세 정보를 응답한다.")
+	void 뮤지컬_상세_조회_성공() throws Exception {
+		// given
+		MusicalResponse.Detail response = MusicalResponse.Detail.builder()
+			.musicalId(1L)
+			.title("뮤지컬A")
+			.posterUrl("https://img/1.jpg")
+			.stage("예술의전당")
+			.runningTime("120분")
+			.ageLimit("8세 이상")
+			.priceInfo("VIP 150000")
+			.startDate(LocalDate.of(2026, 3, 1))
+			.endDate(LocalDate.of(2026, 4, 1))
+			.openAt(LocalDateTime.of(2026, 2, 20, 10, 0))
+			.ratingAverage(4.6)
+			.weeklyRank(3)
+			.reviewCount(120)
+			.timeInfo("수/금 19:30")
+			.noticeUrl("https://img/notice.jpg")
+			.detailsUrl("https://img/detail.jpg")
+			.schedules(List.of(
+				MusicalResponse.Schedule.builder()
+					.scheduleId(1L)
+					.dateTime(LocalDateTime.of(2026, 3, 2, 19, 30))
+					.isAvailable(true)
+					.actors(List.of(
+						MusicalResponse.Actor.builder()
+							.actorId(101L)
+							.role("주연")
+							.name("배우A")
+							.isLiked(true)
+							.build()
+					))
+					.build()
+			))
+			.seatPrices(List.of(
+				MusicalResponse.SeatPrice.builder()
+					.seatGrade("VIP")
+					.price(150000)
+					.build()
+			))
+			.build();
+
+		given(musicalService.getDetail(anyLong())).willReturn(response);
+
+		// when & then
+		mockMvc.perform(get("/api/musicals/{musicalId}", 1L))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.code").value("ok"))
+			.andExpect(jsonPath("$.data.musicalId").value(1))
+			.andExpect(jsonPath("$.data.schedules[0].actors[0].name").value("배우A"));
+	}
+
+	@Test
+	@DisplayName("존재하지 않는 뮤지컬을 조회하면 404를 응답한다.")
+	void 뮤지컬_상세_조회_실패() throws Exception {
+		// given
+		willThrow(new CustomException(ErrorCode.NOT_FOUND_MUSICAL))
+			.given(musicalService).getDetail(999L);
+
+		// when & then
+		mockMvc.perform(get("/api/musicals/{musicalId}", 999L))
+			.andExpect(status().isNotFound())
+			.andExpect(jsonPath("$.code").value("CLIENT_ERROR"))
+			.andExpect(jsonPath("$.message").exists());
+	}
+}

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/constant/ReservationStatus.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/constant/ReservationStatus.java
@@ -1,0 +1,16 @@
+package org.truve.platform.ticketing.service.constant;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ReservationStatus {
+	CREATED("생성"),
+	PAID("결제 완료"),
+	CANCELED("취소"),
+	EXPIRED("만료"),
+	;
+
+	private final String description;
+}

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/constant/SeatStatus.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/constant/SeatStatus.java
@@ -1,0 +1,16 @@
+package org.truve.platform.ticketing.service.constant;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum SeatStatus {
+	AVAILABLE("예매 가능"),
+	HOLD("좌석 선점"),
+	SOLD("판매된 좌석"),
+	;
+
+	private final String description;
+
+}

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/constant/TicketStatus.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/constant/TicketStatus.java
@@ -1,0 +1,15 @@
+package org.truve.platform.ticketing.service.constant;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum TicketStatus {
+	ISSUED("발급"),
+	USED("사용"),
+	CANCELED("취소"),
+	;
+
+	private final String description;
+}

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/controller/TicketingController.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/controller/TicketingController.java
@@ -23,34 +23,34 @@ public class TicketingController {
 
 	private final TicketingService ticketingService;
 
-	@PostMapping("/{musicalScheduleId}/enter")
+	@PostMapping("/{showScheduleId}/enter")
 	public ApiResult<TicketingResponse.Enter> enter(
-		@PathVariable Long musicalScheduleId,
+		@PathVariable Long showScheduleId,
 		@RequestHeader(value = USER_ID_HEADER) Long userId,
 		@RequestHeader(value = ADMISSION_HEADER, required = false) String admissionToken
 	) {
-		var response = ticketingService.enter(musicalScheduleId, userId, admissionToken);
+		var response = ticketingService.enter(showScheduleId, userId, admissionToken);
 		return ApiResult.ok(response);
 	}
 
-	@PostMapping("/{musicalScheduleId}/heartbeat")
+	@PostMapping("/{showScheduleId}/heartbeat")
 	public ApiResult<Void> heartbeat(
-		@PathVariable Long musicalScheduleId,
+		@PathVariable Long showScheduleId,
 		@RequestHeader(value = USER_ID_HEADER) Long userId,
 		@RequestHeader(value = SESSION_HEADER) String sessionToken
 	) {
-		ticketingService.heartbeat(musicalScheduleId, userId, sessionToken);
+		ticketingService.heartbeat(showScheduleId, userId, sessionToken);
 		return ApiResult.ok();
 	}
 
-	@PostMapping("/{musicalScheduleId}/hold/seat/{seatId}")
+	@PostMapping("/{showScheduleId}/hold/seat/{seatId}")
 	public ApiResult<Void> holdSeat(
 		@PathVariable Long seatId,
-		@PathVariable Long musicalScheduleId,
+		@PathVariable Long showScheduleId,
 		@RequestHeader(value = USER_ID_HEADER) Long userId,
 		@RequestHeader(value = SESSION_HEADER) String sessionToken
 	) {
-		ticketingService.holdSeat(musicalScheduleId, userId, sessionToken, seatId);
+		ticketingService.holdSeat(showScheduleId, userId, sessionToken, seatId);
 		return ApiResult.ok();
 	}
 

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/controller/TicketingController.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/controller/TicketingController.java
@@ -43,4 +43,15 @@ public class TicketingController {
 		return ApiResult.ok();
 	}
 
+	@PostMapping("{musicalScheduleId}/hold/seat/{seatId}")
+	public ApiResult<Void> holdSeat(
+		@PathVariable Long seatId,
+		@PathVariable Long musicalScheduleId,
+		@RequestHeader(value = USER_ID_HEADER) Long userId,
+		@RequestHeader(value = SESSION_HEADER) String sessionToken
+	) {
+		ticketingService.holdSeat(musicalScheduleId, userId, sessionToken, seatId);
+		return ApiResult.ok();
+	}
+
 }

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/controller/TicketingController.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/controller/TicketingController.java
@@ -43,7 +43,7 @@ public class TicketingController {
 		return ApiResult.ok();
 	}
 
-	@PostMapping("{musicalScheduleId}/hold/seat/{seatId}")
+	@PostMapping("/{musicalScheduleId}/hold/seat/{seatId}")
 	public ApiResult<Void> holdSeat(
 		@PathVariable Long seatId,
 		@PathVariable Long musicalScheduleId,

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/controller/TicketingController.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/controller/TicketingController.java
@@ -23,23 +23,23 @@ public class TicketingController {
 
 	private final TicketingService ticketingService;
 
-	@PostMapping("/{showId}/enter")
+	@PostMapping("/{musicalScheduleId}/enter")
 	public ApiResult<TicketingResponse.Enter> enter(
-		@PathVariable String showId,
+		@PathVariable String musicalScheduleId,
 		@RequestHeader(value = USER_ID_HEADER) String userId,
 		@RequestHeader(value = ADMISSION_HEADER, required = false) String admissionToken
 	) {
-		var response = ticketingService.enter(showId, userId, admissionToken);
+		var response = ticketingService.enter(musicalScheduleId, userId, admissionToken);
 		return ApiResult.ok(response);
 	}
 
-	@PostMapping("/{showId}/heartbeat")
+	@PostMapping("/{musicalScheduleId}/heartbeat")
 	public ApiResult<Void> heartbeat(
-		@PathVariable String showId,
+		@PathVariable String musicalScheduleId,
 		@RequestHeader(value = USER_ID_HEADER) String userId,
 		@RequestHeader(value = SESSION_HEADER) String sessionToken
 	) {
-		ticketingService.heartbeat(showId, userId, sessionToken);
+		ticketingService.heartbeat(musicalScheduleId, userId, sessionToken);
 		return ApiResult.ok();
 	}
 

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/controller/TicketingController.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/controller/TicketingController.java
@@ -25,8 +25,8 @@ public class TicketingController {
 
 	@PostMapping("/{musicalScheduleId}/enter")
 	public ApiResult<TicketingResponse.Enter> enter(
-		@PathVariable String musicalScheduleId,
-		@RequestHeader(value = USER_ID_HEADER) String userId,
+		@PathVariable Long musicalScheduleId,
+		@RequestHeader(value = USER_ID_HEADER) Long userId,
 		@RequestHeader(value = ADMISSION_HEADER, required = false) String admissionToken
 	) {
 		var response = ticketingService.enter(musicalScheduleId, userId, admissionToken);
@@ -35,8 +35,8 @@ public class TicketingController {
 
 	@PostMapping("/{musicalScheduleId}/heartbeat")
 	public ApiResult<Void> heartbeat(
-		@PathVariable String musicalScheduleId,
-		@RequestHeader(value = USER_ID_HEADER) String userId,
+		@PathVariable Long musicalScheduleId,
+		@RequestHeader(value = USER_ID_HEADER) Long userId,
 		@RequestHeader(value = SESSION_HEADER) String sessionToken
 	) {
 		ticketingService.heartbeat(musicalScheduleId, userId, sessionToken);

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/domain/entity/MusicalScheduleSeat.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/domain/entity/MusicalScheduleSeat.java
@@ -1,0 +1,70 @@
+package org.truve.platform.ticketing.service.domain.entity;
+
+import org.truve.platform.ticketing.service.constant.SeatStatus;
+
+import com.truve.platform.common.exception.CustomException;
+import com.truve.platform.common.exception.ErrorCode;
+import com.truve.platform.common.support.BaseEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "musical_schedule_seat_mapping")
+public class MusicalScheduleSeat extends BaseEntity {
+
+	@Column(nullable = false)
+	private Long musicalScheduleId;
+
+	@Column(nullable = false)
+	private Long seatId;
+
+	@Column(nullable = false)
+	private Long musicalSeatGradeId;
+
+	@Column(nullable = false)
+	private Long priceSnapshot;
+
+	@Column(nullable = false)
+	@Enumerated(EnumType.STRING)
+	private SeatStatus status;
+
+	@Builder
+	public MusicalScheduleSeat(
+		Long musicalScheduleId,
+		Long seatId,
+		Long musicalSeatGradeId,
+		Long priceSnapshot
+	) {
+		this.musicalScheduleId = musicalScheduleId;
+		this.seatId = seatId;
+		this.musicalSeatGradeId = musicalSeatGradeId;
+		this.priceSnapshot = priceSnapshot;
+		this.status = SeatStatus.AVAILABLE;
+	}
+
+	public boolean  isAvailable() {
+		return status == SeatStatus.AVAILABLE;
+	}
+
+	public void cancelSeat() {
+		this.status = SeatStatus.AVAILABLE;
+	}
+
+	public void purchaseSeat() {
+		if (this.status == SeatStatus.SOLD) {
+			throw new CustomException(ErrorCode.ALREADY_SOLD_SEAT);
+		}
+		this.status = SeatStatus.SOLD;
+	}
+
+}

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/domain/entity/Reservation.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/domain/entity/Reservation.java
@@ -1,0 +1,49 @@
+package org.truve.platform.ticketing.service.domain.entity;
+
+import java.time.LocalDateTime;
+
+import org.truve.platform.ticketing.service.constant.ReservationStatus;
+
+import com.truve.platform.common.support.BaseEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "reservations")
+public class Reservation extends BaseEntity {
+
+	@Column(nullable = false)
+	private Long musicalScheduleId;
+
+	@Column(nullable = false)
+	@Enumerated(EnumType.STRING)
+	private ReservationStatus status;
+
+	@Column
+	private Long totalAmount;
+
+	@Column
+	private LocalDateTime paidAt;
+
+	@Column(nullable = false)
+	private Long userId;
+
+	@Builder
+	public Reservation(Long musicalScheduleId, Long totalAmount, Long userId) {
+		this.musicalScheduleId = musicalScheduleId;
+		this.status = ReservationStatus.CREATED;
+		this.totalAmount = totalAmount;
+		this.userId = userId;
+	}
+
+}

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/domain/entity/Reservation.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/domain/entity/Reservation.java
@@ -23,7 +23,7 @@ import lombok.NoArgsConstructor;
 public class Reservation extends BaseEntity {
 
 	@Column(nullable = false)
-	private Long musicalScheduleId;
+	private Long showScheduleId;
 
 	@Column(nullable = false)
 	@Enumerated(EnumType.STRING)
@@ -39,8 +39,8 @@ public class Reservation extends BaseEntity {
 	private Long userId;
 
 	@Builder
-	public Reservation(Long musicalScheduleId, Long totalAmount, Long userId) {
-		this.musicalScheduleId = musicalScheduleId;
+	public Reservation(Long showScheduleId, Long totalAmount, Long userId) {
+		this.showScheduleId = showScheduleId;
 		this.status = ReservationStatus.CREATED;
 		this.totalAmount = totalAmount;
 		this.userId = userId;

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/domain/entity/ReservationSeat.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/domain/entity/ReservationSeat.java
@@ -1,0 +1,39 @@
+package org.truve.platform.ticketing.service.domain.entity;
+
+import com.truve.platform.common.support.BaseEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "reservation_seat_mapping")
+public class ReservationSeat extends BaseEntity {
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "reservation_id", nullable = false)
+	private Reservation reservation;
+
+	@Column(nullable = false)
+	private Long scheduleSeatMappingId;
+
+	@Column(nullable = false)
+	private Long priceSnapshot;
+
+	@Builder
+	public ReservationSeat(Reservation reservation, Long scheduleSeatMappingId, Long priceSnapshot) {
+		this.reservation = reservation;
+		this.scheduleSeatMappingId = scheduleSeatMappingId;
+		this.priceSnapshot = priceSnapshot;
+	}
+
+}

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/domain/entity/ShowScheduleSeat.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/domain/entity/ShowScheduleSeat.java
@@ -19,17 +19,17 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "musical_schedule_seat_mapping")
-public class MusicalScheduleSeat extends BaseEntity {
+@Table(name = "show_schedule_seat_mapping")
+public class ShowScheduleSeat extends BaseEntity {
 
 	@Column(nullable = false)
-	private Long musicalScheduleId;
+	private Long showScheduleId;
 
 	@Column(nullable = false)
 	private Long seatId;
 
 	@Column(nullable = false)
-	private Long musicalSeatGradeId;
+	private Long showSeatGradeId;
 
 	@Column(nullable = false)
 	private Long priceSnapshot;
@@ -39,15 +39,15 @@ public class MusicalScheduleSeat extends BaseEntity {
 	private SeatStatus status;
 
 	@Builder
-	public MusicalScheduleSeat(
-		Long musicalScheduleId,
+	public ShowScheduleSeat(
+		Long showScheduleId,
 		Long seatId,
-		Long musicalSeatGradeId,
+		Long showSeatGradeId,
 		Long priceSnapshot
 	) {
-		this.musicalScheduleId = musicalScheduleId;
+		this.showScheduleId = showScheduleId;
 		this.seatId = seatId;
-		this.musicalSeatGradeId = musicalSeatGradeId;
+		this.showSeatGradeId = showSeatGradeId;
 		this.priceSnapshot = priceSnapshot;
 		this.status = SeatStatus.AVAILABLE;
 	}

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/domain/entity/Ticket.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/domain/entity/Ticket.java
@@ -1,0 +1,57 @@
+package org.truve.platform.ticketing.service.domain.entity;
+
+import java.time.LocalDateTime;
+
+import org.truve.platform.ticketing.service.constant.TicketStatus;
+
+import com.truve.platform.common.support.BaseEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "tickets")
+public class Ticket extends BaseEntity {
+
+	@Column(nullable = false)
+	private Long reservationId;
+
+	@Column(nullable = false)
+	private Long scheduleSeatMappingId;
+
+	@Column(nullable = false)
+	private String ticketNumber;
+
+	@Column(nullable = false)
+	private Long priceSnapshot;
+
+	@Column(nullable = false)
+	@Enumerated(EnumType.STRING)
+	private TicketStatus status;
+
+	@Column(nullable = false)
+	private LocalDateTime issuedAt;
+
+	@Column
+	private LocalDateTime usedAt;
+
+	@Builder
+	public Ticket(Long reservationId, Long scheduleSeatMappingId, String ticketNumber, Long priceSnapshot) {
+		this.reservationId = reservationId;
+		this.scheduleSeatMappingId = scheduleSeatMappingId;
+		this.ticketNumber = ticketNumber;
+		this.priceSnapshot = priceSnapshot;
+		this.status = TicketStatus.ISSUED;
+		this.issuedAt = LocalDateTime.now();
+	}
+
+}

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/dto/AdmissionTokenClaimsDTO.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/dto/AdmissionTokenClaimsDTO.java
@@ -6,11 +6,11 @@ import lombok.Getter;
 @AllArgsConstructor
 @Getter
 public class AdmissionTokenClaimsDTO {
-	private String userId;
-	private String showId;
+	private Long userId;
+	private Long showId;
 	private String tokenType;
 
-	public static AdmissionTokenClaimsDTO of(String userId, String showId, String tokenType) {
+	public static AdmissionTokenClaimsDTO of(Long userId, Long showId, String tokenType) {
 		return new  AdmissionTokenClaimsDTO(userId, showId, tokenType);
 	}
 }

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/dto/SessionTicketValueDTO.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/dto/SessionTicketValueDTO.java
@@ -6,10 +6,10 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public class SessionTicketValueDTO {
-	String userId;
-	String showId;
+	private Long userId;
+	private Long showId;
 
-	public static SessionTicketValueDTO of(String userId, String showId) {
+	public static SessionTicketValueDTO of(Long userId, Long showId) {
 		return new SessionTicketValueDTO(userId, showId);
 	}
 }

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/jwt/AdmissionTokenService.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/jwt/AdmissionTokenService.java
@@ -25,16 +25,16 @@ public class AdmissionTokenService {
 
 	private final JwtProperties jwtProperties;
 
-	public AdmissionTokenClaimsDTO parseAdmissionToken(String token, String expectedShowId, String expectedUserId) {
+	public AdmissionTokenClaimsDTO parseAdmissionToken(String token, Long expectedShowId, Long expectedUserId) {
 		Preconditions.validate(!((token == null) || token.isEmpty()), ErrorCode.INVALID_ADMISSION_TOKEN);
 
 		Claims claims = parseClaims(token);
 
 		String tokenType = (String) claims.get(TOKEN_TYPE_KEY);
-		String showId = (String) claims.get(SHOW_ID_KEY);
-		String userId = claims.getSubject();
+		Long showId = Long.parseLong((String) claims.get(SHOW_ID_KEY));
+		Long userId = Long.parseLong(claims.getSubject());
 
-		Preconditions.validate(tokenType.equals(ADMISSION_TOKEN_TYPE), ErrorCode.INVALID_ADMISSION_TOKEN);
+		Preconditions.validate(ADMISSION_TOKEN_TYPE.equals(tokenType), ErrorCode.INVALID_ADMISSION_TOKEN);
 		Preconditions.validate(userId.equals(expectedUserId), ErrorCode.INVALID_ADMISSION_TOKEN);
 		Preconditions.validate(showId.equals(expectedShowId), ErrorCode.INVALID_ADMISSION_TOKEN);
 

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/repository/MusicalScheduleSeatRepository.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/repository/MusicalScheduleSeatRepository.java
@@ -1,7 +1,0 @@
-package org.truve.platform.ticketing.service.repository;
-
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.truve.platform.ticketing.service.domain.entity.MusicalScheduleSeat;
-
-public interface MusicalScheduleSeatRepository extends JpaRepository<MusicalScheduleSeat, Long> {
-}

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/repository/MusicalScheduleSeatRepository.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/repository/MusicalScheduleSeatRepository.java
@@ -1,0 +1,7 @@
+package org.truve.platform.ticketing.service.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.truve.platform.ticketing.service.domain.entity.MusicalScheduleSeat;
+
+public interface MusicalScheduleSeatRepository extends JpaRepository<MusicalScheduleSeat, Long> {
+}

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/repository/ShowScheduleSeatRepository.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/repository/ShowScheduleSeatRepository.java
@@ -1,0 +1,7 @@
+package org.truve.platform.ticketing.service.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.truve.platform.ticketing.service.domain.entity.ShowScheduleSeat;
+
+public interface ShowScheduleSeatRepository extends JpaRepository<ShowScheduleSeat, Long> {
+}

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/repository/TicketingRedisRepository.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/repository/TicketingRedisRepository.java
@@ -13,7 +13,7 @@ import lombok.RequiredArgsConstructor;
 public class TicketingRedisRepository {
 
 	private static final String SESSION_TOKEN_PREFIX = "ticket:session:";
-	private static final String TICKET_ACTIVE_PERFORMANCE_USER_PREFIX = "ticket:active:";
+	private static final String TICKET_ACTIVE_MUSICAL_USER_PREFIX = "ticket:active:";
 	private static final String READY_KEY_PREFIX = "queue:ready:";
 	private static final String SEAT_HOLD_KEY_PREFIX = "seat:hold:";
 
@@ -31,7 +31,7 @@ public class TicketingRedisRepository {
 	}
 
 	public void addActiveTicketingUser(Long showId, String sessionToken) {
-		String key = TICKET_ACTIVE_PERFORMANCE_USER_PREFIX + showId;
+		String key = TICKET_ACTIVE_MUSICAL_USER_PREFIX + showId;
 		long nowMs =  System.currentTimeMillis();
 		redisSupport.zAdd(key, sessionToken, nowMs);
 	}
@@ -47,7 +47,7 @@ public class TicketingRedisRepository {
 	}
 
 	public long removeInactiveTicketingUsers(Long showId, long beforeMs) {
-		String key = TICKET_ACTIVE_PERFORMANCE_USER_PREFIX + showId;
+		String key = TICKET_ACTIVE_MUSICAL_USER_PREFIX + showId;
 		return redisSupport.zRemRangeByScore(key, 0, beforeMs - 1);
 	}
 

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/repository/TicketingRedisRepository.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/repository/TicketingRedisRepository.java
@@ -19,18 +19,18 @@ public class TicketingRedisRepository {
 
 	private final RedisSupport redisSupport;
 
-	public boolean consumeAdmissionToken(String showId, String userId, String admissionToken) {
+	public boolean consumeAdmissionToken(Long showId, Long userId, String admissionToken) {
 		String key = READY_KEY_PREFIX + showId + ":" + userId;
 		return redisSupport.consumeIfEquals(key, admissionToken);
 	}
 
-	public void saveSessionToken(String sessionToken, String userId, String showId, Duration ttl) {
+	public void saveSessionToken(String sessionToken, Long userId, Long showId, Duration ttl) {
 		String key =  SESSION_TOKEN_PREFIX + sessionToken;
 		SessionTicketValueDTO value = SessionTicketValueDTO.of(userId, showId);
 		redisSupport.setJsonValueWithTtl(key, value, ttl);
 	}
 
-	public void addActiveTicketingUser(String showId, String sessionToken) {
+	public void addActiveTicketingUser(Long showId, String sessionToken) {
 		String key = TICKET_ACTIVE_PERFORMANCE_USER_PREFIX + showId;
 		long nowMs =  System.currentTimeMillis();
 		redisSupport.zAdd(key, sessionToken, nowMs);
@@ -46,7 +46,7 @@ public class TicketingRedisRepository {
 		return redisSupport.getJsonValue(key, SessionTicketValueDTO.class);
 	}
 
-	public long removeInactiveTicketingUsers(String showId, long beforeMs) {
+	public long removeInactiveTicketingUsers(Long showId, long beforeMs) {
 		String key = TICKET_ACTIVE_PERFORMANCE_USER_PREFIX + showId;
 		return redisSupport.zRemRangeByScore(key, 0, beforeMs - 1);
 	}

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/repository/TicketingRedisRepository.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/repository/TicketingRedisRepository.java
@@ -13,7 +13,7 @@ import lombok.RequiredArgsConstructor;
 public class TicketingRedisRepository {
 
 	private static final String SESSION_TOKEN_PREFIX = "ticket:session:";
-	private static final String TICKET_ACTIVE_MUSICAL_USER_PREFIX = "ticket:active:";
+	private static final String TICKET_ACTIVE_SHOW_USER_PREFIX = "ticket:active:";
 	private static final String READY_KEY_PREFIX = "queue:ready:";
 	private static final String SEAT_HOLD_KEY_PREFIX = "seat:hold:";
 
@@ -31,7 +31,7 @@ public class TicketingRedisRepository {
 	}
 
 	public void addActiveTicketingUser(Long showId, String sessionToken) {
-		String key = TICKET_ACTIVE_MUSICAL_USER_PREFIX + showId;
+		String key = TICKET_ACTIVE_SHOW_USER_PREFIX + showId;
 		long nowMs =  System.currentTimeMillis();
 		redisSupport.zAdd(key, sessionToken, nowMs);
 	}
@@ -47,7 +47,7 @@ public class TicketingRedisRepository {
 	}
 
 	public long removeInactiveTicketingUsers(Long showId, long beforeMs) {
-		String key = TICKET_ACTIVE_MUSICAL_USER_PREFIX + showId;
+		String key = TICKET_ACTIVE_SHOW_USER_PREFIX + showId;
 		return redisSupport.zRemRangeByScore(key, 0, beforeMs - 1);
 	}
 
@@ -56,8 +56,8 @@ public class TicketingRedisRepository {
 		return redisSupport.expireSeconds(key, ttlSeconds);
 	}
 
-	public boolean tryHoldSeat(Long musicalScheduleId, Long seatId, String sessionToken) {
-		String key = SEAT_HOLD_KEY_PREFIX + musicalScheduleId + ":" + seatId;
+	public boolean tryHoldSeat(Long showScheduleId, Long seatId, String sessionToken) {
+		String key = SEAT_HOLD_KEY_PREFIX + showScheduleId + ":" + seatId;
 		// TODO: 좌석 점유 시간 기획측과 논의
 		return redisSupport.setIfAbsent(key, sessionToken, Duration.ofMinutes(10));
 	}

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/repository/TicketingRedisRepository.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/repository/TicketingRedisRepository.java
@@ -15,6 +15,7 @@ public class TicketingRedisRepository {
 	private static final String SESSION_TOKEN_PREFIX = "ticket:session:";
 	private static final String TICKET_ACTIVE_PERFORMANCE_USER_PREFIX = "ticket:active:";
 	private static final String READY_KEY_PREFIX = "queue:ready:";
+	private static final String SEAT_HOLD_KEY_PREFIX = "seat:hold:";
 
 	private final RedisSupport redisSupport;
 
@@ -53,6 +54,12 @@ public class TicketingRedisRepository {
 	public boolean refreshSessionTokenTtl(String sessionToken, long ttlSeconds) {
 		String key = SESSION_TOKEN_PREFIX + sessionToken;
 		return redisSupport.expireSeconds(key, ttlSeconds);
+	}
+
+	public boolean tryHoldSeat(Long musicalScheduleId, Long seatId, String sessionToken) {
+		String key = SEAT_HOLD_KEY_PREFIX + musicalScheduleId + ":" + seatId;
+		// TODO: 좌석 점유 시간 기획측과 논의
+		return redisSupport.setIfAbsent(key, sessionToken, Duration.ofMinutes(10));
 	}
 
 

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/service/TicketingService.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/service/TicketingService.java
@@ -28,7 +28,7 @@ public class TicketingService {
 	private final TicketingProperties ticketingProperties;
 	private final MusicalScheduleSeatRepository musicalScheduleSeatRepository;
 
-	public TicketingResponse.Enter enter(String musicalScheduleId, String userId, String admissionToken) {
+	public TicketingResponse.Enter enter(Long musicalScheduleId, Long userId, String admissionToken) {
 		AdmissionTokenClaimsDTO claims = admissionTokenService.parseAdmissionToken(admissionToken, musicalScheduleId, userId);
 
 		boolean consumedAdmissionToken = ticketingRedisRepository.consumeAdmissionToken(claims.getShowId(), claims.getUserId(), admissionToken);
@@ -44,7 +44,7 @@ public class TicketingService {
 		return new TicketingResponse.Enter(sessionToken, sessionTokenTtl);
 	}
 
-	public void heartbeat(String musicalScheduleId, String userId, String sessionToken) {
+	public void heartbeat(Long musicalScheduleId, Long userId, String sessionToken) {
 
 		isCorrectSessionToken(musicalScheduleId, userId, sessionToken);
 
@@ -57,8 +57,8 @@ public class TicketingService {
 		Preconditions.validate(extended, ErrorCode.INVALID_SESSION_TOKEN);
 	}
 
-	public void holdSeat(Long musicalScheduleId, String userId, String sessionToken, Long musicalScheduleSeatId) {
-		heartbeat(String.valueOf(musicalScheduleId), userId, sessionToken);
+	public void holdSeat(Long musicalScheduleId, Long userId, String sessionToken, Long musicalScheduleSeatId) {
+		heartbeat(musicalScheduleId, userId, sessionToken);
 
 		MusicalScheduleSeat seat = musicalScheduleSeatRepository.findById(musicalScheduleSeatId)
 			.orElseThrow(() -> new CustomException(ErrorCode.NOT_CORRECT_SEAT));
@@ -77,7 +77,7 @@ public class TicketingService {
 		Preconditions.validate(tryHoldSeatResult, ErrorCode.ALREADY_HOLD_SEAT);
 	}
 
-	private void isCorrectSessionToken(String musicalScheduleId, String userId, String sessionToken) {
+	private void isCorrectSessionToken(Long musicalScheduleId, Long userId, String sessionToken) {
 		Preconditions.validate(sessionToken != null && !sessionToken.isBlank(), ErrorCode.INVALID_SESSION_TOKEN);
 
 		SessionTicketValueDTO sessionValue = ticketingRedisRepository.getSessionTokenValue(sessionToken);

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/service/TicketingService.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/service/TicketingService.java
@@ -28,8 +28,8 @@ public class TicketingService {
 	private final TicketingProperties ticketingProperties;
 	private final MusicalScheduleSeatRepository musicalScheduleSeatRepository;
 
-	public TicketingResponse.Enter enter(String showId, String userId, String admissionToken) {
-		AdmissionTokenClaimsDTO claims = admissionTokenService.parseAdmissionToken(admissionToken, showId, userId);
+	public TicketingResponse.Enter enter(String musicalScheduleId, String userId, String admissionToken) {
+		AdmissionTokenClaimsDTO claims = admissionTokenService.parseAdmissionToken(admissionToken, musicalScheduleId, userId);
 
 		boolean consumedAdmissionToken = ticketingRedisRepository.consumeAdmissionToken(claims.getShowId(), claims.getUserId(), admissionToken);
 		Preconditions.validate(consumedAdmissionToken, ErrorCode.INVALID_ADMISSION_TOKEN);
@@ -37,21 +37,21 @@ public class TicketingService {
 		String sessionToken = UUID.randomUUID().toString();
 
 		// TODO: 만료시간 기획측과 논의
-		ticketingRedisRepository.saveSessionToken(sessionToken, userId, showId, Duration.ofMinutes(5));
-		ticketingRedisRepository.addActiveTicketingUser(showId, sessionToken);
+		ticketingRedisRepository.saveSessionToken(sessionToken, userId, musicalScheduleId, Duration.ofMinutes(5));
+		ticketingRedisRepository.addActiveTicketingUser(musicalScheduleId, sessionToken);
 		long sessionTokenTtl = ticketingRedisRepository.getSessionTokenTtl(sessionToken);
 
 		return new TicketingResponse.Enter(sessionToken, sessionTokenTtl);
 	}
 
-	public void heartbeat(String showId, String userId, String sessionToken) {
+	public void heartbeat(String musicalScheduleId, String userId, String sessionToken) {
 
-		isCorrectSessionToken(showId, userId, sessionToken);
+		isCorrectSessionToken(musicalScheduleId, userId, sessionToken);
 
-		ticketingRedisRepository.addActiveTicketingUser(showId, sessionToken);
+		ticketingRedisRepository.addActiveTicketingUser(musicalScheduleId, sessionToken);
 		long nowMs = System.currentTimeMillis();
 		long activeWindowMs = ticketingProperties.getActiveWindowMs();
-		ticketingRedisRepository.removeInactiveTicketingUsers(showId, nowMs - activeWindowMs);
+		ticketingRedisRepository.removeInactiveTicketingUsers(musicalScheduleId, nowMs - activeWindowMs);
 
 		boolean extended = ticketingRedisRepository.refreshSessionTokenTtl(sessionToken, ticketingProperties.getSessionTtlSec());
 		Preconditions.validate(extended, ErrorCode.INVALID_SESSION_TOKEN);
@@ -77,14 +77,14 @@ public class TicketingService {
 		Preconditions.validate(tryHoldSeatResult, ErrorCode.ALREADY_HOLD_SEAT);
 	}
 
-	private void isCorrectSessionToken(String showId, String userId, String sessionToken) {
+	private void isCorrectSessionToken(String musicalScheduleId, String userId, String sessionToken) {
 		Preconditions.validate(sessionToken != null && !sessionToken.isBlank(), ErrorCode.INVALID_SESSION_TOKEN);
 
 		SessionTicketValueDTO sessionValue = ticketingRedisRepository.getSessionTokenValue(sessionToken);
 
 		Preconditions.validate(sessionValue != null, ErrorCode.INVALID_SESSION_TOKEN);
 		Preconditions.validate(userId.equals(sessionValue.getUserId()), ErrorCode.SESSION_TOKEN_MISMATCH);
-		Preconditions.validate(showId.equals(sessionValue.getShowId()), ErrorCode.SESSION_TOKEN_MISMATCH);
+		Preconditions.validate(musicalScheduleId.equals(sessionValue.getShowId()), ErrorCode.SESSION_TOKEN_MISMATCH);
 	}
 
 }

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/service/TicketingService.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/service/TicketingService.java
@@ -4,13 +4,13 @@ import java.time.Duration;
 import java.util.UUID;
 
 import org.springframework.stereotype.Service;
-import org.truve.platform.ticketing.service.domain.entity.MusicalScheduleSeat;
+import org.truve.platform.ticketing.service.domain.entity.ShowScheduleSeat;
 import org.truve.platform.ticketing.service.dto.AdmissionTokenClaimsDTO;
 import org.truve.platform.ticketing.service.dto.SessionTicketValueDTO;
 import org.truve.platform.ticketing.service.dto.TicketingResponse;
 import org.truve.platform.ticketing.service.config.TicketingProperties;
 import org.truve.platform.ticketing.service.jwt.AdmissionTokenService;
-import org.truve.platform.ticketing.service.repository.MusicalScheduleSeatRepository;
+import org.truve.platform.ticketing.service.repository.ShowScheduleSeatRepository;
 import org.truve.platform.ticketing.service.repository.TicketingRedisRepository;
 
 import com.truve.platform.common.exception.CustomException;
@@ -26,10 +26,10 @@ public class TicketingService {
 	private final TicketingRedisRepository ticketingRedisRepository;
 	private final AdmissionTokenService admissionTokenService;
 	private final TicketingProperties ticketingProperties;
-	private final MusicalScheduleSeatRepository musicalScheduleSeatRepository;
+	private final ShowScheduleSeatRepository showScheduleSeatRepository;
 
-	public TicketingResponse.Enter enter(Long musicalScheduleId, Long userId, String admissionToken) {
-		AdmissionTokenClaimsDTO claims = admissionTokenService.parseAdmissionToken(admissionToken, musicalScheduleId, userId);
+	public TicketingResponse.Enter enter(Long showScheduleId, Long userId, String admissionToken) {
+		AdmissionTokenClaimsDTO claims = admissionTokenService.parseAdmissionToken(admissionToken, showScheduleId, userId);
 
 		boolean consumedAdmissionToken = ticketingRedisRepository.consumeAdmissionToken(claims.getShowId(), claims.getUserId(), admissionToken);
 		Preconditions.validate(consumedAdmissionToken, ErrorCode.INVALID_ADMISSION_TOKEN);
@@ -37,30 +37,30 @@ public class TicketingService {
 		String sessionToken = UUID.randomUUID().toString();
 
 		// TODO: 만료시간 기획측과 논의
-		ticketingRedisRepository.saveSessionToken(sessionToken, userId, musicalScheduleId, Duration.ofMinutes(5));
-		ticketingRedisRepository.addActiveTicketingUser(musicalScheduleId, sessionToken);
+		ticketingRedisRepository.saveSessionToken(sessionToken, userId, showScheduleId, Duration.ofMinutes(5));
+		ticketingRedisRepository.addActiveTicketingUser(showScheduleId, sessionToken);
 		long sessionTokenTtl = ticketingRedisRepository.getSessionTokenTtl(sessionToken);
 
 		return new TicketingResponse.Enter(sessionToken, sessionTokenTtl);
 	}
 
-	public void heartbeat(Long musicalScheduleId, Long userId, String sessionToken) {
+	public void heartbeat(Long showScheduleId, Long userId, String sessionToken) {
 
-		isCorrectSessionToken(musicalScheduleId, userId, sessionToken);
+		isCorrectSessionToken(showScheduleId, userId, sessionToken);
 
-		ticketingRedisRepository.addActiveTicketingUser(musicalScheduleId, sessionToken);
+		ticketingRedisRepository.addActiveTicketingUser(showScheduleId, sessionToken);
 		long nowMs = System.currentTimeMillis();
 		long activeWindowMs = ticketingProperties.getActiveWindowMs();
-		ticketingRedisRepository.removeInactiveTicketingUsers(musicalScheduleId, nowMs - activeWindowMs);
+		ticketingRedisRepository.removeInactiveTicketingUsers(showScheduleId, nowMs - activeWindowMs);
 
 		boolean extended = ticketingRedisRepository.refreshSessionTokenTtl(sessionToken, ticketingProperties.getSessionTtlSec());
 		Preconditions.validate(extended, ErrorCode.INVALID_SESSION_TOKEN);
 	}
 
-	public void holdSeat(Long musicalScheduleId, Long userId, String sessionToken, Long musicalScheduleSeatId) {
-		heartbeat(musicalScheduleId, userId, sessionToken);
+	public void holdSeat(Long showScheduleId, Long userId, String sessionToken, Long showScheduleSeatId) {
+		heartbeat(showScheduleId, userId, sessionToken);
 
-		MusicalScheduleSeat seat = musicalScheduleSeatRepository.findById(musicalScheduleSeatId)
+		ShowScheduleSeat seat = showScheduleSeatRepository.findById(showScheduleSeatId)
 			.orElseThrow(() -> new CustomException(ErrorCode.NOT_CORRECT_SEAT));
 
 		Preconditions.validate(
@@ -69,22 +69,22 @@ public class TicketingService {
 		);
 
 		Preconditions.validate(
-			seat.getMusicalScheduleId().equals(musicalScheduleId),
+			seat.getShowScheduleId().equals(showScheduleId),
 			ErrorCode.NOT_CORRECT_SEAT
 		);
 
-		boolean tryHoldSeatResult = ticketingRedisRepository.tryHoldSeat(musicalScheduleId, seat.getSeatId(), sessionToken);
+		boolean tryHoldSeatResult = ticketingRedisRepository.tryHoldSeat(showScheduleId, seat.getSeatId(), sessionToken);
 		Preconditions.validate(tryHoldSeatResult, ErrorCode.ALREADY_HOLD_SEAT);
 	}
 
-	private void isCorrectSessionToken(Long musicalScheduleId, Long userId, String sessionToken) {
+	private void isCorrectSessionToken(Long showScheduleId, Long userId, String sessionToken) {
 		Preconditions.validate(sessionToken != null && !sessionToken.isBlank(), ErrorCode.INVALID_SESSION_TOKEN);
 
 		SessionTicketValueDTO sessionValue = ticketingRedisRepository.getSessionTokenValue(sessionToken);
 
 		Preconditions.validate(sessionValue != null, ErrorCode.INVALID_SESSION_TOKEN);
 		Preconditions.validate(userId.equals(sessionValue.getUserId()), ErrorCode.SESSION_TOKEN_MISMATCH);
-		Preconditions.validate(musicalScheduleId.equals(sessionValue.getShowId()), ErrorCode.SESSION_TOKEN_MISMATCH);
+		Preconditions.validate(showScheduleId.equals(sessionValue.getShowId()), ErrorCode.SESSION_TOKEN_MISMATCH);
 	}
 
 }

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/service/TicketingService.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/service/TicketingService.java
@@ -4,13 +4,16 @@ import java.time.Duration;
 import java.util.UUID;
 
 import org.springframework.stereotype.Service;
+import org.truve.platform.ticketing.service.domain.entity.MusicalScheduleSeat;
 import org.truve.platform.ticketing.service.dto.AdmissionTokenClaimsDTO;
 import org.truve.platform.ticketing.service.dto.SessionTicketValueDTO;
 import org.truve.platform.ticketing.service.dto.TicketingResponse;
 import org.truve.platform.ticketing.service.config.TicketingProperties;
 import org.truve.platform.ticketing.service.jwt.AdmissionTokenService;
+import org.truve.platform.ticketing.service.repository.MusicalScheduleSeatRepository;
 import org.truve.platform.ticketing.service.repository.TicketingRedisRepository;
 
+import com.truve.platform.common.exception.CustomException;
 import com.truve.platform.common.exception.ErrorCode;
 import com.truve.platform.common.support.Preconditions;
 
@@ -23,6 +26,7 @@ public class TicketingService {
 	private final TicketingRedisRepository ticketingRedisRepository;
 	private final AdmissionTokenService admissionTokenService;
 	private final TicketingProperties ticketingProperties;
+	private final MusicalScheduleSeatRepository musicalScheduleSeatRepository;
 
 	public TicketingResponse.Enter enter(String showId, String userId, String admissionToken) {
 		AdmissionTokenClaimsDTO claims = admissionTokenService.parseAdmissionToken(admissionToken, showId, userId);
@@ -41,13 +45,8 @@ public class TicketingService {
 	}
 
 	public void heartbeat(String showId, String userId, String sessionToken) {
-		Preconditions.validate(sessionToken != null && !sessionToken.isBlank(), ErrorCode.INVALID_SESSION_TOKEN);
 
-		SessionTicketValueDTO sessionValue = ticketingRedisRepository.getSessionTokenValue(sessionToken);
-
-		Preconditions.validate(sessionValue != null, ErrorCode.INVALID_SESSION_TOKEN);
-		Preconditions.validate(userId.equals(sessionValue.getUserId()), ErrorCode.SESSION_TOKEN_MISMATCH);
-		Preconditions.validate(showId.equals(sessionValue.getShowId()), ErrorCode.SESSION_TOKEN_MISMATCH);
+		isCorrectSessionToken(showId, userId, sessionToken);
 
 		ticketingRedisRepository.addActiveTicketingUser(showId, sessionToken);
 		long nowMs = System.currentTimeMillis();
@@ -56,6 +55,36 @@ public class TicketingService {
 
 		boolean extended = ticketingRedisRepository.refreshSessionTokenTtl(sessionToken, ticketingProperties.getSessionTtlSec());
 		Preconditions.validate(extended, ErrorCode.INVALID_SESSION_TOKEN);
-
 	}
+
+	public void holdSeat(Long musicalScheduleId, String userId, String sessionToken, Long musicalScheduleSeatId) {
+		heartbeat(String.valueOf(musicalScheduleId), userId, sessionToken);
+
+		MusicalScheduleSeat seat = musicalScheduleSeatRepository.findById(musicalScheduleSeatId)
+			.orElseThrow(() -> new CustomException(ErrorCode.NOT_CORRECT_SEAT));
+
+		Preconditions.validate(
+			seat.isAvailable(),
+			ErrorCode.ALREADY_SOLD_SEAT
+		);
+
+		Preconditions.validate(
+			seat.getMusicalScheduleId().equals(musicalScheduleId),
+			ErrorCode.NOT_CORRECT_SEAT
+		);
+
+		boolean tryHoldSeatResult = ticketingRedisRepository.tryHoldSeat(musicalScheduleId, seat.getSeatId(), sessionToken);
+		Preconditions.validate(tryHoldSeatResult, ErrorCode.ALREADY_HOLD_SEAT);
+	}
+
+	private void isCorrectSessionToken(String showId, String userId, String sessionToken) {
+		Preconditions.validate(sessionToken != null && !sessionToken.isBlank(), ErrorCode.INVALID_SESSION_TOKEN);
+
+		SessionTicketValueDTO sessionValue = ticketingRedisRepository.getSessionTokenValue(sessionToken);
+
+		Preconditions.validate(sessionValue != null, ErrorCode.INVALID_SESSION_TOKEN);
+		Preconditions.validate(userId.equals(sessionValue.getUserId()), ErrorCode.SESSION_TOKEN_MISMATCH);
+		Preconditions.validate(showId.equals(sessionValue.getShowId()), ErrorCode.SESSION_TOKEN_MISMATCH);
+	}
+
 }


### PR DESCRIPTION
## 변경 사항

추가/변경 사항과 사유를 작성해 주세요.

- **티켓팅 서비스 필요 엔티티**

저희 논의 상 좌석/공연장 정보는 우선 Musical 서비스에서 프론트에서 조회하고, 차후 분리 예정이었으며
티켓팅 과정중에 정말 필요하다고 생각되는 `공연회차-좌석 매핑`, `예약`, `티켓` 엔티티 구현했습니다. 
도메인 로직들 더 추가 필요합니다!

기존 ERD와 다른 점은 Reservation과 좌석 간 매핑이 필요하다고 생각되어 추가했습니다.

Reservation Id가 결제 시 주문 Id로 넘어가야할 것 같은데, 1건의 주문당 여러 좌석이 동반될 수 있음을 놓쳤던 것 같습니다!
결제 서비스 관점에서 검토 한번 부탁드립니다! 이렇게 진행해도 괜찮을까요? @YeKim1

ERD 반영했습니다.


- **좌석 선점 로직**
  
Redis로 간단하게 좌석 홀드하도록 구현했습니다.   
redis String + ttl로 setIfAbsent 사용하여 `seat:hold:{musicalScheduleId}:{seatId}` `value: sessionToken`
Redis 내 해당 값이 없으면 락 점유, 해당 값이 있으면 다른 유저가 선점 중으로 간단하게 락 구현하였습니다.

락 방식은 멘토링이나 강사님께 여쭤보며 디벨롭 하겠습니다!


- **변수명 및 타입 통일**
 
승희님께서 Musical을 사용하셔서 기존 show/performance -> Musical로 네이밍 변경했습니다.
생각보다 변수명들이 길어져서.. 변수명/api 엔드포인트에 있어서 좋은 아이디어 주시면 감사하겠습니다.
또한 제가 구현의 편의성을 위해 String으로 다 받던 값들을 Long으로 고쳤습니다..


## 관련 이슈


- Notion Ticket: [#41
](https://www.notion.so/3149e3e335cc80348582c4379b4062a3?source=copy_link)

## 참고사항 (선택)

연관관계를 많이 맺지 않았는데, 조금 더 고민하고 걸어보아야할 것 같습니다!
도메인이 차후 분리될 것까지 예상하여 분리할 부분들은 안걸고 작업하는게 나으리라 예상되어
최대한 걸지 않았었습니다.

뮤지컬 도메인이 필요할 것 같아 승희님 브랜치에서 따서 작업하여 
base 브랜치 승희님 PR 브랜치로 맞춰놓았습니다!