### PR TITLE
fix(musical): API-Gateway 라우팅 및 S3Service 경로 수정

### DIFF
--- a/api-gateway/src/main/resources/application.yml
+++ b/api-gateway/src/main/resources/application.yml
@@ -62,6 +62,10 @@ spring:
               uri: ${TICKETING_SERVER_URI:http://localhost:8084}
               predicates:
                 - Path=/api/ticketing/**
+            - id: show
+              uri: ${MUSICAL_SERVER_URI:http://localhost:8085}
+              predicates:
+                - Path=/api/shows/**
 
 
 
@@ -84,5 +88,5 @@ springdoc:
       - name: "04-Ticketing Service"
         url: /api/ticketing/v3/api-docs
       - name: "05-Musical Service"
-        url: /api/musical/v3/api-docs
+        url: /api/shows/v3/api-docs
 

--- a/api-gateway/src/main/resources/application.yml
+++ b/api-gateway/src/main/resources/application.yml
@@ -84,5 +84,5 @@ springdoc:
       - name: "04-Ticketing Service"
         url: /api/ticketing/v3/api-docs
       - name: "05-Musical Service"
-        url: /api/shows/v3/api-docs
+        url: /api/musical/v3/api-docs
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -68,6 +68,7 @@ services:
       - USER_REDIS_HOST=user-redis
       - USER_REDIS_PORT=6379
       - TICKETING_SERVER_URI=http://ticketing:8084
+      - MUSICAL_SERVER_URI=http://musical:8085
     networks:
       - truve-network
 

--- a/musical/build.gradle
+++ b/musical/build.gradle
@@ -16,5 +16,5 @@ dependencies {
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui'
 
     // [AWS S3]
-    implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3:3.4.0'
+    implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3:4.0.0'
 }

--- a/musical/src/main/java/com/truve/platform/musical/s3/S3Service.java
+++ b/musical/src/main/java/com/truve/platform/musical/s3/S3Service.java
@@ -8,9 +8,9 @@ import lombok.RequiredArgsConstructor;
 @Service
 @RequiredArgsConstructor
 public class S3Service {
-	@Value("${s3.endpoint}")
+	@Value("${spring.cloud.aws.s3.endpoint}")
 	private String endpoint;
-	@Value("${s3.bucket}")
+	@Value("${spring.cloud.aws.s3.bucket}")
 	private String bucketName;
 
 	public String getImageUrl(String fileName) {

--- a/musical/src/main/resources/application.yml
+++ b/musical/src/main/resources/application.yml
@@ -26,3 +26,7 @@ spring:
         secret-key: ${AWS_SECRET_KEY:test}
       stack:
         auto: false
+
+springdoc:
+  api-docs:
+    path: /api/musical/v3/api-docs

--- a/musical/src/main/resources/application.yml
+++ b/musical/src/main/resources/application.yml
@@ -29,4 +29,4 @@ spring:
 
 springdoc:
   api-docs:
-    path: /api/musical/v3/api-docs
+    path: /api/shows/v3/api-docs


### PR DESCRIPTION
## 변경 사항

---
### S3Service 경로 수정 

yml에 지정되어 있는 S3 관련 환경변수의 경로가 잘못되어 Docker 환경에서 실행이 안 되는 이슈가 있었습니다.
정상적인 경로로 변경 처리했습니다.

### spring cloud starter s3 라이브러리 버전업

Spring Boot 4.x.x와 호환성이 좋지 않은 것 같아서 3.4.0 -> 4.0.0 버전업했습니다.

### API-Gateway 연동

API-Gateway에 Musical 서버 라우팅 관련 설정이 안 되어 있는 것을 발견해서 겸사겸사 연동했습니다.
현재 Musical 서버 내에 도메인이 show밖에 없는 관계로 show 경로로 하드코딩해서 추후 도메인 추가되면 그룹 설정 필요합니다..

- [x] 전체 테스트 코드 성공 여부

## 관련 이슈

---
- Notion Ticket: #

## 참고사항 (선택)

---