### PR TITLE
fix(infra): Docker Compose 내 Kafka 연결 및 네트워크 이슈 해결

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -10,7 +10,7 @@ jobs:
 
     strategy:
       matrix:
-        service: [ api-gateway, auth-server, payment, queue, ticketing, musical ]
+        service: [ api-gateway, auth-server, kafka, payment, queue, ticketing, musical ]
 
     steps:
       - name: Checkout code

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,6 +50,8 @@ services:
       KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
       CLUSTER_ID: 'ciWo7IWazngRchmPES6q5A=='
       KAFKA_LOG_DIRS: '/tmp/kraft-combined-logs'
+    networks:
+      - truve-network
 
   # 4. API Gateway
   api-gateway:
@@ -98,10 +100,13 @@ services:
       - NAVER_CLIENT_SECRET=${NAVER_CLIENT_SECRET}
       - NAVER_REDIRECT_URI=${NAVER_REDIRECT_URI}
       - FRONT_OAUTH_CALLBACK=${FRONT_OAUTH_CALLBACK}
+      - KAFKA_SERVERS=kafka:9092
     depends_on:
       db:
         condition: service_healthy
       user-redis:
+        condition: service_started
+      kafka:
         condition: service_started
     networks:
       - truve-network


### PR DESCRIPTION
## 변경 사항

---
<img width="2746" height="1272" alt="image" src="https://github.com/user-attachments/assets/dfd2462d-8282-44b9-b953-95f1a2cbea5f" />

docker-compose up 했을 때 auth-server와 kafka 연결이 안 돼서? 무한로그 지옥에 갇히는 이슈가 있었습니다

### kafka_servers 환경변수

카프카 사용이 필요한 서비스는 환경변수에 `KAFKA_SERVERS=kafka:9092` 추가, depends_on에 카프카 추가 부탁드립니다!

### kafka 배포 설정

- docker-compose network 설정 추가
- 배포 스크립트 서비스 매트릭스에 kafka 서버 추가

- [ ] 전체 테스트 코드 성공 여부

## 관련 이슈

---
- Notion Ticket: #

## 참고사항 (선택)

---