### PR TITLE
fix(payment): Cancel DTO Schema 명시

### DIFF
--- a/payment/src/main/java/com/truve/platform/payment/service/dto/PaymentRequest.java
+++ b/payment/src/main/java/com/truve/platform/payment/service/dto/PaymentRequest.java
@@ -1,5 +1,6 @@
 package com.truve.platform.payment.service.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
@@ -22,6 +23,7 @@ public class PaymentRequest {
 	@Getter
 	@AllArgsConstructor
 	@NoArgsConstructor
+	@Schema(name = "CancelRequest")
 	public static class Cancel {
 		@NotNull
 		private String cancelReason;

--- a/payment/src/main/java/com/truve/platform/payment/service/dto/PaymentResponse.java
+++ b/payment/src/main/java/com/truve/platform/payment/service/dto/PaymentResponse.java
@@ -13,6 +13,7 @@ import com.truve.platform.payment.service.domain.entity.Payment;
 import com.truve.platform.payment.service.domain.entity.PaymentCancel;
 import com.truve.platform.payment.service.domain.entity.VirtualAccount;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -41,6 +42,7 @@ public class PaymentResponse {
 
 	@Getter
 	@Builder
+	@Schema(name = "CancelResponse")
 	public static class Cancel {
 		private final Long requestAmount;
 		private final Long refundFee;


### PR DESCRIPTION
## 변경 사항

---
`PaymentRequest.Cancel`, `PaymentResponse.Cancel` 이름이 동일해서 Swagger에서 구분을 못 하는 문제가 있었습니다.
Swagger 인식을 위해 클래스에 `Schema` name을 지정했습니다.

- [x] 전체 테스트 코드 성공 여부

## 관련 이슈

---
- Notion Ticket: #

## 참고사항 (선택)

---
기능적 차이는 없어서 리뷰없이 머지 진행하겠습니다!