### PR TITLE
feat(musical): 유저 회원가입 시 이벤트 전파

### DIFF
--- a/auth-server/src/main/java/com/truve/platform/auth/service/event/UserSignedUpEvent.java
+++ b/auth-server/src/main/java/com/truve/platform/auth/service/event/UserSignedUpEvent.java
@@ -1,0 +1,32 @@
+package com.truve.platform.auth.service.event;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import com.truve.platform.auth.service.domain.entity.User;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class UserSignedUpEvent {
+
+	private static final String EVENT_TYPE = "USER_SIGNED_UP";
+
+	private UUID eventId;
+	private String eventType;
+	private LocalDateTime occurredAt;
+	private Long userId;
+	private String nickname;
+
+	public static UserSignedUpEvent from (User user) {
+		return new UserSignedUpEvent(
+			UUID.randomUUID(),
+			EVENT_TYPE,
+			LocalDateTime.now(),
+			user.getId(),
+			// TODO: 닉네임으로 변경 예정
+			user.getEmail()
+		);
+	}
+}

--- a/auth-server/src/main/java/com/truve/platform/auth/service/event/UserSignedUpEvent.java
+++ b/auth-server/src/main/java/com/truve/platform/auth/service/event/UserSignedUpEvent.java
@@ -7,7 +7,9 @@ import com.truve.platform.auth.service.domain.entity.User;
 
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Getter;
 
+@Getter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class UserSignedUpEvent {
 

--- a/auth-server/src/main/java/com/truve/platform/auth/service/service/AuthService.java
+++ b/auth-server/src/main/java/com/truve/platform/auth/service/service/AuthService.java
@@ -5,6 +5,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.truve.platform.auth.service.event.UserSignedUpEvent;
 import com.truve.platform.common.exception.CustomException;
 import com.truve.platform.common.exception.ErrorCode;
 import com.truve.platform.common.support.Preconditions;
@@ -27,6 +28,7 @@ public class AuthService {
 	private final JwtService jwtService;
 	private final RefreshTokenService refreshTokenService;
 	private final AccessTokenBlacklistService accessTokenBlacklistService;
+	private final UserSignedUpEventPublisher  userSignedUpEventPublisher;
 
 	@Transactional
 	public Pair<String, String> login(String email, String password) {
@@ -105,9 +107,12 @@ public class AuthService {
 		String encodedPassword = passwordEncoder.encode(password);
 
 		User user = User.createLocalUser(email, encodedPassword);
+
 		userRepository.save(user);
 		emailVerificationRepository.deleteVerifiedEmail(email);
 
+		UserSignedUpEvent event = UserSignedUpEvent.from(user);
+		userSignedUpEventPublisher.publish(String.valueOf(user.getId()), event);
 	}
 
 }

--- a/auth-server/src/main/java/com/truve/platform/auth/service/service/UserSignedUpEventPublisher.java
+++ b/auth-server/src/main/java/com/truve/platform/auth/service/service/UserSignedUpEventPublisher.java
@@ -1,0 +1,20 @@
+package com.truve.platform.auth.service.service;
+
+import org.springframework.stereotype.Component;
+
+import com.truve.platform.common.event.EventPublisher;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class UserSignedUpEventPublisher {
+
+	private static final String USER_SIGNED_UP_TOPIC = "user.signedup.event";
+	private final EventPublisher eventPublisher;
+
+	public void publish(String key, Object event) {
+		eventPublisher.publish(USER_SIGNED_UP_TOPIC, key, event);
+	}
+
+}

--- a/auth-server/src/test/java/com/truve/platform/auth/service/service/AuthServiceTest.java
+++ b/auth-server/src/test/java/com/truve/platform/auth/service/service/AuthServiceTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -19,6 +20,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import com.truve.platform.auth.service.domain.entity.User;
+import com.truve.platform.auth.service.event.UserSignedUpEvent;
 import com.truve.platform.auth.service.repository.EmailVerificationRepository;
 import com.truve.platform.auth.service.repository.UserRepository;
 import com.truve.platform.auth.service.security.JwtService;
@@ -43,6 +45,8 @@ class AuthServiceTest {
 	private RefreshTokenService refreshTokenService;
 	@Mock
 	private AccessTokenBlacklistService accessTokenBlacklistService;
+	@Mock
+	private UserSignedUpEventPublisher userSignedUpEventPublisher;
 
 	@InjectMocks
 	private AuthService authService;
@@ -232,17 +236,27 @@ class AuthServiceTest {
 			given(emailVerificationRepository.isVerifiedEmail(email)).willReturn(verifiedAt);
 			given(userRepository.existsByEmail(email)).willReturn(false);
 			given(passwordEncoder.encode(password)).willReturn("encoded");
+			given(userRepository.save(any(User.class))).willAnswer(invocation -> {
+				User savedUser = invocation.getArgument(0);
+				ReflectionTestUtils.setField(savedUser, "id", 1L);
+				return savedUser;
+			});
 
 			// when
 			authService.signUp(email, password);
 
 			// then
-			verify(userRepository).save(argThat(user ->
-				user.getEmail().equals(email)
-					&& user.getPassword().equals("encoded")
-					&& user.getRole() == UserRole.MEMBER
-			));
+			ArgumentCaptor<User> savedUserCaptor = ArgumentCaptor.forClass(User.class);
+			ArgumentCaptor<Object> eventCaptor = ArgumentCaptor.forClass(Object.class);
+
+			verify(userRepository).save(savedUserCaptor.capture());
 			verify(emailVerificationRepository).deleteVerifiedEmail(email);
+			verify(userSignedUpEventPublisher).publish(eq("1"), eventCaptor.capture());
+
+			assertThat(savedUserCaptor.getValue().getEmail()).isEqualTo(email);
+			assertThat(savedUserCaptor.getValue().getPassword()).isEqualTo("encoded");
+			assertThat(savedUserCaptor.getValue().getRole()).isEqualTo(UserRole.MEMBER);
+			assertThat(eventCaptor.getValue()).isInstanceOf(UserSignedUpEvent.class);
 		}
 
 		@Test
@@ -260,6 +274,7 @@ class AuthServiceTest {
 			// then
 			assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.NOT_VERIFIED_EMAIL);
 			verify(userRepository, never()).save(any(User.class));
+			verify(userSignedUpEventPublisher, never()).publish(anyString(), any());
 		}
 
 		@Test
@@ -279,6 +294,7 @@ class AuthServiceTest {
 			assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.ALREADY_EXISTS_EMAIL);
 			verify(userRepository, never()).save(any(User.class));
 			verify(emailVerificationRepository, never()).deleteVerifiedEmail(anyString());
+			verify(userSignedUpEventPublisher, never()).publish(anyString(), any());
 		}
 	}
 }

--- a/common/src/main/java/com/truve/platform/common/config/ObjectMapperConfig.java
+++ b/common/src/main/java/com/truve/platform/common/config/ObjectMapperConfig.java
@@ -1,0 +1,17 @@
+package com.truve.platform.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+
+@Configuration
+public class ObjectMapperConfig {
+	@Bean
+	public ObjectMapper objectMapper() {
+		return JsonMapper.builder()
+			.findAndAddModules()
+			.build();
+	}
+}

--- a/common/src/main/java/com/truve/platform/common/event/EventPublisher.java
+++ b/common/src/main/java/com/truve/platform/common/event/EventPublisher.java
@@ -1,0 +1,5 @@
+package com.truve.platform.common.event;
+
+public interface EventPublisher {
+	void publish(String topic, String key, Object event);
+}

--- a/common/src/main/java/com/truve/platform/common/event/KafkaEventPublisher.java
+++ b/common/src/main/java/com/truve/platform/common/event/KafkaEventPublisher.java
@@ -1,0 +1,31 @@
+package com.truve.platform.common.event;
+
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.truve.platform.common.exception.CustomException;
+import com.truve.platform.common.exception.ErrorCode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class KafkaEventPublisher implements EventPublisher {
+
+	private final KafkaTemplate<String, String> kafkaTemplate;
+	private final ObjectMapper objectMapper;
+
+	@Override
+	public void publish(String topic, String key, Object event) {
+		try {
+			String payload = objectMapper.writeValueAsString(event);
+			kafkaTemplate.send(topic, key, payload);
+		} catch (JsonProcessingException exception) {
+			throw new CustomException(ErrorCode.EVENT_SERIALIZATION_FAILED);
+		} catch (Exception exception) {
+			throw new CustomException(ErrorCode.EVENT_PUBLISH_FAILED);
+		}
+	}
+}

--- a/common/src/main/java/com/truve/platform/common/exception/ErrorCode.java
+++ b/common/src/main/java/com/truve/platform/common/exception/ErrorCode.java
@@ -51,12 +51,12 @@ public enum ErrorCode {
 
 
 	NOT_FOUND_SHOW(HttpStatus.NOT_FOUND, "존재하지 않는 공연입니다.", "M01"),
-    NOT_FOUND_ARTIST(HttpStatus.NOT_FOUND, "존재하지 않는 배우입니다.", "M02"),
-    ALREADY_LIKED_ARTIST(HttpStatus.BAD_REQUEST, "이미 좋아요한 배우입니다.", "M03"),
+	NOT_FOUND_ARTIST(HttpStatus.NOT_FOUND, "존재하지 않는 배우입니다.", "M02"),
+	ALREADY_LIKED_ARTIST(HttpStatus.BAD_REQUEST, "이미 좋아요한 배우입니다.", "M03"),
 
 	EVENT_SERIALIZATION_FAILED(HttpStatus.BAD_REQUEST, "이벤트 직렬화 오류입니다.", "I01"),
 	EVENT_PUBLISH_FAILED(HttpStatus.BAD_REQUEST, "이벤트 발행 실패입니다.", "I02"),
-
+	EVENT_USER_SIGNED_UP_FAILED(HttpStatus.BAD_REQUEST, "유저 회원가입 이벤트 소비 실패입니다.", "I03"),
 	;
 
 

--- a/common/src/main/java/com/truve/platform/common/exception/ErrorCode.java
+++ b/common/src/main/java/com/truve/platform/common/exception/ErrorCode.java
@@ -52,8 +52,13 @@ public enum ErrorCode {
 
 	NOT_FOUND_SHOW(HttpStatus.NOT_FOUND, "존재하지 않는 공연입니다.", "M01"),
     NOT_FOUND_ARTIST(HttpStatus.NOT_FOUND, "존재하지 않는 배우입니다.", "M02"),
-    ALREADY_LIKED_ARTIST(HttpStatus.BAD_REQUEST, "이미 좋아요한 배우입니다.", "M03");
+    ALREADY_LIKED_ARTIST(HttpStatus.BAD_REQUEST, "이미 좋아요한 배우입니다.", "M03"),
+
+	EVENT_SERIALIZATION_FAILED(HttpStatus.BAD_REQUEST, "이벤트 직렬화 오류입니다.", "I01"),
+	EVENT_PUBLISH_FAILED(HttpStatus.BAD_REQUEST, "이벤트 발행 실패입니다.", "I02"),
+
 	;
+
 
 
 	private final HttpStatus status;

--- a/musical/src/main/java/com/truve/platform/musical/user/domain/entity/User.java
+++ b/musical/src/main/java/com/truve/platform/musical/user/domain/entity/User.java
@@ -1,0 +1,30 @@
+package com.truve.platform.musical.user.domain.entity;
+
+import com.truve.platform.common.support.BaseEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "user")
+public class User extends BaseEntity {
+
+	@Column(nullable = false, unique = true)
+	private Long userId;
+
+	@Column(nullable = false)
+	private String nickname;
+
+	@Builder
+	public User(Long userId, String nickname) {
+		this.userId = userId;
+		this.nickname = nickname;
+	}
+}

--- a/musical/src/main/java/com/truve/platform/musical/user/domain/entity/UserViewedShow.java
+++ b/musical/src/main/java/com/truve/platform/musical/user/domain/entity/UserViewedShow.java
@@ -1,0 +1,34 @@
+package com.truve.platform.musical.user.domain.entity;
+
+import com.truve.platform.common.support.BaseEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "user_viewed_show")
+public class UserViewedShow extends BaseEntity {
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_id")
+	private User user;
+
+	@Column(nullable = false)
+	private Long showId;
+
+	@Builder
+	public UserViewedShow(User user, Long showId) {
+		this.user = user;
+		this.showId = showId;
+	}
+}

--- a/musical/src/main/java/com/truve/platform/musical/user/repository/UserRepository.java
+++ b/musical/src/main/java/com/truve/platform/musical/user/repository/UserRepository.java
@@ -5,4 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import com.truve.platform.musical.user.domain.entity.User;
 
 public interface UserRepository extends JpaRepository<User, Long> {
+	boolean existsByUserId(Long userId);
 }

--- a/musical/src/main/java/com/truve/platform/musical/user/repository/UserRepository.java
+++ b/musical/src/main/java/com/truve/platform/musical/user/repository/UserRepository.java
@@ -1,0 +1,8 @@
+package com.truve.platform.musical.user.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.truve.platform.musical.user.domain.entity.User;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+}

--- a/musical/src/main/java/com/truve/platform/musical/user/repository/UserViewedShowRepository.java
+++ b/musical/src/main/java/com/truve/platform/musical/user/repository/UserViewedShowRepository.java
@@ -1,0 +1,8 @@
+package com.truve.platform.musical.user.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.truve.platform.musical.user.domain.entity.UserViewedShow;
+
+public interface UserViewedShowRepository extends JpaRepository<UserViewedShow, Long> {
+}

--- a/musical/src/main/java/com/truve/platform/musical/user/service/UserSignedUpEventConsumer.java
+++ b/musical/src/main/java/com/truve/platform/musical/user/service/UserSignedUpEventConsumer.java
@@ -1,0 +1,55 @@
+package com.truve.platform.musical.user.service;
+
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.truve.platform.common.exception.CustomException;
+import com.truve.platform.common.exception.ErrorCode;
+import com.truve.platform.musical.user.domain.entity.User;
+import com.truve.platform.musical.user.repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class UserSignedUpEventConsumer {
+
+	private static final String TOPIC =  "user.signedup.event";
+	private static final String GROUP_ID = "musical-user-group";
+	private static final String USER_ID = "userId";
+	private static final String NICKNAME = "nickname";
+
+	private final ObjectMapper objectMapper;
+	private final UserRepository userRepository;
+
+	@KafkaListener(
+		topics = TOPIC,
+		groupId = GROUP_ID
+	)
+	@Transactional
+	public void consume(String message) throws Exception {
+		JsonNode root = objectMapper.readTree(message);
+
+		Long userId = root.path(USER_ID).asLong();
+		String nickname = root.path(NICKNAME).asText();
+
+		if (userId == 0L || !StringUtils.hasText(nickname)) {
+			throw new CustomException(ErrorCode.EVENT_USER_SIGNED_UP_FAILED);
+		}
+
+		if (userRepository.existsByUserId(userId)) {
+			return;
+		}
+
+		userRepository.save(
+			User.builder()
+				.userId(userId)
+				.nickname(nickname)
+				.build()
+		);
+	}
+}

--- a/musical/src/test/java/com/truve/platform/musical/user/service/UserSignedUpEventConsumerTest.java
+++ b/musical/src/test/java/com/truve/platform/musical/user/service/UserSignedUpEventConsumerTest.java
@@ -1,0 +1,84 @@
+package com.truve.platform.musical.user.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.truve.platform.common.exception.CustomException;
+import com.truve.platform.common.exception.ErrorCode;
+import com.truve.platform.musical.user.domain.entity.User;
+import com.truve.platform.musical.user.repository.UserRepository;
+
+@ExtendWith(MockitoExtension.class)
+class UserSignedUpEventConsumerTest {
+
+	@Mock
+	private UserRepository userRepository;
+
+	private UserSignedUpEventConsumer userSignedUpEventConsumer;
+
+	@BeforeEach
+	void setUp() {
+		userSignedUpEventConsumer = new UserSignedUpEventConsumer(new ObjectMapper(), userRepository);
+	}
+
+	@Test
+	@DisplayName("정상 회원가입 이벤트를 수신하면 musical service 유저를 생성한다.")
+	void 회원가입_이벤트_수신_성공() throws Exception {
+		String message = """
+			{"userId":1,"nickname":"test@test.com"}
+			""";
+
+		given(userRepository.existsByUserId(1L)).willReturn(false);
+
+		userSignedUpEventConsumer.consume(message);
+
+		ArgumentCaptor<User> savedUserCaptor = ArgumentCaptor.forClass(User.class);
+
+		verify(userRepository).save(savedUserCaptor.capture());
+		assertThat(savedUserCaptor.getValue().getUserId()).isEqualTo(1L);
+		assertThat(savedUserCaptor.getValue().getNickname()).isEqualTo("test@test.com");
+	}
+
+	@Test
+	@DisplayName("이미 생성된 유저면 저장을 건너뛴다.")
+	void 회원가입_이벤트_중복_유저_건너뜀() throws Exception {
+		String message = """
+			{"userId":1,"nickname":"test@test.com"}
+			""";
+
+		given(userRepository.existsByUserId(1L)).willReturn(true);
+
+		userSignedUpEventConsumer.consume(message);
+
+		verify(userRepository, never()).save(any(User.class));
+	}
+
+	@Test
+	@DisplayName("userId 또는 nickname 이 올바르지 않으면 예외가 발생한다.")
+	void 회원가입_이벤트_유효성_실패() {
+		String message = """
+			{"userId":0,"nickname":""}
+			""";
+
+		CustomException exception = assertThrows(
+			CustomException.class,
+			() -> userSignedUpEventConsumer.consume(message)
+		);
+
+		assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.EVENT_USER_SIGNED_UP_FAILED);
+		verify(userRepository, never()).save(any(User.class));
+	}
+}


### PR DESCRIPTION
## 변경 사항

추가/변경 사항과 사유를 작성해 주세요.

- [x] 전체 테스트 코드 성공 여부
- 로컬에서 회원가입 진행 시 musical-service 유저 생성 확인 완료 

### 공통 EventPublisher, KafkaEventPublisher common 모듈에 추가
간단하게 EventPublisher, KafkaEventPublihser 만들었습니다. 도메인별로 선언해서 사용하면 좋을 것 같습니다.
좋은 의견 있으시면 제시해주세요! 같이 개선해나가봅시다

### 회원가입 시 musical-service 유저 생성
1. `auth-server`에서 회원가입 완료 시 이벤트 발행
2. `musical-server`에서 회원가입 이벤트 consume하여 유저 저장

 
## 관련 이슈

- Notion Ticket: [#66](https://www.notion.so/DB-31f9e3e335cc80a6adfed5cf72c39fb5?source=copy_link)

## 참고사항 (선택)

### 실질적 식별자 변경

MySQL `auto increment`로 인해서 기존 `Long`으로 사용하던 DB PK는 유지하더라도 
실제 서비스에서 사용하는 식별자는 `UUID`로 전환을 검토해야할 것 같습니다. 

한 메서드 내에서 객체 생성 -> 이벤트 발행 과정에서 생성 이후 DB 커밋 이전에 이벤트 발행이 된다면 정상 로직 보장이 어렵습니다.
객체 생성 이후 `UUID`를 직접 주입하여 그 값을 실제 서비스 레벨에서 사용하면 어떨 지 검토가 필요할 것 같습니다.

### 에러 핸들링
현재 일괄적으로 저희 기존 에러코드 사용해서 throw하고 있는데, 제대로된 핸들링은 학습 및 정리 필요하다고 판단됩니다.
차후 메시지 유실이나 재처리 등은 `Retry`나 `DLT` 전략 학습 후 보완 필요해보입니다.