### PR TITLE
refactor(payment): 결제 생성 요청 DTO 내 미사용 필드(method) 삭제

### DIFF
--- a/payment/src/main/java/com/truve/platform/payment/service/dto/PaymentRequest.java
+++ b/payment/src/main/java/com/truve/platform/payment/service/dto/PaymentRequest.java
@@ -1,7 +1,5 @@
 package com.truve.platform.payment.service.dto;
 
-import com.truve.platform.payment.service.domain.constant.PaymentMethod;
-
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
@@ -18,7 +16,5 @@ public class PaymentRequest {
 		@NotNull
 		@Positive
 		private Long amount;
-		@NotNull
-		private PaymentMethod method;
 	}
 }

--- a/payment/src/test/java/com/truve/platform/payment/service/controller/PaymentControllerTest.java
+++ b/payment/src/test/java/com/truve/platform/payment/service/controller/PaymentControllerTest.java
@@ -44,7 +44,7 @@ public class PaymentControllerTest {
 			.orderId(orderId)
 			.paymentKey("test-payment-key")
 			.amount(10000L)
-			.method(PaymentMethod.CARD)
+			.method(PaymentMethod.CARD.getDisplayName())
 			.status(PaymentStatus.DONE)
 			.build();
 
@@ -58,7 +58,7 @@ public class PaymentControllerTest {
 			.andExpect(jsonPath("$.data.orderId").value(orderId))
 			.andExpect(jsonPath("$.data.paymentKey").value("test-payment-key"))
 			.andExpect(jsonPath("$.data.amount").value(10000L))
-			.andExpect(jsonPath("$.data.method").value("CARD"))
+			.andExpect(jsonPath("$.data.method").value(PaymentMethod.CARD.getDisplayName()))
 			.andExpect(jsonPath("$.data.status").value("DONE"));
 		verify(paymentService).details(orderId);
 	}
@@ -67,7 +67,7 @@ public class PaymentControllerTest {
 	@DisplayName("결제 생성에 성공하면 200 OK와 생성된 paymentId를 응답한다.")
 	void 결제_생성() throws Exception {
 		// given
-		var request = new PaymentRequest.Create("orderId", 100L, PaymentMethod.CARD);
+		var request = new PaymentRequest.Create("orderId", 100L);
 		given(paymentService.create(any())).willReturn(1L);
 
 		// when
@@ -84,7 +84,7 @@ public class PaymentControllerTest {
 	@DisplayName("중복된 orderId로 요청한 경우, 400과 ALREADY_EXIST_PAYMENT를 응답한다. ")
 	void 결제_생성_중복_에러_테스트() throws Exception {
 		// given
-		var request = new PaymentRequest.Create("orderId", 100L, PaymentMethod.CARD);
+		var request = new PaymentRequest.Create("orderId", 100L);
 		given(paymentService.create(any()))
 			.willThrow(new CustomException(ErrorCode.ALREADY_EXIST_PAYMENT));
 

--- a/payment/src/test/java/com/truve/platform/payment/service/service/PaymentServiceTest.java
+++ b/payment/src/test/java/com/truve/platform/payment/service/service/PaymentServiceTest.java
@@ -15,7 +15,6 @@ import org.springframework.test.util.ReflectionTestUtils;
 
 import com.truve.platform.common.exception.CustomException;
 import com.truve.platform.common.exception.ErrorCode;
-import com.truve.platform.payment.service.domain.constant.PaymentMethod;
 import com.truve.platform.payment.service.domain.entity.Payment;
 import com.truve.platform.payment.service.dto.PaymentRequest;
 import com.truve.platform.payment.service.repository.PaymentRepository;
@@ -32,7 +31,7 @@ class PaymentServiceTest {
 	@DisplayName("결제 생성 테스트")
 	class createPaymentTest {
 
-		private final PaymentRequest.Create request = new PaymentRequest.Create("orderId", 100L, PaymentMethod.CARD);
+		private final PaymentRequest.Create request = new PaymentRequest.Create("orderId", 100L);
 
 		@Test
 		@DisplayName("새로운 결제를 요청하면 전달받은 결제 정보를 저장한다.")


### PR DESCRIPTION
## 변경 사항

---
결제 생성시 결제 방식을 전달받지 않는 변경 사항(#39 )에 따른, `PaymentRequest.Create` DTO 필드 반영이 누락되어 별도의 PR로 업로드합니다!  🥹

- [x] 전체 테스트 코드 성공 여부

## 관련 이슈

---
- Notion Ticket: #

## 참고사항 (선택)

---