### PR TITLE
feat(show): S3 및 LocalStack 도입

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ out/
 
 ### .env ###
 .env*
+
+### LocalStack ###
+/localstack/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -171,9 +171,31 @@ services:
       - MUSICAL_MYSQL_URL=jdbc:mysql://db:3306/musical_db
       - MUSICAL_MYSQL_USERNAME=root
       - MUSICAL_MYSQL_PASSWORD=1234
+      - AWS_S3_BUCKET=truve-media
+      - AWS_REGION=us-east-1
+      - AWS_ACCESS_KEY=test
+      - AWS_SECRET_KEY=test
+      - AWS_S3_ENDPOINT=http://localstack:4566
     depends_on:
       db:
         condition: service_healthy
+    networks:
+      - truve-network
+
+
+  # 9. LocalStack
+  localstack:
+    image: localstack/localstack
+    container_name: truve-media-dev
+    ports:
+      - "4566:4566"
+    volumes:
+      - "./localstack:/var/lib/localstack"
+      - "./init-s3.sh:/etc/localstack/init/ready.d/init-s3.sh"
+    environment:
+      - PERSISTENCE=1
+    entrypoint: >
+      /bin/sh -c "chmod +x /etc/localstack/init/ready.d/init-s3.sh && /usr/local/bin/docker-entrypoint.sh"
     networks:
       - truve-network
 

--- a/init-s3.sh
+++ b/init-s3.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+awslocal s3 mb s3://truve-media
+
+awslocal s3api put-public-access-block \
+    --bucket truve-media \
+    --public-access-block-configuration "BlockPublicAcls=false,IgnorePublicAcls=false,BlockPublicPolicy=false,RestrictPublicBuckets=false"
+
+cd /tmp
+for i in {1..5}; do
+  echo "This is fake image $i" > "test_$i.png"
+  awslocal s3 cp "test_$i.png" s3://truve-media/ --acl public-read
+done

--- a/musical/build.gradle
+++ b/musical/build.gradle
@@ -14,4 +14,7 @@ dependencies {
 
     // [OpenApi]
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui'
+
+    // [AWS S3]
+    implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3:3.4.0'
 }

--- a/musical/src/main/java/com/truve/platform/musical/s3/S3Service.java
+++ b/musical/src/main/java/com/truve/platform/musical/s3/S3Service.java
@@ -1,0 +1,19 @@
+package com.truve.platform.musical.s3;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class S3Service {
+	@Value("${s3.endpoint}")
+	private String endpoint;
+	@Value("${s3.bucket}")
+	private String bucketName;
+
+	public String getImageUrl(String fileName) {
+		return String.format("%s/%s/%s", endpoint, bucketName, fileName);
+	}
+}

--- a/musical/src/main/java/com/truve/platform/musical/show/domain/entity/Artist.java
+++ b/musical/src/main/java/com/truve/platform/musical/show/domain/entity/Artist.java
@@ -18,5 +18,5 @@ public class Artist extends BaseEntity {
 	private String name;
 
 	@Column(length = 500)
-	private String profileImageUrl;
+	private String profileImg;
 }

--- a/musical/src/main/java/com/truve/platform/musical/show/domain/entity/Show.java
+++ b/musical/src/main/java/com/truve/platform/musical/show/domain/entity/Show.java
@@ -33,10 +33,10 @@ public class Show extends BaseEntity {
 	private Integer ageLimit;
 
 	@Column(nullable = false, length = 500)
-	private String posterUrl;
+	private String posterImg;
 
 	@Column(length = 500)
-	private String noticeUrl;
+	private String noticeImg;
 
 	@Column(name = "start_time")
 	private LocalDateTime startTime;
@@ -51,8 +51,8 @@ public class Show extends BaseEntity {
 		String description,
 		Integer runtimeMin,
 		Integer ageLimit,
-		String posterUrl,
-		String noticeUrl,
+		String posterImg,
+		String noticeImg,
 		LocalDateTime startTime,
 		LocalDateTime endTime
 	) {
@@ -61,8 +61,8 @@ public class Show extends BaseEntity {
 		this.description = description;
 		this.runtimeMin = runtimeMin;
 		this.ageLimit = ageLimit;
-		this.posterUrl = posterUrl;
-		this.noticeUrl = noticeUrl;
+		this.posterImg = posterImg;
+		this.noticeImg = noticeImg;
 		this.startTime = startTime;
 		this.endTime = endTime;
 	}

--- a/musical/src/main/java/com/truve/platform/musical/show/service/ShowService.java
+++ b/musical/src/main/java/com/truve/platform/musical/show/service/ShowService.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.truve.platform.musical.s3.S3Service;
 import com.truve.platform.musical.seat.domain.entity.Venue;
 import com.truve.platform.musical.seat.domain.repository.VenueRepository;
 import com.truve.platform.musical.show.domain.entity.Show;
@@ -28,6 +29,7 @@ public class ShowService {
 	private final VenueRepository venueRepository;
 	private final ShowScheduleRepository showScheduleRepository;
 	private final ShowSeatGradeRepository showSeatGradeRepository;
+	private final S3Service s3Service;
 
 	@Transactional(readOnly = true)
 	public ShowResponse.Detail getDetail(Long showId) {
@@ -53,8 +55,8 @@ public class ShowService {
 			.description(show.getDescription())
 			.runtimeMin(show.getRuntimeMin())
 			.ageLimit(show.getAgeLimit())
-			.posterUrl(show.getPosterUrl())
-			.noticeUrl(show.getNoticeUrl())
+			.posterUrl(s3Service.getImageUrl(show.getPosterImg()))
+			.noticeUrl(s3Service.getImageUrl(show.getNoticeImg()))
 			.startTime(show.getStartTime())
 			.endTime(show.getEndTime())
 			.venue(toVenueResponse(show))
@@ -86,7 +88,7 @@ public class ShowService {
 			.showCastId(casting.getId())
 			.artistId(casting.getArtist().getId())
 			.artistName(casting.getArtist().getName())
-			.profileImageUrl(casting.getArtist().getProfileImageUrl())
+			.profileImageUrl(s3Service.getImageUrl(casting.getArtist().getProfileImg()))
 			.roleName(casting.getRoleName())
 			.order(casting.getCastingOrder())
 			// TODO: artist_likes 연동 후 로그인 사용자 기준 값으로 교체

--- a/musical/src/main/resources/application.yml
+++ b/musical/src/main/resources/application.yml
@@ -3,3 +3,16 @@ spring:
     name: musical
   profiles:
     active: ${SPRING_PROFILES_ACTIVE:local}
+
+  cloud:
+    aws:
+      s3:
+        bucket: ${AWS_S3_BUCKET:truve-media}
+        endpoint: ${AWS_S3_ENDPOINT:http://localstack:4566}
+      region:
+        static: ${AWS_REGION:us-east-1}
+      credentials:
+        access-key: ${AWS_ACCESS_KEY:test}
+        secret-key: ${AWS_SECRET_KEY:test}
+      stack:
+        auto: false

--- a/musical/src/test/java/com/truve/platform/show/service/service/ShowServiceTest.java
+++ b/musical/src/test/java/com/truve/platform/show/service/service/ShowServiceTest.java
@@ -1,9 +1,7 @@
 package com.truve.platform.show.service.service;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.mockito.Mockito.when;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -16,6 +14,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import com.truve.platform.musical.s3.S3Service;
 import com.truve.platform.musical.seat.domain.entity.Venue;
 import com.truve.platform.musical.seat.domain.repository.VenueRepository;
 import com.truve.platform.musical.show.domain.constant.ShowScheduleStatus;
@@ -44,6 +43,8 @@ class ShowServiceTest {
 	private ShowScheduleRepository showScheduleRepository;
 	@Mock
 	private ShowSeatGradeRepository showSeatGradeRepository;
+	@Mock
+	private S3Service s3Service;
 
 	@InjectMocks
 	private ShowService showService;
@@ -60,8 +61,10 @@ class ShowServiceTest {
 		when(show.getDescription()).thenReturn("설명");
 		when(show.getRuntimeMin()).thenReturn(120);
 		when(show.getAgeLimit()).thenReturn(8);
-		when(show.getPosterUrl()).thenReturn("https://img/poster.jpg");
-		when(show.getNoticeUrl()).thenReturn(null);
+		when(show.getPosterImg()).thenReturn("poster.jpg");
+		when(show.getNoticeImg()).thenReturn("notice.jpg");
+		when(s3Service.getImageUrl("poster.jpg")).thenReturn("https://img/poster.jpg");
+		when(s3Service.getImageUrl("notice.jpg")).thenReturn(null);
 		when(show.getStartTime()).thenReturn(LocalDateTime.of(2026, 3, 1, 0, 0));
 		when(show.getEndTime()).thenReturn(LocalDateTime.of(2026, 4, 1, 0, 0));
 		when(show.getVenueId()).thenReturn(10L);
@@ -82,13 +85,16 @@ class ShowServiceTest {
 		Artist artistC = org.mockito.Mockito.mock(Artist.class);
 		when(artistA.getId()).thenReturn(101L);
 		when(artistA.getName()).thenReturn("배우A");
-		when(artistA.getProfileImageUrl()).thenReturn("https://img.example/artistA.jpg");
+		when(artistA.getProfileImg()).thenReturn("artistA.jpg");
+		when(s3Service.getImageUrl("artistA.jpg")).thenReturn("https://img.example/artistA.jpg");
 		when(artistB.getId()).thenReturn(102L);
 		when(artistB.getName()).thenReturn("배우B");
-		when(artistB.getProfileImageUrl()).thenReturn("https://img.example/artistB.jpg");
+		when(artistB.getProfileImg()).thenReturn("artistB.jpg");
+		when(s3Service.getImageUrl("artistB.jpg")).thenReturn("https://img.example/artistB.jpg");
 		when(artistC.getId()).thenReturn(103L);
 		when(artistC.getName()).thenReturn("배우C");
-		when(artistC.getProfileImageUrl()).thenReturn("https://img.example/artistC.jpg");
+		when(artistC.getProfileImg()).thenReturn("artistC.jpg");
+		when(s3Service.getImageUrl("artistC.jpg")).thenReturn("https://img.example/artistC.jpg");
 
 		ShowCasting castOrder1 = org.mockito.Mockito.mock(ShowCasting.class);
 		ShowCasting castOrder2 = org.mockito.Mockito.mock(ShowCasting.class);


### PR DESCRIPTION
## 변경 사항

---
### Docker-Compose LocalStack 세팅 및 MusIcal 서버 환경변수 추가

`LocalStack`: AWS 클라우드 환경을 로컬에서 에뮬레이션할 수 있게 해주는 프레임워크 -> 로컬/개발 환경에서 S3을 대체한다고 생각하시면 됩니다! 

- LocalStack 세팅했고, 버킷 생성 및 테스트를 위한 test_1.png ~ test_5.png 생성하는 스크립트 추가했습니다. 
- Musical 서버에 S3 관련 환경변수 추가했습니다. 

### Musical 서버 application.yml 및 build.gradle 세팅

- S3/LocalStack 연동을 위한 정보 및 라이브러리 작성했습니다.

### S3Service 이미지 URL 생성 기능 추가

- 파일명을 파라미터로 받아 이미지 URL을 생성하는 기능을 추가했습니다.

### Show 변경사항

[기존] 이미지 URL 전부를 저장 
[변경] 이미지 파일 이름만 저장

- Domain 이미지 필드명을 *ImageUrl -> *Img로 변경했습니다.
- ShowService에서 DTO 생성시 S3Service.getImageUrl 메서드를 통해 조립된 전체 URL을 넘기도록 변경했습니다.
@seungh22 이 변경사항 관련해서 의견이나 궁금하신 부분 있으면 편히 말씀주세요!

- [x] 전체 테스트 코드 성공 여부

## 관련 이슈

---
- Notion Ticket: # 48

## 참고사항 (선택)

---

요즘 제 작업 시간을 보면 예상 가능하시겠지만 밤낮이 뒤집어 졌습니다 🥹🥹🥹
오늘 진짜 죽을 거 같아서 점심 시간에 몰래 조퇴를 햇습니다........
주말동안 다시 정상 패턴 찾아오겠습니다....................... 다들 즐건 주말 보내세요!!
