### PR TITLE
refactor(musical): 뮤지컬 서비스 폴더 구조 리팩토링

### DIFF
--- a/musical/src/main/java/com/truve/platform/musical/MusicalApplication.java
+++ b/musical/src/main/java/com/truve/platform/musical/MusicalApplication.java
@@ -1,4 +1,4 @@
-package com.truve.platform.show;
+package com.truve.platform.musical;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;

--- a/musical/src/main/java/com/truve/platform/musical/pricing/domain/entity/ShowSeatGrade.java
+++ b/musical/src/main/java/com/truve/platform/musical/pricing/domain/entity/ShowSeatGrade.java
@@ -1,6 +1,7 @@
-package com.truve.platform.show.service.domain.entity;
+package com.truve.platform.musical.pricing.domain.entity;
 
 import com.truve.platform.common.support.BaseEntity;
+import com.truve.platform.musical.show.domain.entity.Show;
 
 import jakarta.persistence.AttributeOverride;
 import jakarta.persistence.Column;

--- a/musical/src/main/java/com/truve/platform/musical/pricing/domain/repository/ShowSeatGradeRepository.java
+++ b/musical/src/main/java/com/truve/platform/musical/pricing/domain/repository/ShowSeatGradeRepository.java
@@ -1,4 +1,4 @@
-package com.truve.platform.show.service.repository;
+package com.truve.platform.musical.pricing.domain.repository;
 
 import java.util.List;
 
@@ -6,7 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import com.truve.platform.show.service.domain.entity.ShowSeatGrade;
+import com.truve.platform.musical.pricing.domain.entity.ShowSeatGrade;
 
 public interface ShowSeatGradeRepository extends JpaRepository<ShowSeatGrade, Long> {
 

--- a/musical/src/main/java/com/truve/platform/musical/seat/domain/entity/Venue.java
+++ b/musical/src/main/java/com/truve/platform/musical/seat/domain/entity/Venue.java
@@ -1,4 +1,4 @@
-package com.truve.platform.musical.show.domain.entity;
+package com.truve.platform.musical.seat.domain.entity;
 
 import com.truve.platform.common.support.BaseEntity;
 

--- a/musical/src/main/java/com/truve/platform/musical/show/controller/ShowController.java
+++ b/musical/src/main/java/com/truve/platform/musical/show/controller/ShowController.java
@@ -1,4 +1,4 @@
-package com.truve.platform.show.service.controller;
+package com.truve.platform.musical.show.controller;
 
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -6,8 +6,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.truve.platform.common.response.ApiResult;
-import com.truve.platform.show.service.dto.ShowResponse;
-import com.truve.platform.show.service.service.ShowService;
+import com.truve.platform.musical.show.dto.ShowResponse;
+import com.truve.platform.musical.show.service.ShowService;
 
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;

--- a/musical/src/main/java/com/truve/platform/musical/show/domain/constant/ShowScheduleStatus.java
+++ b/musical/src/main/java/com/truve/platform/musical/show/domain/constant/ShowScheduleStatus.java
@@ -1,4 +1,4 @@
-package com.truve.platform.show.service.domain.constant;
+package com.truve.platform.musical.show.domain.constant;
 
 public enum ShowScheduleStatus {
 	OPEN,   // 예매 가능

--- a/musical/src/main/java/com/truve/platform/musical/show/domain/entity/Artist.java
+++ b/musical/src/main/java/com/truve/platform/musical/show/domain/entity/Artist.java
@@ -1,4 +1,4 @@
-package com.truve.platform.show.service.domain.entity;
+package com.truve.platform.musical.show.domain.entity;
 
 import com.truve.platform.common.support.BaseEntity;
 

--- a/musical/src/main/java/com/truve/platform/musical/show/domain/entity/Show.java
+++ b/musical/src/main/java/com/truve/platform/musical/show/domain/entity/Show.java
@@ -1,11 +1,9 @@
-package com.truve.platform.show.service.domain.entity;
+package com.truve.platform.musical.show.domain.entity;
 
 import java.time.LocalDateTime;
 
 import com.truve.platform.common.support.BaseEntity;
 
-import jakarta.persistence.AttributeOverride;
-import jakarta.persistence.AttributeOverrides;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;

--- a/musical/src/main/java/com/truve/platform/musical/show/domain/entity/Show.java
+++ b/musical/src/main/java/com/truve/platform/musical/show/domain/entity/Show.java
@@ -3,6 +3,7 @@ package com.truve.platform.musical.show.domain.entity;
 import java.time.LocalDateTime;
 
 import com.truve.platform.common.support.BaseEntity;
+import com.truve.platform.musical.seat.domain.entity.Venue;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;

--- a/musical/src/main/java/com/truve/platform/musical/show/domain/entity/ShowCasting.java
+++ b/musical/src/main/java/com/truve/platform/musical/show/domain/entity/ShowCasting.java
@@ -1,4 +1,4 @@
-package com.truve.platform.show.service.domain.entity;
+package com.truve.platform.musical.show.domain.entity;
 
 import com.truve.platform.common.support.BaseEntity;
 

--- a/musical/src/main/java/com/truve/platform/musical/show/domain/entity/ShowSchedule.java
+++ b/musical/src/main/java/com/truve/platform/musical/show/domain/entity/ShowSchedule.java
@@ -1,9 +1,9 @@
-package com.truve.platform.show.service.domain.entity;
+package com.truve.platform.musical.show.domain.entity;
 
 import java.time.LocalDateTime;
 
 import com.truve.platform.common.support.BaseEntity;
-import com.truve.platform.show.service.domain.constant.ShowScheduleStatus;
+import com.truve.platform.musical.show.domain.constant.ShowScheduleStatus;
 
 import jakarta.persistence.AttributeOverride;
 import jakarta.persistence.Column;

--- a/musical/src/main/java/com/truve/platform/musical/show/domain/entity/ShowScheduleCasting.java
+++ b/musical/src/main/java/com/truve/platform/musical/show/domain/entity/ShowScheduleCasting.java
@@ -1,4 +1,4 @@
-package com.truve.platform.show.service.domain.entity;
+package com.truve.platform.musical.show.domain.entity;
 
 import com.truve.platform.common.support.BaseEntity;
 

--- a/musical/src/main/java/com/truve/platform/musical/show/domain/entity/Venue.java
+++ b/musical/src/main/java/com/truve/platform/musical/show/domain/entity/Venue.java
@@ -1,4 +1,4 @@
-package com.truve.platform.show.service.domain.entity;
+package com.truve.platform.musical.show.domain.entity;
 
 import com.truve.platform.common.support.BaseEntity;
 

--- a/musical/src/main/java/com/truve/platform/musical/show/dto/ShowResponse.java
+++ b/musical/src/main/java/com/truve/platform/musical/show/dto/ShowResponse.java
@@ -1,4 +1,4 @@
-package com.truve.platform.show.service.dto;
+package com.truve.platform.musical.show.dto;
 
 import java.time.LocalDateTime;
 import java.util.List;

--- a/musical/src/main/java/com/truve/platform/musical/show/repository/ShowRepository.java
+++ b/musical/src/main/java/com/truve/platform/musical/show/repository/ShowRepository.java
@@ -1,4 +1,4 @@
-package com.truve.platform.show.service.repository;
+package com.truve.platform.musical.show.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -6,7 +6,7 @@ import org.springframework.data.repository.query.Param;
 
 import com.truve.platform.common.exception.CustomException;
 import com.truve.platform.common.exception.ErrorCode;
-import com.truve.platform.show.service.domain.entity.Show;
+import com.truve.platform.musical.show.domain.entity.Show;
 
 public interface ShowRepository extends JpaRepository<Show, Long> {
 

--- a/musical/src/main/java/com/truve/platform/musical/show/repository/ShowScheduleCastingRepository.java
+++ b/musical/src/main/java/com/truve/platform/musical/show/repository/ShowScheduleCastingRepository.java
@@ -1,4 +1,4 @@
-package com.truve.platform.show.service.repository;
+package com.truve.platform.musical.show.repository;
 
 import java.util.List;
 
@@ -6,7 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import com.truve.platform.show.service.domain.entity.ShowScheduleCasting;
+import com.truve.platform.musical.show.domain.entity.ShowScheduleCasting;
 
 public interface ShowScheduleCastingRepository extends JpaRepository<ShowScheduleCasting, Long> {
 

--- a/musical/src/main/java/com/truve/platform/musical/show/repository/ShowScheduleRepository.java
+++ b/musical/src/main/java/com/truve/platform/musical/show/repository/ShowScheduleRepository.java
@@ -1,4 +1,4 @@
-package com.truve.platform.show.service.repository;
+package com.truve.platform.musical.show.repository;
 
 import java.util.List;
 
@@ -6,7 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import com.truve.platform.show.service.domain.entity.ShowSchedule;
+import com.truve.platform.musical.show.domain.entity.ShowSchedule;
 
 public interface ShowScheduleRepository extends JpaRepository<ShowSchedule, Long> {
 

--- a/musical/src/main/java/com/truve/platform/musical/show/service/ShowService.java
+++ b/musical/src/main/java/com/truve/platform/musical/show/service/ShowService.java
@@ -1,4 +1,4 @@
-package com.truve.platform.show.service.service;
+package com.truve.platform.musical.show.service;
 
 import java.util.Comparator;
 import java.util.List;
@@ -8,16 +8,16 @@ import java.util.stream.Collectors;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.truve.platform.show.service.domain.entity.Show;
-import com.truve.platform.show.service.domain.entity.ShowCasting;
-import com.truve.platform.show.service.domain.entity.ShowSchedule;
-import com.truve.platform.show.service.domain.entity.ShowScheduleCasting;
-import com.truve.platform.show.service.domain.entity.ShowSeatGrade;
-import com.truve.platform.show.service.dto.ShowResponse;
-import com.truve.platform.show.service.repository.ShowRepository;
-import com.truve.platform.show.service.repository.ShowScheduleRepository;
-import com.truve.platform.show.service.repository.ShowScheduleCastingRepository;
-import com.truve.platform.show.service.repository.ShowSeatGradeRepository;
+import com.truve.platform.musical.show.domain.entity.Show;
+import com.truve.platform.musical.show.domain.entity.ShowCasting;
+import com.truve.platform.musical.show.domain.entity.ShowSchedule;
+import com.truve.platform.musical.show.domain.entity.ShowScheduleCasting;
+import com.truve.platform.musical.pricing.domain.entity.ShowSeatGrade;
+import com.truve.platform.musical.show.dto.ShowResponse;
+import com.truve.platform.musical.show.repository.ShowRepository;
+import com.truve.platform.musical.show.repository.ShowScheduleRepository;
+import com.truve.platform.musical.show.repository.ShowScheduleCastingRepository;
+import com.truve.platform.musical.pricing.domain.repository.ShowSeatGradeRepository;
 
 import lombok.RequiredArgsConstructor;
 

--- a/musical/src/test/java/com/truve/platform/show/service/controller/ShowControllerTest.java
+++ b/musical/src/test/java/com/truve/platform/show/service/controller/ShowControllerTest.java
@@ -22,9 +22,10 @@ import org.springframework.test.web.servlet.MockMvc;
 import com.truve.platform.common.exception.CustomException;
 import com.truve.platform.common.exception.ApiAdvice;
 import com.truve.platform.common.exception.ErrorCode;
-import com.truve.platform.show.service.domain.constant.ShowScheduleStatus;
-import com.truve.platform.show.service.dto.ShowResponse;
-import com.truve.platform.show.service.service.ShowService;
+import com.truve.platform.musical.show.controller.ShowController;
+import com.truve.platform.musical.show.domain.constant.ShowScheduleStatus;
+import com.truve.platform.musical.show.dto.ShowResponse;
+import com.truve.platform.musical.show.service.ShowService;
 
 @WebMvcTest(controllers = ShowController.class)
 @org.springframework.context.annotation.Import(ApiAdvice.class)

--- a/musical/src/test/java/com/truve/platform/show/service/service/ShowServiceTest.java
+++ b/musical/src/test/java/com/truve/platform/show/service/service/ShowServiceTest.java
@@ -14,19 +14,20 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import com.truve.platform.show.service.domain.constant.ShowScheduleStatus;
-import com.truve.platform.show.service.domain.entity.Artist;
-import com.truve.platform.show.service.domain.entity.Show;
-import com.truve.platform.show.service.domain.entity.ShowCasting;
-import com.truve.platform.show.service.domain.entity.ShowSchedule;
-import com.truve.platform.show.service.domain.entity.ShowScheduleCasting;
-import com.truve.platform.show.service.domain.entity.ShowSeatGrade;
-import com.truve.platform.show.service.domain.entity.Venue;
-import com.truve.platform.show.service.dto.ShowResponse;
-import com.truve.platform.show.service.repository.ShowRepository;
-import com.truve.platform.show.service.repository.ShowScheduleCastingRepository;
-import com.truve.platform.show.service.repository.ShowScheduleRepository;
-import com.truve.platform.show.service.repository.ShowSeatGradeRepository;
+import com.truve.platform.musical.show.domain.constant.ShowScheduleStatus;
+import com.truve.platform.musical.show.domain.entity.Artist;
+import com.truve.platform.musical.show.domain.entity.Show;
+import com.truve.platform.musical.show.domain.entity.ShowCasting;
+import com.truve.platform.musical.show.domain.entity.ShowSchedule;
+import com.truve.platform.musical.show.domain.entity.ShowScheduleCasting;
+import com.truve.platform.musical.pricing.domain.entity.ShowSeatGrade;
+import com.truve.platform.musical.show.domain.entity.Venue;
+import com.truve.platform.musical.show.dto.ShowResponse;
+import com.truve.platform.musical.show.repository.ShowRepository;
+import com.truve.platform.musical.show.repository.ShowScheduleCastingRepository;
+import com.truve.platform.musical.show.repository.ShowScheduleRepository;
+import com.truve.platform.musical.pricing.domain.repository.ShowSeatGradeRepository;
+import com.truve.platform.musical.show.service.ShowService;
 
 @ExtendWith(MockitoExtension.class)
 class ShowServiceTest {

--- a/musical/src/test/java/com/truve/platform/show/service/service/ShowServiceTest.java
+++ b/musical/src/test/java/com/truve/platform/show/service/service/ShowServiceTest.java
@@ -21,7 +21,7 @@ import com.truve.platform.musical.show.domain.entity.ShowCasting;
 import com.truve.platform.musical.show.domain.entity.ShowSchedule;
 import com.truve.platform.musical.show.domain.entity.ShowScheduleCasting;
 import com.truve.platform.musical.pricing.domain.entity.ShowSeatGrade;
-import com.truve.platform.musical.show.domain.entity.Venue;
+import com.truve.platform.musical.seat.domain.entity.Venue;
 import com.truve.platform.musical.show.dto.ShowResponse;
 import com.truve.platform.musical.show.repository.ShowRepository;
 import com.truve.platform.musical.show.repository.ShowScheduleCastingRepository;


### PR DESCRIPTION
## 변경 사항

- [x] 로컬 빌드 및 테스트 코드 확인 완료

```
com.truve.plaform.musical
├── show
│   ├── controller
│   ├── service
│   ├── repository
│   ├── domain
│   ├── dto
│   └── exception
├── pricing
│   ├── controller
│   ├── service
│   ├── repository
│   ├── domain
│   ├── dto
│   └── exception
└── config
```

뮤지컬 서비스의 폴더 구조를 다음과 같이  도메인별로 제안합니다.

보통 global 폴더도 두어야 하지만 저희는 common모듈에서 관리되기 때문에 global 폴더도 관리할 필요가 없고,
MSA로 프로젝트를 진행하면서 분리를 상정한 서비스들이 존재하기 때문에
도메인 별로 디렉토리 분리해서 뮤지컬 서비스 진행해나가면 어떨까 싶습니다!

따라서 각 도메인별 참조를 최소화하여서 차후 분리할 때 수월하게 가능하면 좋을 것 같습니다!

## 관련 이슈

- Notion Ticket: #

## 참고사항 (선택)

[도메인형 폴더구조 블로그 링크](https://velog.io/@chanmi125/Spring-Boot-%ED%8C%A8%ED%82%A4%EC%A7%80-%EA%B5%AC%EC%A1%B0-%EA%B3%84%EC%B8%B5%ED%98%95-vs-%EB%8F%84%EB%A9%94%EC%9D%B8%ED%98%95)
