### PR TITLE
feat(common): 페이지네이션 객체 구현

### DIFF
--- a/common/src/main/java/com/truve/platform/common/response/ApiResult.java
+++ b/common/src/main/java/com/truve/platform/common/response/ApiResult.java
@@ -1,6 +1,7 @@
 package com.truve.platform.common.response;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import org.springframework.data.domain.Page;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -20,6 +21,10 @@ public class ApiResult<T> {
 
 	public static <T> ApiResult<T> ok(T data) {
 		return ApiResult.of("ok", "성공", data);
+	}
+
+	public static <T> ApiResult<PageResponse<T>> ok(Page<T> page) {
+		return ApiResult.of("ok", "성공", new PageResponse<>(page));
 	}
 
 	private static <T> ApiResult<T> of(String code, String message, T data) {

--- a/common/src/main/java/com/truve/platform/common/response/PageResponse.java
+++ b/common/src/main/java/com/truve/platform/common/response/PageResponse.java
@@ -22,7 +22,7 @@ public class PageResponse<T> {
 		this.content = pageData.getContent();
 		this.totalCount = pageData.getTotalElements();
 		this.totalPages = pageData.getTotalPages();
-		this.page = pageData.getNumber();
+		this.page = pageData.getNumber() + 1;
 		this.size = pageData.getSize();
 		this.hasNext = pageData.hasNext();
 		this.hasPrevious = pageData.hasPrevious();

--- a/common/src/main/java/com/truve/platform/common/response/PageResponse.java
+++ b/common/src/main/java/com/truve/platform/common/response/PageResponse.java
@@ -1,0 +1,30 @@
+package com.truve.platform.common.response;
+
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class PageResponse<T> {
+	private List<T> content;
+	private long totalCount;
+	private int totalPages;
+	private int page;
+	private int size;
+	private boolean hasNext;
+	private boolean hasPrevious;
+
+	public PageResponse(Page<T> pageData) {
+		this.content = pageData.getContent();
+		this.totalCount = pageData.getTotalElements();
+		this.totalPages = pageData.getTotalPages();
+		this.page = pageData.getNumber();
+		this.size = pageData.getSize();
+		this.hasNext = pageData.hasNext();
+		this.hasPrevious = pageData.hasPrevious();
+	}
+}

--- a/common/src/main/java/com/truve/platform/common/response/Paging.java
+++ b/common/src/main/java/com/truve/platform/common/response/Paging.java
@@ -3,16 +3,22 @@ package com.truve.platform.common.response;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @AllArgsConstructor
+@NoArgsConstructor
 public class Paging {
+	@Min(0)
 	int page;
+	@Min(1)
 	int size;
 
 	public Pageable toPageable() {
-		return PageRequest.of(page, size);
+		return PageRequest.of(page - 1, size);
 	}
 }

--- a/common/src/main/java/com/truve/platform/common/response/Paging.java
+++ b/common/src/main/java/com/truve/platform/common/response/Paging.java
@@ -13,7 +13,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 public class Paging {
-	@Min(0)
+	@Min(1)
 	int page;
 	@Min(1)
 	int size;

--- a/common/src/main/java/com/truve/platform/common/response/Paging.java
+++ b/common/src/main/java/com/truve/platform/common/response/Paging.java
@@ -1,0 +1,18 @@
+package com.truve.platform.common.response;
+
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class Paging {
+	int page;
+	int size;
+
+	public Pageable toPageable() {
+		return PageRequest.of(page, size);
+	}
+}


### PR DESCRIPTION
## 변경 사항

- [x] 전체 테스트 코드 성공 여부

페이지네이션 간 필요한 부분들 저희 과정 간 작업했던 파일들 간단히 수정해서 올립니다.

### Paging
클라이언트에서 페이지네이션 관련 정보 받을 때 사용합니다.

### PageResponse
클라이언트에게 페이지네이션 관련 정보 내려줄 때 사용합니다.

<br/>
다음과 같이 사용하길 기대합니다.
사용 시 1-based, 0-based 프론트와 매칭 필요합니다! <br/>
프론트는 보통 1-based, JPA는 0-based로 진행하여 해당 갭 맞춰놨습니다.

```
@GetMapping
public ApiResult<PageResponse<RESPONSEDTO>> getUsers(Paging paging) {
    Paging<> page = userService.getUsers(paiging);
    return ApiResult.ok(page);
}
```

## 관련 이슈

- Notion Ticket: [#62](https://www.notion.so/31f9e3e335cc80488c77f9009313afc3?source=copy_link)

## 참고사항 (선택)

