### PR TITLE
hotfix: CI Service Matrix에서 kafka 제외

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -10,7 +10,7 @@ jobs:
 
     strategy:
       matrix:
-        service: [ api-gateway, auth-server, kafka, payment, queue, ticketing, musical ]
+        service: [ api-gateway, auth-server, payment, queue, ticketing, musical ]
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
## 변경 사항

---
Git Workflow 서비스 매트릭스에서 kafka를 제외했습니다.
build가 필요없는 서비스라 넣으면 안된다고 합니다..
긴급 머지하겠슴돠 ㅠ.ㅠ

- [ ] 전체 테스트 코드 성공 여부

## 관련 이슈

---
- Notion Ticket: #

## 참고사항 (선택)

---