### PR TITLE
refactor(user): User 서비스 레이어 식별자 UUID로 변경

### DIFF
--- a/api-gateway/src/main/java/com/truve/platform/apigateway/authentication/JwtAuthenticationFilter.java
+++ b/api-gateway/src/main/java/com/truve/platform/apigateway/authentication/JwtAuthenticationFilter.java
@@ -2,11 +2,11 @@ package com.truve.platform.apigateway.authentication;
 
 import javax.crypto.SecretKey;
 
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cloud.gateway.filter.GatewayFilter;
 import org.springframework.cloud.gateway.filter.factory.AbstractGatewayFilterFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
 
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
@@ -46,11 +46,11 @@ public class JwtAuthenticationFilter extends AbstractGatewayFilterFactory {
 				return exchange.getResponse().setComplete();
 			}
 
-			Long userId = claims.get("user_id", Long.class);
+			String userId = claims.get("user_public_id", String.class);
 			String role = claims.get("role", String.class);
 			String tokenType = claims.get("token_type", String.class);
 
-			if (!"access".equals(tokenType)) {
+			if (!"access".equals(tokenType) || !StringUtils.hasText(tokenType)) {
 				exchange.getResponse().setStatusCode(HttpStatus.UNAUTHORIZED);
 				return exchange.getResponse().setComplete();
 			}
@@ -60,7 +60,7 @@ public class JwtAuthenticationFilter extends AbstractGatewayFilterFactory {
 					.request(
 						exchange.getRequest()
 							.mutate()
-							.header("X-User-Id", userId.toString())
+							.header("X-User-Id", userId)
 							.header("X-User-Role", role)
 							.header("X-Token", token)
 							.build()

--- a/auth-server/src/main/java/com/truve/platform/auth/service/controller/AuthController.java
+++ b/auth-server/src/main/java/com/truve/platform/auth/service/controller/AuthController.java
@@ -115,12 +115,11 @@ public class AuthController {
 	})
 	@DeleteMapping("/logout")
 	public ApiResult<Void> logout(
-		@RequestHeader("X-User-Id") String userId,
 		@RequestHeader("X-Token") String accessToken,
 		HttpServletResponse httpServletResponse
 	) {
 
-		authService.logout(Long.parseLong(userId), accessToken);
+		authService.logout(accessToken);
 
 		authCookieManager.clearRefreshToken(httpServletResponse);
 

--- a/auth-server/src/main/java/com/truve/platform/auth/service/domain/entity/User.java
+++ b/auth-server/src/main/java/com/truve/platform/auth/service/domain/entity/User.java
@@ -1,5 +1,7 @@
 package com.truve.platform.auth.service.domain.entity;
 
+import java.util.UUID;
+
 import com.truve.platform.common.constants.AuthProvider;
 import com.truve.platform.common.constants.UserRole;
 import com.truve.platform.common.support.BaseEntity;
@@ -20,6 +22,9 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "users")
 public class User extends BaseEntity {
+
+	@Column(nullable = false, unique = true, updatable = false)
+	private UUID publicId;
 
 	@Email
 	@Column(nullable = false, unique = true)
@@ -44,8 +49,9 @@ public class User extends BaseEntity {
 
 
 	@Builder
-	private User(String email, String password, AuthProvider provider,
+	private User(UUID publicId, String email, String password, AuthProvider provider,
 		UserRole role,  String oAuthUserId, String oAuthAccessToken, String oAuthRefreshToken) {
+		this.publicId = publicId;
 		this.email = email;
 		this.password = password;
 		this.provider = provider;
@@ -57,6 +63,7 @@ public class User extends BaseEntity {
 
 	public static User createLocalUser(String email, String password) {
 		return User.builder()
+			.publicId(UUID.randomUUID())
 			.email(email)
 			.password(password)
 			.provider(AuthProvider.LOCAL)
@@ -72,6 +79,7 @@ public class User extends BaseEntity {
 		String oAuthRefreshToken
 	) {
 		return User.builder()
+			.publicId(UUID.randomUUID())
 			.email(email)
 			.provider(provider)
 			.role(UserRole.MEMBER)

--- a/auth-server/src/main/java/com/truve/platform/auth/service/event/UserSignedUpEvent.java
+++ b/auth-server/src/main/java/com/truve/platform/auth/service/event/UserSignedUpEvent.java
@@ -18,7 +18,7 @@ public class UserSignedUpEvent {
 	private UUID eventId;
 	private String eventType;
 	private LocalDateTime occurredAt;
-	private Long userId;
+	private UUID userId;
 	private String nickname;
 
 	public static UserSignedUpEvent from (User user) {
@@ -26,7 +26,7 @@ public class UserSignedUpEvent {
 			UUID.randomUUID(),
 			EVENT_TYPE,
 			LocalDateTime.now(),
-			user.getId(),
+			user.getPublicId(),
 			// TODO: 닉네임으로 변경 예정
 			user.getEmail()
 		);

--- a/auth-server/src/main/java/com/truve/platform/auth/service/repository/UserRepository.java
+++ b/auth-server/src/main/java/com/truve/platform/auth/service/repository/UserRepository.java
@@ -1,5 +1,6 @@
 package com.truve.platform.auth.service.repository;
 
+import java.util.UUID;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -11,6 +12,8 @@ import com.truve.platform.auth.service.domain.entity.User;
 public interface UserRepository extends JpaRepository<User, Long> {
 
 	Optional<User> findByEmail(String email);
+
+	Optional<User> findByPublicId(UUID publicId);
 
 	boolean existsByEmail(String email);
 

--- a/auth-server/src/main/java/com/truve/platform/auth/service/security/JwtService.java
+++ b/auth-server/src/main/java/com/truve/platform/auth/service/security/JwtService.java
@@ -15,12 +15,15 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class JwtService {
 
+	private static final String USER_PUBLIC_ID_CLAIM = "user_public_id";
+
 	private final JwtProperties jwtProperties;
 
-	public String issue(Long userId, String email, UserRole role, Date expiration, String tokenType) {
+	public String issue(UUID userPublicId, Long userId, String email, UserRole role, Date expiration, String tokenType) {
 		return Jwts.builder()
 			.issuer("truve-api")
 			.subject(email)
+			.claim(USER_PUBLIC_ID_CLAIM, userPublicId.toString())
 			.claim("user_id", userId)
 			.claim("role", role.name())
 			.claim("token_type", tokenType)
@@ -58,6 +61,17 @@ public class JwtService {
 			.parseSignedClaims(token)
 			.getPayload()
 			.getSubject();
+	}
+
+	public UUID parsePublicId(String token) {
+		String publicId = Jwts.parser()
+			.verifyWith(jwtProperties.getSecret())
+			.build()
+			.parseSignedClaims(token)
+			.getPayload()
+			.get(USER_PUBLIC_ID_CLAIM, String.class);
+
+		return UUID.fromString(publicId);
 	}
 
 	// public Role parseRole(String token) {

--- a/auth-server/src/main/java/com/truve/platform/auth/service/service/AuthService.java
+++ b/auth-server/src/main/java/com/truve/platform/auth/service/service/AuthService.java
@@ -1,5 +1,7 @@
 package com.truve.platform.auth.service.service;
 
+import java.util.UUID;
+
 import org.springframework.data.util.Pair;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -39,50 +41,53 @@ public class AuthService {
 		var accessExp = jwtService.getAccessExpiration();
 		var refreshExp = jwtService.getRefreshExpiration();
 
-		String accessToken = jwtService.issue(user.getId(), user.getEmail(), user.getRole(), accessExp, TokenType.ACCESS_TOKEN.getType());
+		String accessToken = jwtService.issue(
+			user.getPublicId(), user.getId(), user.getEmail(), user.getRole(), accessExp, TokenType.ACCESS_TOKEN.getType()
+		);
 
-		String refreshToken = jwtService.issue(user.getId(), user.getEmail(), user.getRole(), refreshExp,
+		String refreshToken = jwtService.issue(user.getPublicId(), user.getId(), user.getEmail(), user.getRole(), refreshExp,
 			TokenType.REFRESH_TOKEN.getType());
 
 		long refreshTtlMs = refreshExp.getTime() - System.currentTimeMillis();
-		refreshTokenService.save(user.getId(), refreshToken, refreshTtlMs);
+		refreshTokenService.save(user.getPublicId(), refreshToken, refreshTtlMs);
 
 		return Pair.of(accessToken, refreshToken);
 	}
 
 	@Transactional
 	public Pair<String, String> reissue(String refreshToken) {
-		String email;
+		UUID userPublicId;
 
 		try {
-			email = jwtService.parseEmail(refreshToken);
+			userPublicId = jwtService.parsePublicId(refreshToken);
 		} catch (JwtException | IllegalArgumentException e) {
 			throw new CustomException(ErrorCode.INVALID_REFRESH_TOKEN);
 		}
 
-		User user = userRepository.findByEmailOrThrow(email);
+		User user = userRepository.findByPublicId(userPublicId)
+			.orElseThrow(() -> new CustomException(ErrorCode.INVALID_REFRESH_TOKEN));
 		var newAccessExp = jwtService.getAccessExpiration();
 		var newRefreshExp = jwtService.getRefreshExpiration();
 
-		String newAccessToken = jwtService.issue(user.getId(), user.getEmail(), user.getRole(), newAccessExp,
+		String newAccessToken = jwtService.issue(user.getPublicId(), user.getId(), user.getEmail(), user.getRole(), newAccessExp,
 			TokenType.ACCESS_TOKEN.getType());
 
-		String newRefreshToken = jwtService.issue(user.getId(), user.getEmail(), user.getRole(), newRefreshExp,
+		String newRefreshToken = jwtService.issue(user.getPublicId(), user.getId(), user.getEmail(), user.getRole(), newRefreshExp,
 			TokenType.REFRESH_TOKEN.getType());
 
 		long newRefreshTtlMs = newRefreshExp.getTime() - System.currentTimeMillis();
-		refreshTokenService.save(user.getId(), newRefreshToken, newRefreshTtlMs);
+		refreshTokenService.save(user.getPublicId(), newRefreshToken, newRefreshTtlMs);
 
 		return Pair.of(newAccessToken, newRefreshToken);
 	}
 
 	@Transactional
-	public void logout(Long id, String accessToken) {
-		refreshTokenService.delete(id);
-
+	public void logout(String accessToken) {
 		try {
+			UUID userPublicId = jwtService.parsePublicId(accessToken);
 			String jti = jwtService.parseJti(accessToken);
 			var exp = jwtService.parseExpiration(accessToken);
+			refreshTokenService.delete(userPublicId);
 
 			long ttlMs = exp.getTime() - System.currentTimeMillis();
 			if (ttlMs > 0) {

--- a/auth-server/src/main/java/com/truve/platform/auth/service/service/AuthService.java
+++ b/auth-server/src/main/java/com/truve/platform/auth/service/service/AuthService.java
@@ -117,7 +117,7 @@ public class AuthService {
 		emailVerificationRepository.deleteVerifiedEmail(email);
 
 		UserSignedUpEvent event = UserSignedUpEvent.from(user);
-		userSignedUpEventPublisher.publish(String.valueOf(user.getId()), event);
+		userSignedUpEventPublisher.publish(user.getPublicId().toString(), event);
 	}
 
 }

--- a/auth-server/src/main/java/com/truve/platform/auth/service/service/KakaoOAuthService.java
+++ b/auth-server/src/main/java/com/truve/platform/auth/service/service/KakaoOAuthService.java
@@ -59,13 +59,15 @@ public class KakaoOAuthService {
 		var accessExp = jwtService.getAccessExpiration();
 		var refreshExp = jwtService.getRefreshExpiration();
 
-		String accessToken = jwtService.issue(user.getId(), user.getEmail(), user.getRole(), accessExp, TokenType.ACCESS_TOKEN.getType());
+		String accessToken = jwtService.issue(
+			user.getPublicId(), user.getId(), user.getEmail(), user.getRole(), accessExp, TokenType.ACCESS_TOKEN.getType()
+		);
 
-		String refreshToken = jwtService.issue(user.getId(), user.getEmail(), user.getRole(), refreshExp,
+		String refreshToken = jwtService.issue(user.getPublicId(), user.getId(), user.getEmail(), user.getRole(), refreshExp,
 			TokenType.REFRESH_TOKEN.getType());
 
 		long refreshTtlMs = refreshExp.getTime() - System.currentTimeMillis();
-		refreshTokenService.save(user.getId(), refreshToken, refreshTtlMs);
+		refreshTokenService.save(user.getPublicId(), refreshToken, refreshTtlMs);
 
 		return Pair.of(accessToken, refreshToken);
 	}

--- a/auth-server/src/main/java/com/truve/platform/auth/service/service/NaverOAuthService.java
+++ b/auth-server/src/main/java/com/truve/platform/auth/service/service/NaverOAuthService.java
@@ -61,13 +61,15 @@ public class NaverOAuthService {
 		var accessExp = jwtService.getAccessExpiration();
 		var refreshExp = jwtService.getRefreshExpiration();
 
-		String accessToken = jwtService.issue(user.getId(), user.getEmail(), user.getRole(), accessExp, TokenType.ACCESS_TOKEN.getType());
+		String accessToken = jwtService.issue(
+			user.getPublicId(), user.getId(), user.getEmail(), user.getRole(), accessExp, TokenType.ACCESS_TOKEN.getType()
+		);
 
-		String refreshToken = jwtService.issue(user.getId(), user.getEmail(), user.getRole(), refreshExp,
+		String refreshToken = jwtService.issue(user.getPublicId(), user.getId(), user.getEmail(), user.getRole(), refreshExp,
 			TokenType.REFRESH_TOKEN.getType());
 
 		long refreshTtlMs = refreshExp.getTime() - System.currentTimeMillis();
-		refreshTokenService.save(user.getId(), refreshToken, refreshTtlMs);
+		refreshTokenService.save(user.getPublicId(), refreshToken, refreshTtlMs);
 
 		return Pair.of(accessToken, refreshToken);
 	}

--- a/auth-server/src/main/java/com/truve/platform/auth/service/service/RefreshTokenService.java
+++ b/auth-server/src/main/java/com/truve/platform/auth/service/service/RefreshTokenService.java
@@ -1,6 +1,7 @@
 package com.truve.platform.auth.service.service;
 
 import java.time.Duration;
+import java.util.UUID;
 
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
@@ -14,21 +15,21 @@ public class RefreshTokenService {
 	private final StringRedisTemplate redisTemplate;
 	private static final String PREFIX = "RT:";
 
-	private String key(Long userId) {
-		return PREFIX + userId.toString();
+	private String key(UUID userPublicId) {
+		return PREFIX + userPublicId;
 	}
 
-	public void save(Long userId, String refreshToken, long expireMs) {
+	public void save(UUID userPublicId, String refreshToken, long expireMs) {
 		redisTemplate.opsForValue()
-			.set(key(userId), refreshToken, Duration.ofMillis(expireMs));
+			.set(key(userPublicId), refreshToken, Duration.ofMillis(expireMs));
 	}
 
-	public boolean isSame(Long userId, String refreshToken) {
-		String stored = redisTemplate.opsForValue().get(key(userId));
+	public boolean isSame(UUID userPublicId, String refreshToken) {
+		String stored = redisTemplate.opsForValue().get(key(userPublicId));
 		return refreshToken.equals(stored);
 	}
 
-	public void delete(Long userId) {
-		redisTemplate.delete(key(userId));
+	public void delete(UUID userPublicId) {
+		redisTemplate.delete(key(userPublicId));
 	}
 }

--- a/auth-server/src/test/java/com/truve/platform/auth/service/controller/AuthControllerTest.java
+++ b/auth-server/src/test/java/com/truve/platform/auth/service/controller/AuthControllerTest.java
@@ -130,13 +130,12 @@ class AuthControllerTest {
 	void 로그아웃_성공() throws Exception {
 		// when
 		ResultActions resultActions = mockMvc.perform(delete("/api/auth/logout")
-			.header("X-User-Id", "1")
 			.header("X-Token", "access-token"));
 
 		// then
 		resultActions.andExpect(status().isOk())
 			.andExpect(jsonPath("$.code").value("ok"));
-		verify(authService).logout(1L, "access-token");
+		verify(authService).logout("access-token");
 		verify(authCookieManager).clearRefreshToken(any(HttpServletResponse.class));
 	}
 }

--- a/auth-server/src/test/java/com/truve/platform/auth/service/controller/AuthControllerTest.java
+++ b/auth-server/src/test/java/com/truve/platform/auth/service/controller/AuthControllerTest.java
@@ -23,7 +23,7 @@ import com.truve.platform.common.exception.CustomException;
 import com.truve.platform.common.exception.ErrorCode;
 
 import jakarta.servlet.http.HttpServletResponse;
-import tools.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 @WebMvcTest(controllers = AuthController.class)
 @Import(SecurityConfig.class)
@@ -80,7 +80,8 @@ class AuthControllerTest {
 
 		// then
 		resultActions.andExpect(status().isBadRequest())
-			.andExpect(jsonPath("$.code").value("CLIENT_ERROR"));
+			.andExpect(jsonPath("$.errorType").value("CLIENT_ERROR"))
+			.andExpect(jsonPath("$.code").value(ErrorCode.ALREADY_EXISTS_EMAIL.getCode()));
 	}
 
 	@Test

--- a/auth-server/src/test/java/com/truve/platform/auth/service/controller/EmailControllerTest.java
+++ b/auth-server/src/test/java/com/truve/platform/auth/service/controller/EmailControllerTest.java
@@ -20,7 +20,6 @@ import com.truve.platform.auth.service.service.EmailService;
 import com.truve.platform.common.exception.CustomException;
 import com.truve.platform.common.exception.ErrorCode;
 
-import tools.jackson.databind.ObjectMapper;
 
 @WebMvcTest(controllers = EmailController.class)
 @Import(SecurityConfig.class)
@@ -73,7 +72,8 @@ class EmailControllerTest {
 
 		// then
 		resultActions.andExpect(status().isBadRequest())
-			.andExpect(jsonPath("$.code").value("CLIENT_ERROR"));
+			.andExpect(jsonPath("$.errorType").value("CLIENT_ERROR"))
+			.andExpect(jsonPath("$.code").value(ErrorCode.ALREADY_EXISTS_EMAIL.getCode()));
 	}
 
 	@Test
@@ -119,6 +119,7 @@ class EmailControllerTest {
 
 		// then
 		resultActions.andExpect(status().isBadRequest())
-			.andExpect(jsonPath("$.code").value("CLIENT_ERROR"));
+			.andExpect(jsonPath("$.errorType").value("CLIENT_ERROR"))
+			.andExpect(jsonPath("$.code").value(ErrorCode.NOT_CORRECT_EMAIL_CODE.getCode()));
 	}
 }

--- a/auth-server/src/test/java/com/truve/platform/auth/service/domain/entity/UserTest.java
+++ b/auth-server/src/test/java/com/truve/platform/auth/service/domain/entity/UserTest.java
@@ -3,6 +3,8 @@ package com.truve.platform.auth.service.domain.entity;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
+import java.util.UUID;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -30,6 +32,7 @@ class UserTest {
 
 			// then
 			assertAll(
+				() -> assertThat(user.getPublicId()).isInstanceOf(UUID.class),
 				() -> assertThat(user.getEmail()).isEqualTo(EMAIL),
 				() -> assertThat(user.getPassword()).isEqualTo(PASSWORD),
 				() -> assertThat(user.getProvider()).isEqualTo(AuthProvider.LOCAL),
@@ -59,6 +62,7 @@ class UserTest {
 
 			// then
 			assertAll(
+				() -> assertThat(user.getPublicId()).isInstanceOf(UUID.class),
 				() -> assertThat(user.getEmail()).isEqualTo(EMAIL),
 				() -> assertThat(user.getPassword()).isNull(),
 				() -> assertThat(user.getProvider()).isEqualTo(AuthProvider.KAKAO),

--- a/auth-server/src/test/java/com/truve/platform/auth/service/service/AuthServiceTest.java
+++ b/auth-server/src/test/java/com/truve/platform/auth/service/service/AuthServiceTest.java
@@ -120,6 +120,8 @@ class AuthServiceTest {
 		void 재발급_성공() {
 			// given
 			String refreshToken = "refresh-token";
+			String email = "user@test.com";
+
 			User user = createUser(1L, email, "encoded");
 			Date newAccessExp = new Date(System.currentTimeMillis() + 60_000L);
 			Date newRefreshExp = new Date(System.currentTimeMillis() + 120_000L);
@@ -249,15 +251,17 @@ class AuthServiceTest {
 			// then
 			ArgumentCaptor<User> savedUserCaptor = ArgumentCaptor.forClass(User.class);
 			ArgumentCaptor<Object> eventCaptor = ArgumentCaptor.forClass(Object.class);
+			ArgumentCaptor<String> keyCaptor = ArgumentCaptor.forClass(String.class);
 
 			verify(userRepository).save(savedUserCaptor.capture());
 			verify(emailVerificationRepository).deleteVerifiedEmail(email);
-			verify(userSignedUpEventPublisher).publish(eq("1"), eventCaptor.capture());
+			verify(userSignedUpEventPublisher).publish(keyCaptor.capture(), eventCaptor.capture());
 
 			assertThat(savedUserCaptor.getValue().getEmail()).isEqualTo(email);
 			assertThat(savedUserCaptor.getValue().getPassword()).isEqualTo("encoded");
 			assertThat(savedUserCaptor.getValue().getRole()).isEqualTo(UserRole.MEMBER);
 			assertThat(savedUserCaptor.getValue().getPublicId()).isInstanceOf(UUID.class);
+			assertThat(keyCaptor.getValue()).isEqualTo(savedUserCaptor.getValue().getPublicId().toString());
 			assertThat(eventCaptor.getValue()).isInstanceOf(UserSignedUpEvent.class);
 		}
 

--- a/auth-server/src/test/java/com/truve/platform/auth/service/service/AuthServiceTest.java
+++ b/auth-server/src/test/java/com/truve/platform/auth/service/service/AuthServiceTest.java
@@ -6,6 +6,7 @@ import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.*;
 
 import java.util.Date;
+import java.util.UUID;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -256,6 +257,7 @@ class AuthServiceTest {
 			assertThat(savedUserCaptor.getValue().getEmail()).isEqualTo(email);
 			assertThat(savedUserCaptor.getValue().getPassword()).isEqualTo("encoded");
 			assertThat(savedUserCaptor.getValue().getRole()).isEqualTo(UserRole.MEMBER);
+			assertThat(savedUserCaptor.getValue().getPublicId()).isInstanceOf(UUID.class);
 			assertThat(eventCaptor.getValue()).isInstanceOf(UserSignedUpEvent.class);
 		}
 

--- a/auth-server/src/test/java/com/truve/platform/auth/service/service/AuthServiceTest.java
+++ b/auth-server/src/test/java/com/truve/platform/auth/service/service/AuthServiceTest.java
@@ -76,9 +76,9 @@ class AuthServiceTest {
 			given(passwordEncoder.matches(password, user.getPassword())).willReturn(true);
 			given(jwtService.getAccessExpiration()).willReturn(accessExp);
 			given(jwtService.getRefreshExpiration()).willReturn(refreshExp);
-			given(jwtService.issue(eq(user.getId()), eq(user.getEmail()), eq(UserRole.MEMBER), eq(accessExp), eq("access")))
+			given(jwtService.issue(eq(user.getPublicId()), eq(user.getId()), eq(user.getEmail()), eq(UserRole.MEMBER), eq(accessExp), eq("access")))
 				.willReturn("access-token");
-			given(jwtService.issue(eq(user.getId()), eq(user.getEmail()), eq(UserRole.MEMBER), eq(refreshExp), eq("refresh")))
+			given(jwtService.issue(eq(user.getPublicId()), eq(user.getId()), eq(user.getEmail()), eq(UserRole.MEMBER), eq(refreshExp), eq("refresh")))
 				.willReturn("refresh-token");
 
 			// when
@@ -87,7 +87,7 @@ class AuthServiceTest {
 			// then
 			assertThat(result.getFirst()).isEqualTo("access-token");
 			assertThat(result.getSecond()).isEqualTo("refresh-token");
-			verify(refreshTokenService).save(eq(user.getId()), eq("refresh-token"), anyLong());
+			verify(refreshTokenService).save(eq(user.getPublicId()), eq("refresh-token"), anyLong());
 		}
 
 		@Test
@@ -106,8 +106,8 @@ class AuthServiceTest {
 
 			// then
 			assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.NOT_CORRECT_PASSWORD);
-			verify(jwtService, never()).issue(anyLong(), anyString(), any(), any(), anyString());
-			verify(refreshTokenService, never()).save(anyLong(), anyString(), anyLong());
+			verify(jwtService, never()).issue(any(), anyLong(), anyString(), any(), any(), anyString());
+			verify(refreshTokenService, never()).save(any(), anyString(), anyLong());
 		}
 	}
 
@@ -120,18 +120,17 @@ class AuthServiceTest {
 		void 재발급_성공() {
 			// given
 			String refreshToken = "refresh-token";
-			String email = "user@test.com";
 			User user = createUser(1L, email, "encoded");
 			Date newAccessExp = new Date(System.currentTimeMillis() + 60_000L);
 			Date newRefreshExp = new Date(System.currentTimeMillis() + 120_000L);
 
-			given(jwtService.parseEmail(refreshToken)).willReturn(email);
-			given(userRepository.findByEmailOrThrow(email)).willReturn(user);
+			given(jwtService.parsePublicId(refreshToken)).willReturn(user.getPublicId());
+			given(userRepository.findByPublicId(user.getPublicId())).willReturn(java.util.Optional.of(user));
 			given(jwtService.getAccessExpiration()).willReturn(newAccessExp);
 			given(jwtService.getRefreshExpiration()).willReturn(newRefreshExp);
-			given(jwtService.issue(eq(user.getId()), eq(user.getEmail()), eq(UserRole.MEMBER), eq(newAccessExp), eq("access")))
+			given(jwtService.issue(eq(user.getPublicId()), eq(user.getId()), eq(user.getEmail()), eq(UserRole.MEMBER), eq(newAccessExp), eq("access")))
 				.willReturn("new-access-token");
-			given(jwtService.issue(eq(user.getId()), eq(user.getEmail()), eq(UserRole.MEMBER), eq(newRefreshExp), eq("refresh")))
+			given(jwtService.issue(eq(user.getPublicId()), eq(user.getId()), eq(user.getEmail()), eq(UserRole.MEMBER), eq(newRefreshExp), eq("refresh")))
 				.willReturn("new-refresh-token");
 
 			// when
@@ -140,7 +139,7 @@ class AuthServiceTest {
 			// then
 			assertThat(result.getFirst()).isEqualTo("new-access-token");
 			assertThat(result.getSecond()).isEqualTo("new-refresh-token");
-			verify(refreshTokenService).save(eq(user.getId()), eq("new-refresh-token"), anyLong());
+			verify(refreshTokenService).save(eq(user.getPublicId()), eq("new-refresh-token"), anyLong());
 		}
 
 		@Test
@@ -148,14 +147,14 @@ class AuthServiceTest {
 		void 재발급_실패_유효하지_않은_토큰() {
 			// given
 			String refreshToken = "invalid-refresh-token";
-			given(jwtService.parseEmail(refreshToken)).willThrow(new JwtException("invalid"));
+			given(jwtService.parsePublicId(refreshToken)).willThrow(new JwtException("invalid"));
 
 			// when
 			CustomException exception = assertThrows(CustomException.class, () -> authService.reissue(refreshToken));
 
 			// then
 			assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.INVALID_REFRESH_TOKEN);
-			verify(userRepository, never()).findByEmailOrThrow(anyString());
+			verify(userRepository, never()).findByPublicId(any());
 		}
 	}
 
@@ -167,19 +166,20 @@ class AuthServiceTest {
 		@DisplayName("액세스 토큰이 유효하고 만료 전이면 블랙리스트에 등록한다.")
 		void 로그아웃_성공() {
 			// given
-			Long userId = 1L;
 			String accessToken = "access-token";
 			String jti = "jti-123";
 			Date exp = new Date(System.currentTimeMillis() + 60_000L);
+			UUID userPublicId = UUID.randomUUID();
 
+			given(jwtService.parsePublicId(accessToken)).willReturn(userPublicId);
 			given(jwtService.parseJti(accessToken)).willReturn(jti);
 			given(jwtService.parseExpiration(accessToken)).willReturn(exp);
 
 			// when
-			authService.logout(userId, accessToken);
+			authService.logout(accessToken);
 
 			// then
-			verify(refreshTokenService).delete(userId);
+			verify(refreshTokenService).delete(userPublicId);
 			verify(accessTokenBlacklistService).save(eq(jti), anyLong());
 		}
 
@@ -187,19 +187,20 @@ class AuthServiceTest {
 		@DisplayName("액세스 토큰이 이미 만료됐으면 블랙리스트 저장은 생략한다.")
 		void 로그아웃_성공_만료된_토큰() {
 			// given
-			Long userId = 1L;
 			String accessToken = "expired-access-token";
 			String jti = "jti-123";
 			Date expired = new Date(System.currentTimeMillis() - 1_000L);
+			UUID userPublicId = UUID.randomUUID();
 
+			given(jwtService.parsePublicId(accessToken)).willReturn(userPublicId);
 			given(jwtService.parseJti(accessToken)).willReturn(jti);
 			given(jwtService.parseExpiration(accessToken)).willReturn(expired);
 
 			// when
-			authService.logout(userId, accessToken);
+			authService.logout(accessToken);
 
 			// then
-			verify(refreshTokenService).delete(userId);
+			verify(refreshTokenService).delete(userPublicId);
 			verify(accessTokenBlacklistService, never()).save(anyString(), anyLong());
 		}
 
@@ -207,17 +208,16 @@ class AuthServiceTest {
 		@DisplayName("액세스 토큰 파싱에 실패하면 예외가 발생한다.")
 		void 로그아웃_실패_유효하지_않은_토큰() {
 			// given
-			Long userId = 1L;
 			String accessToken = "invalid-access-token";
 
-			given(jwtService.parseJti(accessToken)).willThrow(new JwtException("invalid"));
+			given(jwtService.parsePublicId(accessToken)).willThrow(new JwtException("invalid"));
 
 			// when
-			CustomException exception = assertThrows(CustomException.class, () -> authService.logout(userId, accessToken));
+			CustomException exception = assertThrows(CustomException.class, () -> authService.logout(accessToken));
 
 			// then
 			assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.INVALID_REFRESH_TOKEN);
-			verify(refreshTokenService).delete(userId);
+			verify(refreshTokenService, never()).delete(any());
 			verify(accessTokenBlacklistService, never()).save(anyString(), anyLong());
 		}
 	}

--- a/auth-server/src/test/java/com/truve/platform/auth/service/service/EmailServiceTest.java
+++ b/auth-server/src/test/java/com/truve/platform/auth/service/service/EmailServiceTest.java
@@ -17,6 +17,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import com.truve.platform.auth.service.event.EmailEventService;
 import com.truve.platform.auth.service.repository.EmailVerificationRepository;
 import com.truve.platform.auth.service.repository.UserRepository;
 import com.truve.platform.common.exception.CustomException;
@@ -37,6 +38,8 @@ class EmailServiceTest {
 	private JavaMailSender mailSender;
 	@Mock
 	private VerificationCodeGenerateUtils verificationCodeGenerateUtils;
+	@Mock
+	private EmailEventService emailEventService;
 
 	@InjectMocks
 	private EmailService emailService;
@@ -64,6 +67,7 @@ class EmailServiceTest {
 			// then
 			verify(emailVerificationRepository).registerEmailVerificationCode(email, code);
 			verify(mailSender).send(mimeMessage);
+			verify(emailEventService).sendEmail(email);
 		}
 
 		@Test

--- a/musical/src/main/java/com/truve/platform/musical/review/domain/entity/Review.java
+++ b/musical/src/main/java/com/truve/platform/musical/review/domain/entity/Review.java
@@ -1,6 +1,7 @@
 package com.truve.platform.musical.review.domain.entity;
 
 import java.time.LocalDateTime;
+import java.util.UUID;
 
 import com.truve.platform.common.support.BaseEntity;
 
@@ -22,7 +23,7 @@ public class Review extends BaseEntity {
 	private Long showId;
 
 	@Column(nullable = false)
-	private Long userId;
+	private UUID userId;
 
 	@Column(nullable = false)
 	private String content;
@@ -37,7 +38,7 @@ public class Review extends BaseEntity {
 	private LocalDateTime deletedAt;
 
 	@Builder
-	public Review(Long showId, Long userId, String content, Boolean isPositive, LocalDateTime watchedAt) {
+	public Review(Long showId, UUID userId, String content, Boolean isPositive, LocalDateTime watchedAt) {
 		this.showId = showId;
 		this.userId = userId;
 		this.content = content;

--- a/musical/src/main/java/com/truve/platform/musical/review/repository/ReviewPointType.java
+++ b/musical/src/main/java/com/truve/platform/musical/review/repository/ReviewPointType.java
@@ -1,6 +1,0 @@
-package com.truve.platform.musical.review.repository;
-
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface ReviewPointType extends JpaRepository<ReviewPointType, Long> {
-}

--- a/musical/src/main/java/com/truve/platform/musical/review/repository/ReviewPointType.java
+++ b/musical/src/main/java/com/truve/platform/musical/review/repository/ReviewPointType.java
@@ -1,0 +1,6 @@
+package com.truve.platform.musical.review.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReviewPointType extends JpaRepository<ReviewPointType, Long> {
+}

--- a/musical/src/main/java/com/truve/platform/musical/show/controller/ArtistLikeController.java
+++ b/musical/src/main/java/com/truve/platform/musical/show/controller/ArtistLikeController.java
@@ -7,6 +7,8 @@ import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.UUID;
+
 import com.truve.platform.common.response.ApiResult;
 import com.truve.platform.musical.show.service.ArtistService;
 
@@ -24,7 +26,7 @@ public class ArtistLikeController {
 	@PostMapping("/{artistId}/likes")
 	public ApiResult<Void> likeArtist(
 		@PathVariable Long artistId,
-		@RequestHeader(name = "X-User-Id") Long userId
+		@RequestHeader(name = "X-User-Id") UUID userId
 	) {
 		artistService.likeArtist(artistId, userId);
 		return ApiResult.ok();
@@ -34,7 +36,7 @@ public class ArtistLikeController {
 	@DeleteMapping("/{artistId}/likes")
 	public ApiResult<Void> unlikeArtist(
 		@PathVariable Long artistId,
-		@RequestHeader(name = "X-User-Id") Long userId
+		@RequestHeader(name = "X-User-Id") UUID userId
 	) {
 		artistService.unlikeArtist(artistId, userId);
 		return ApiResult.ok();

--- a/musical/src/main/java/com/truve/platform/musical/show/controller/ShowController.java
+++ b/musical/src/main/java/com/truve/platform/musical/show/controller/ShowController.java
@@ -2,6 +2,7 @@ package com.truve.platform.musical.show.controller;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.UUID;
 
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -31,7 +32,7 @@ public class ShowController {
 	@GetMapping("/{showId}")
 	public ApiResult<ShowResponse.Detail> getDetail(
 		@PathVariable Long showId,
-		@RequestHeader(name = "X-User-Id", required = false) Long userId
+		@RequestHeader(name = "X-User-Id", required = false) UUID userId
 	) {
 		return ApiResult.ok(showDetailService.getDetail(showId, userId));
 	}

--- a/musical/src/main/java/com/truve/platform/musical/show/domain/entity/ArtistLike.java
+++ b/musical/src/main/java/com/truve/platform/musical/show/domain/entity/ArtistLike.java
@@ -9,6 +9,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
+import java.util.UUID;
 import lombok.Builder;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -29,14 +30,14 @@ import lombok.NoArgsConstructor;
 public class ArtistLike extends BaseEntity {
 
 	@Column(name = "user_id", nullable = false)
-	private Long userId;
+	private UUID userId;
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "artist_id", nullable = false)
 	private Artist artist;
 
 	@Builder
-	private ArtistLike(Long userId, Artist artist) {
+	private ArtistLike(UUID userId, Artist artist) {
 		this.userId = userId;
 		this.artist = artist;
 	}

--- a/musical/src/main/java/com/truve/platform/musical/show/repository/ArtistLikeRepository.java
+++ b/musical/src/main/java/com/truve/platform/musical/show/repository/ArtistLikeRepository.java
@@ -2,6 +2,7 @@ package com.truve.platform.musical.show.repository;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.UUID;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -18,11 +19,11 @@ public interface ArtistLikeRepository extends JpaRepository<ArtistLike, Long> {
 		and al.artist.id in :artistIds
 		""")
 	List<Long> findLikedArtistIds(
-		@Param("userId") Long userId,
+		@Param("userId") UUID userId,
 		@Param("artistIds") Collection<Long> artistIds
 	);
 
-	boolean existsByUserIdAndArtistId(Long userId, Long artistId);
+	boolean existsByUserIdAndArtistId(UUID userId, Long artistId);
 
-	void deleteByUserIdAndArtistId(Long userId, Long artistId);
+	void deleteByUserIdAndArtistId(UUID userId, Long artistId);
 }

--- a/musical/src/main/java/com/truve/platform/musical/show/service/ArtistService.java
+++ b/musical/src/main/java/com/truve/platform/musical/show/service/ArtistService.java
@@ -4,6 +4,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.dao.DataIntegrityViolationException;
 
+import java.util.UUID;
+
 import com.truve.platform.common.exception.CustomException;
 import com.truve.platform.common.exception.ErrorCode;
 import com.truve.platform.common.support.Preconditions;
@@ -22,7 +24,7 @@ public class ArtistService {
 	private final ArtistLikeRepository artistLikeRepository;
 
 	@Transactional
-	public void likeArtist(Long artistId, Long userId) {
+	public void likeArtist(Long artistId, UUID userId) {
 		Preconditions.validate(artistRepository.existsById(artistId), ErrorCode.NOT_FOUND_ARTIST);
 		Preconditions.validate(
 			!artistLikeRepository.existsByUserIdAndArtistId(userId, artistId),
@@ -42,7 +44,7 @@ public class ArtistService {
 	}
 
 	@Transactional
-	public void unlikeArtist(Long artistId, Long userId) {
+	public void unlikeArtist(Long artistId, UUID userId) {
 		artistLikeRepository.deleteByUserIdAndArtistId(userId, artistId);
 	}
 }

--- a/musical/src/main/java/com/truve/platform/musical/show/service/ShowDetailService.java
+++ b/musical/src/main/java/com/truve/platform/musical/show/service/ShowDetailService.java
@@ -2,6 +2,7 @@ package com.truve.platform.musical.show.service;
 
 import java.util.List;
 import java.util.Set;
+import java.util.UUID;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -36,7 +37,7 @@ public class ShowDetailService {
 	private final S3Service s3Service;
 
 	@Transactional(readOnly = true)
-	public ShowResponse.Detail getDetail(Long showId, Long userId) {
+	public ShowResponse.Detail getDetail(Long showId, UUID userId) {
 		Show show = showRepository.findByIdOrThrow(showId);
 
 		List<ShowSchedule> schedules = showScheduleRepository.findSchedules(showId);
@@ -76,7 +77,7 @@ public class ShowDetailService {
 			.build();
 	}
 
-	private Set<Long> findLikedArtistIds(Long userId, List<ShowCasting> showCastings) {
+	private Set<Long> findLikedArtistIds(UUID userId, List<ShowCasting> showCastings) {
 		if (userId == null || showCastings.isEmpty()) {
 			return Set.of();
 		}

--- a/musical/src/main/java/com/truve/platform/musical/user/domain/entity/User.java
+++ b/musical/src/main/java/com/truve/platform/musical/user/domain/entity/User.java
@@ -1,5 +1,7 @@
 package com.truve.platform.musical.user.domain.entity;
 
+import java.util.UUID;
+
 import com.truve.platform.common.support.BaseEntity;
 
 import jakarta.persistence.Column;
@@ -17,13 +19,13 @@ import lombok.NoArgsConstructor;
 public class User extends BaseEntity {
 
 	@Column(nullable = false, unique = true)
-	private Long userId;
+	private UUID userId;
 
 	@Column(nullable = false)
 	private String nickname;
 
 	@Builder
-	public User(Long userId, String nickname) {
+	public User(UUID userId, String nickname) {
 		this.userId = userId;
 		this.nickname = nickname;
 	}

--- a/musical/src/main/java/com/truve/platform/musical/user/domain/entity/UserViewedShow.java
+++ b/musical/src/main/java/com/truve/platform/musical/user/domain/entity/UserViewedShow.java
@@ -1,12 +1,11 @@
 package com.truve.platform.musical.user.domain.entity;
 
+import java.util.UUID;
+
 import com.truve.platform.common.support.BaseEntity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -19,13 +18,13 @@ import lombok.NoArgsConstructor;
 @Table(name = "user_viewed_show")
 public class UserViewedShow extends BaseEntity {
 
-	private Long userId;
+	private UUID userId;
 
 	@Column(nullable = false)
 	private Long showId;
 
 	@Builder
-	public UserViewedShow(Long userId, Long showId) {
+	public UserViewedShow(UUID userId, Long showId) {
 		this.userId = userId;
 		this.showId = showId;
 	}

--- a/musical/src/main/java/com/truve/platform/musical/user/repository/UserRepository.java
+++ b/musical/src/main/java/com/truve/platform/musical/user/repository/UserRepository.java
@@ -1,9 +1,11 @@
 package com.truve.platform.musical.user.repository;
 
+import java.util.UUID;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.truve.platform.musical.user.domain.entity.User;
 
 public interface UserRepository extends JpaRepository<User, Long> {
-	boolean existsByUserId(Long userId);
+	boolean existsByUserId(UUID userId);
 }

--- a/musical/src/main/java/com/truve/platform/musical/user/service/UserSignedUpEventConsumer.java
+++ b/musical/src/main/java/com/truve/platform/musical/user/service/UserSignedUpEventConsumer.java
@@ -1,5 +1,7 @@
 package com.truve.platform.musical.user.service;
 
+import java.util.UUID;
+
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -34,10 +36,17 @@ public class UserSignedUpEventConsumer {
 	public void consume(String message) throws Exception {
 		JsonNode root = objectMapper.readTree(message);
 
-		Long userId = root.path(USER_ID).asLong();
+		String rawUserId = root.path(USER_ID).asText();
 		String nickname = root.path(NICKNAME).asText();
 
-		if (userId == 0L || !StringUtils.hasText(nickname)) {
+		if (!StringUtils.hasText(rawUserId) || !StringUtils.hasText(nickname)) {
+			throw new CustomException(ErrorCode.EVENT_USER_SIGNED_UP_FAILED);
+		}
+
+		UUID userId;
+		try {
+			userId = UUID.fromString(rawUserId);
+		} catch (IllegalArgumentException e) {
 			throw new CustomException(ErrorCode.EVENT_USER_SIGNED_UP_FAILED);
 		}
 

--- a/musical/src/test/java/com/truve/platform/musical/review/domain/entity/ReviewTest.java
+++ b/musical/src/test/java/com/truve/platform/musical/review/domain/entity/ReviewTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 import java.time.LocalDateTime;
+import java.util.UUID;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -14,10 +15,11 @@ class ReviewTest {
 	@DisplayName("Review를 생성한다.")
 	void 리뷰_생성_성공() {
 		LocalDateTime watchedAt = LocalDateTime.of(2026, 3, 11, 0, 0);
+		UUID userId = UUID.fromString("11111111-1111-1111-1111-111111111111");
 
 		Review review = Review.builder()
 			.showId(10L)
-			.userId(20L)
+			.userId(userId)
 			.content("테스트")
 			.isPositive(true)
 			.watchedAt(watchedAt)
@@ -25,7 +27,7 @@ class ReviewTest {
 
 		assertAll(
 			() -> assertThat(review.getShowId()).isEqualTo(10L),
-			() -> assertThat(review.getUserId()).isEqualTo(20L),
+			() -> assertThat(review.getUserId()).isEqualTo(userId),
 			() -> assertThat(review.getContent()).isEqualTo("테스트"),
 			() -> assertThat(review.getIsPositive()).isTrue(),
 			() -> assertThat(review.getWatchedAt()).isEqualTo(watchedAt),

--- a/musical/src/test/java/com/truve/platform/musical/show/controller/ArtistLikeControllerTest.java
+++ b/musical/src/test/java/com/truve/platform/musical/show/controller/ArtistLikeControllerTest.java
@@ -15,6 +15,8 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
+import java.util.UUID;
+
 import com.truve.platform.common.exception.ApiAdvice;
 import com.truve.platform.musical.MusicalApplication;
 import com.truve.platform.musical.show.controller.ArtistLikeController;
@@ -35,10 +37,11 @@ class ArtistLikeControllerTest {
 	@Test
 	@DisplayName("배우 좋아요 등록에 성공하면 200 OK를 응답한다.")
 	void 배우_좋아요_등록_성공() throws Exception {
-		willDoNothing().given(artistService).likeArtist(101L, 7L);
+		UUID userId = UUID.fromString("11111111-1111-1111-1111-111111111111");
+		willDoNothing().given(artistService).likeArtist(101L, userId);
 
 		mockMvc.perform(post("/api/artists/{artistId}/likes", 101L)
-				.header("X-User-Id", "7"))
+				.header("X-User-Id", userId))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.code").value("ok"));
 	}
@@ -46,10 +49,11 @@ class ArtistLikeControllerTest {
 	@Test
 	@DisplayName("배우 좋아요 취소에 성공하면 200 OK를 응답한다.")
 	void 배우_좋아요_취소_성공() throws Exception {
-		willDoNothing().given(artistService).unlikeArtist(101L, 7L);
+		UUID userId = UUID.fromString("11111111-1111-1111-1111-111111111111");
+		willDoNothing().given(artistService).unlikeArtist(101L, userId);
 
 		mockMvc.perform(delete("/api/artists/{artistId}/likes", 101L)
-				.header("X-User-Id", "7"))
+				.header("X-User-Id", userId))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.code").value("ok"));
 	}

--- a/musical/src/test/java/com/truve/platform/musical/show/controller/ShowControllerTest.java
+++ b/musical/src/test/java/com/truve/platform/musical/show/controller/ShowControllerTest.java
@@ -13,6 +13,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Map;
 import java.util.List;
+import java.util.UUID;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -105,7 +106,7 @@ class ShowControllerTest {
 			))
 			.build();
 
-		given(showDetailService.getDetail(anyLong(), nullable(Long.class))).willReturn(response);
+		given(showDetailService.getDetail(anyLong(), nullable(UUID.class))).willReturn(response);
 
 		mockMvc.perform(get("/api/shows/{showId}", 1L))
 			.andExpect(status().isOk())
@@ -142,7 +143,7 @@ class ShowControllerTest {
 			.seatGrades(List.of())
 			.build();
 
-		given(showDetailService.getDetail(org.mockito.ArgumentMatchers.eq(10L), nullable(Long.class))).willReturn(response);
+		given(showDetailService.getDetail(org.mockito.ArgumentMatchers.eq(10L), nullable(UUID.class))).willReturn(response);
 
 		mockMvc.perform(get("/api/shows/{showId}", 10L))
 			.andExpect(status().isOk())
@@ -157,7 +158,7 @@ class ShowControllerTest {
 	@DisplayName("존재하지 않는 공연을 조회하면 404를 응답한다.")
 	void 뮤지컬_상세_조회_실패() throws Exception {
 		willThrow(new CustomException(ErrorCode.NOT_FOUND_SHOW))
-			.given(showDetailService).getDetail(org.mockito.ArgumentMatchers.eq(999L), nullable(Long.class));
+			.given(showDetailService).getDetail(org.mockito.ArgumentMatchers.eq(999L), nullable(UUID.class));
 
 		mockMvc.perform(get("/api/shows/{showId}", 999L))
 			.andExpect(status().isNotFound())

--- a/musical/src/test/java/com/truve/platform/musical/user/service/UserSignedUpEventConsumerTest.java
+++ b/musical/src/test/java/com/truve/platform/musical/user/service/UserSignedUpEventConsumerTest.java
@@ -7,6 +7,8 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
+import java.util.UUID;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -37,18 +39,19 @@ class UserSignedUpEventConsumerTest {
 	@Test
 	@DisplayName("정상 회원가입 이벤트를 수신하면 musical service 유저를 생성한다.")
 	void 회원가입_이벤트_수신_성공() throws Exception {
+		UUID userId = UUID.fromString("11111111-1111-1111-1111-111111111111");
 		String message = """
-			{"userId":1,"nickname":"test@test.com"}
+			{"userId":"11111111-1111-1111-1111-111111111111","nickname":"test@test.com"}
 			""";
 
-		given(userRepository.existsByUserId(1L)).willReturn(false);
+		given(userRepository.existsByUserId(userId)).willReturn(false);
 
 		userSignedUpEventConsumer.consume(message);
 
 		ArgumentCaptor<User> savedUserCaptor = ArgumentCaptor.forClass(User.class);
 
 		verify(userRepository).save(savedUserCaptor.capture());
-		assertThat(savedUserCaptor.getValue().getUserId()).isEqualTo(1L);
+		assertThat(savedUserCaptor.getValue().getUserId()).isEqualTo(userId);
 		assertThat(savedUserCaptor.getValue().getNickname()).isEqualTo("test@test.com");
 	}
 
@@ -56,10 +59,10 @@ class UserSignedUpEventConsumerTest {
 	@DisplayName("이미 생성된 유저면 저장을 건너뛴다.")
 	void 회원가입_이벤트_중복_유저_건너뜀() throws Exception {
 		String message = """
-			{"userId":1,"nickname":"test@test.com"}
+			{"userId":"11111111-1111-1111-1111-111111111111","nickname":"test@test.com"}
 			""";
 
-		given(userRepository.existsByUserId(1L)).willReturn(true);
+		given(userRepository.existsByUserId(UUID.fromString("11111111-1111-1111-1111-111111111111"))).willReturn(true);
 
 		userSignedUpEventConsumer.consume(message);
 
@@ -70,7 +73,7 @@ class UserSignedUpEventConsumerTest {
 	@DisplayName("userId 또는 nickname 이 올바르지 않으면 예외가 발생한다.")
 	void 회원가입_이벤트_유효성_실패() {
 		String message = """
-			{"userId":0,"nickname":""}
+			{"userId":"invalid-uuid","nickname":""}
 			""";
 
 		CustomException exception = assertThrows(

--- a/musical/src/test/java/com/truve/platform/show/service/service/ArtistServiceTest.java
+++ b/musical/src/test/java/com/truve/platform/show/service/service/ArtistServiceTest.java
@@ -7,6 +7,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.doThrow;
 
+import java.util.UUID;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -36,12 +38,13 @@ class ArtistServiceTest {
 	@Test
 	@DisplayName("배우 좋아요 등록은 처음 요청일 때만 저장된다.")
 	void 배우_좋아요_등록_성공() {
+		UUID userId = UUID.fromString("11111111-1111-1111-1111-111111111111");
 		Artist artist = org.mockito.Mockito.mock(Artist.class);
 		when(artistRepository.existsById(101L)).thenReturn(true);
 		when(artistRepository.getReferenceById(101L)).thenReturn(artist);
-		when(artistLikeRepository.existsByUserIdAndArtistId(7L, 101L)).thenReturn(false);
+		when(artistLikeRepository.existsByUserIdAndArtistId(userId, 101L)).thenReturn(false);
 
-		artistService.likeArtist(101L, 7L);
+		artistService.likeArtist(101L, userId);
 
 		verify(artistLikeRepository).save(org.mockito.ArgumentMatchers.any());
 	}
@@ -49,10 +52,11 @@ class ArtistServiceTest {
 	@Test
 	@DisplayName("이미 좋아요한 배우는 예외를 발생시킨다.")
 	void 배우_좋아요_등록_중복_실패() {
+		UUID userId = UUID.fromString("11111111-1111-1111-1111-111111111111");
 		when(artistRepository.existsById(101L)).thenReturn(true);
-		when(artistLikeRepository.existsByUserIdAndArtistId(7L, 101L)).thenReturn(true);
+		when(artistLikeRepository.existsByUserIdAndArtistId(userId, 101L)).thenReturn(true);
 
-		CustomException exception = assertThrows(CustomException.class, () -> artistService.likeArtist(101L, 7L));
+		CustomException exception = assertThrows(CustomException.class, () -> artistService.likeArtist(101L, userId));
 
 		assertEquals(ErrorCode.ALREADY_LIKED_ARTIST, exception.getErrorCode());
 		verify(artistLikeRepository, never()).save(org.mockito.ArgumentMatchers.any());
@@ -61,17 +65,19 @@ class ArtistServiceTest {
 	@Test
 	@DisplayName("배우 좋아요 취소는 사용자-배우 기준으로 삭제한다.")
 	void 배우_좋아요_취소_성공() {
-		artistService.unlikeArtist(101L, 7L);
+		UUID userId = UUID.fromString("11111111-1111-1111-1111-111111111111");
+		artistService.unlikeArtist(101L, userId);
 
-		verify(artistLikeRepository).deleteByUserIdAndArtistId(7L, 101L);
+		verify(artistLikeRepository).deleteByUserIdAndArtistId(userId, 101L);
 	}
 
 	@Test
 	@DisplayName("존재하지 않는 배우 좋아요 등록 요청은 예외를 발생시킨다.")
 	void 존재하지않는_배우_좋아요_실패() {
+		UUID userId = UUID.fromString("11111111-1111-1111-1111-111111111111");
 		when(artistRepository.existsById(999L)).thenReturn(false);
 
-		CustomException exception = assertThrows(CustomException.class, () -> artistService.likeArtist(999L, 7L));
+		CustomException exception = assertThrows(CustomException.class, () -> artistService.likeArtist(999L, userId));
 
 		assertEquals(ErrorCode.NOT_FOUND_ARTIST, exception.getErrorCode());
 		verify(artistLikeRepository, never()).save(org.mockito.ArgumentMatchers.any());
@@ -80,14 +86,15 @@ class ArtistServiceTest {
 	@Test
 	@DisplayName("동시성으로 중복 저장 충돌이 발생하면 이미 좋아요 에러를 응답한다.")
 	void 배우_좋아요_등록_동시성_중복충돌_실패() {
+		UUID userId = UUID.fromString("11111111-1111-1111-1111-111111111111");
 		Artist artist = org.mockito.Mockito.mock(Artist.class);
 		when(artistRepository.existsById(101L)).thenReturn(true);
 		when(artistRepository.getReferenceById(101L)).thenReturn(artist);
-		when(artistLikeRepository.existsByUserIdAndArtistId(7L, 101L)).thenReturn(false, true);
+		when(artistLikeRepository.existsByUserIdAndArtistId(userId, 101L)).thenReturn(false, true);
 		doThrow(new DataIntegrityViolationException("duplicate"))
 			.when(artistLikeRepository).save(org.mockito.ArgumentMatchers.any());
 
-		CustomException exception = assertThrows(CustomException.class, () -> artistService.likeArtist(101L, 7L));
+		CustomException exception = assertThrows(CustomException.class, () -> artistService.likeArtist(101L, userId));
 
 		assertEquals(ErrorCode.ALREADY_LIKED_ARTIST, exception.getErrorCode());
 		verify(artistLikeRepository).save(org.mockito.ArgumentMatchers.any());

--- a/musical/src/test/java/com/truve/platform/show/service/service/ShowServiceTest.java
+++ b/musical/src/test/java/com/truve/platform/show/service/service/ShowServiceTest.java
@@ -10,6 +10,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -70,6 +71,7 @@ class ShowServiceTest {
 	@DisplayName("공연 상세는 조회된 공연 전체 캐스팅을 응답한다.")
 	void 공연_상세_공연전체_캐스팅_응답_성공() {
 		Long showId = 1L;
+		UUID userId = UUID.fromString("11111111-1111-1111-1111-111111111111");
 
 		Show show = org.mockito.Mockito.mock(Show.class);
 		Venue venue = org.mockito.Mockito.mock(Venue.class);
@@ -139,11 +141,11 @@ class ShowServiceTest {
 		when(showScheduleRepository.findSchedules(showId)).thenReturn(List.of(schedule1, schedule2));
 		when(showCastingRepository.findAllByShowId(showId))
 			.thenReturn(List.of(castOrder1, castOrder2, castOrderNull));
-		when(artistLikeRepository.findLikedArtistIds(7L, List.of(101L, 102L, 103L)))
+		when(artistLikeRepository.findLikedArtistIds(userId, List.of(101L, 102L, 103L)))
 			.thenReturn(List.of(101L));
 		when(showSeatGradeRepository.findSeatPrices(showId)).thenReturn(List.of(seat));
 
-		ShowResponse.Detail result = showDetailService.getDetail(showId, 7L);
+		ShowResponse.Detail result = showDetailService.getDetail(showId, userId);
 
 		assertEquals(2, result.getSchedules().size());
 		assertEquals("OPEN", result.getSchedules().get(0).getStatus());

--- a/payment/src/test/java/com/truve/platform/payment/service/controller/PaymentControllerTest.java
+++ b/payment/src/test/java/com/truve/platform/payment/service/controller/PaymentControllerTest.java
@@ -22,18 +22,18 @@ import com.truve.platform.payment.service.dto.PaymentRequest;
 import com.truve.platform.payment.service.dto.PaymentResponse;
 import com.truve.platform.payment.service.service.PaymentService;
 
-import tools.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 @WebMvcTest(controllers = PaymentController.class)
 public class PaymentControllerTest {
 	@Autowired
 	private MockMvc mockMvc;
-	@Autowired
-	private ObjectMapper objectMapper;
 	@MockitoBean
 	private PaymentService paymentService;
 	@MockitoBean
 	private JpaMetamodelMappingContext jpaMetamodelMappingContext;
+
+	private final ObjectMapper objectMapper = new ObjectMapper();
 
 	@Test
 	@DisplayName("결제 정보 조회에 성공하면 200 OK와 결제 정보를 응답한다.")

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/controller/BookingController.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/controller/BookingController.java
@@ -9,6 +9,8 @@ import org.truve.platform.ticketing.service.booking.dto.BookingRequest;
 import org.truve.platform.ticketing.service.booking.dto.BookingResponse;
 import org.truve.platform.ticketing.service.booking.service.BookingService;
 
+import java.util.UUID;
+
 import com.truve.platform.common.response.ApiResult;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -26,7 +28,7 @@ public class BookingController {
 	@Operation(summary = "예매 내역 생성", description = "예매 및 티켓 정보를 저장합니다.")
 	@PostMapping
 	public ApiResult<BookingResponse.Create> create(
-		@RequestHeader(USER_ID_HEADER) Long userId,
+		@RequestHeader(USER_ID_HEADER) UUID userId,
 		@RequestBody @Valid BookingRequest.Create request) {
 		return ApiResult.ok(bookingService.create(userId, request));
 	}

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/domain/entity/Reservation.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/domain/entity/Reservation.java
@@ -3,6 +3,7 @@ package org.truve.platform.ticketing.service.booking.domain.entity;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 import org.truve.platform.ticketing.service.booking.domain.constant.ReservationStatus;
 
@@ -27,7 +28,7 @@ import lombok.NoArgsConstructor;
 public class Reservation extends BaseEntity {
 
 	@Column(nullable = false)
-	private Long userId;
+	private UUID userId;
 
 	@Column(name = "reservation_number", unique = true, nullable = false)
 	private String number;
@@ -49,7 +50,7 @@ public class Reservation extends BaseEntity {
 	private List<Ticket> tickets = new ArrayList<>();
 
 	@Builder
-	private Reservation(Long userId, String number, Long totalAmount, String gradeSummary) {
+	private Reservation(UUID userId, String number, Long totalAmount, String gradeSummary) {
 
 		this.userId = userId;
 		this.number = number;
@@ -58,7 +59,7 @@ public class Reservation extends BaseEntity {
 		this.status = ReservationStatus.CREATED;
 	}
 
-	public static Reservation create(Long userId, String number, Long totalAmount, String gradeSummary) {
+	public static Reservation create(UUID userId, String number, Long totalAmount, String gradeSummary) {
 		return Reservation.builder()
 			.userId(userId)
 			.number(number)

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/service/BookingService.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/service/BookingService.java
@@ -2,6 +2,7 @@ package org.truve.platform.ticketing.service.booking.service;
 
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
@@ -29,7 +30,7 @@ public class BookingService {
 	private final NumberGenerator numberGenerator;
 
 	@Transactional
-	public BookingResponse.Create create(Long userId, BookingRequest.Create request) {
+	public BookingResponse.Create create(UUID userId, BookingRequest.Create request) {
 		List<TicketingResponse.SeatInfo> seatInfos = ticketingClient.getSeatInfos(request.getSeatIds());
 
 		Reservation reservation = createReservation(userId, seatInfos);
@@ -40,7 +41,7 @@ public class BookingService {
 		return new BookingResponse.Create(reservation.getNumber());
 	}
 
-	private Reservation createReservation(Long userId, List<TicketingResponse.SeatInfo> seatInfos) {
+	private Reservation createReservation(UUID userId, List<TicketingResponse.SeatInfo> seatInfos) {
 		return Reservation.create(
 			userId,
 			numberGenerator.generateReservationNumber(),

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/global/jwt/AdmissionTokenService.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/global/jwt/AdmissionTokenService.java
@@ -1,5 +1,7 @@
 package org.truve.platform.ticketing.service.global.jwt;
 
+import java.util.UUID;
+
 import org.springframework.stereotype.Component;
 import org.truve.platform.ticketing.service.ticketing.dto.AdmissionTokenClaimsDTO;
 
@@ -23,14 +25,14 @@ public class AdmissionTokenService {
 
 	private final JwtProperties jwtProperties;
 
-	public AdmissionTokenClaimsDTO parseAdmissionToken(String token, Long expectedShowId, Long expectedUserId) {
+	public AdmissionTokenClaimsDTO parseAdmissionToken(String token, Long expectedShowId, UUID expectedUserId) {
 		Preconditions.validate(!((token == null) || token.isEmpty()), ErrorCode.INVALID_ADMISSION_TOKEN);
 
 		Claims claims = parseClaims(token);
 
 		String tokenType = (String) claims.get(TOKEN_TYPE_KEY);
 		Long showId = Long.parseLong((String) claims.get(SHOW_ID_KEY));
-		Long userId = Long.parseLong(claims.getSubject());
+		UUID userId = UUID.fromString(claims.getSubject());
 
 		Preconditions.validate(ADMISSION_TOKEN_TYPE.equals(tokenType), ErrorCode.INVALID_ADMISSION_TOKEN);
 		Preconditions.validate(userId.equals(expectedUserId), ErrorCode.INVALID_ADMISSION_TOKEN);

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/ticketing/controller/TicketingController.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/ticketing/controller/TicketingController.java
@@ -12,6 +12,8 @@ import org.truve.platform.ticketing.service.ticketing.dto.TicketingRequest;
 import org.truve.platform.ticketing.service.ticketing.dto.TicketingResponse;
 import org.truve.platform.ticketing.service.ticketing.service.TicketingService;
 
+import java.util.UUID;
+
 import com.truve.platform.common.response.ApiResult;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -47,7 +49,7 @@ public class TicketingController {
 	public ApiResult<TicketingResponse.Enter> enter(
 		@PathVariable Long showScheduleId,
 		@Parameter(hidden = true)
-		@RequestHeader(value = USER_ID_HEADER) Long userId,
+		@RequestHeader(value = USER_ID_HEADER) UUID userId,
 		@RequestHeader(value = ADMISSION_HEADER, required = false) String admissionToken
 	) {
 		var response = ticketingService.enter(showScheduleId, userId, admissionToken);
@@ -69,7 +71,7 @@ public class TicketingController {
 	public ApiResult<Void> heartbeat(
 		@PathVariable Long showScheduleId,
 		@Parameter(hidden = true)
-		@RequestHeader(value = USER_ID_HEADER) Long userId,
+		@RequestHeader(value = USER_ID_HEADER) UUID userId,
 		@RequestHeader(value = SESSION_HEADER) String sessionToken
 	) {
 		ticketingService.heartbeat(showScheduleId, userId, sessionToken);
@@ -91,7 +93,7 @@ public class TicketingController {
 	public ApiResult<TicketingResponse.Seats> getSeats(
 		@PathVariable Long showScheduleId,
 		@Parameter(hidden = true)
-		@RequestHeader(value = USER_ID_HEADER) Long userId,
+		@RequestHeader(value = USER_ID_HEADER) UUID userId,
 		@RequestHeader(value = SESSION_HEADER) String sessionToken
 	) {
 		var response = ticketingService.getSeats(showScheduleId, userId, sessionToken);
@@ -113,7 +115,7 @@ public class TicketingController {
 	public ApiResult<Void> holdSeat(
 		@PathVariable Long showScheduleId,
 		@Parameter(hidden = true)
-		@RequestHeader(value = USER_ID_HEADER) Long userId,
+		@RequestHeader(value = USER_ID_HEADER) UUID userId,
 		@RequestHeader(value = SESSION_HEADER) String sessionToken,
 		@RequestBody @Valid TicketingRequest.HoldSeat request
 	) {
@@ -135,7 +137,7 @@ public class TicketingController {
 	@GetMapping("/shows/{showScheduleId}/seats")
 	public ApiResult<TicketingResponse.Show> getShow(
 		@Parameter(hidden = true)
-		@RequestHeader(value = USER_ID_HEADER) Long userId,
+		@RequestHeader(value = USER_ID_HEADER) UUID userId,
 		@RequestHeader(value = SESSION_HEADER) String sessionToken,
 		@PathVariable Long showScheduleId
 	) {
@@ -159,7 +161,7 @@ public class TicketingController {
 	public ApiResult<Void> deleteHoldSeat(
 		@PathVariable Long showScheduleId,
 		@Parameter(hidden = true)
-		@RequestHeader(value = USER_ID_HEADER) Long userId,
+		@RequestHeader(value = USER_ID_HEADER) UUID userId,
 		@RequestHeader(value = SESSION_HEADER) String sessionToken,
 		@RequestBody @Valid TicketingRequest.DeleteHoldSeat request
 	) {

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/ticketing/dto/AdmissionTokenClaimsDTO.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/ticketing/dto/AdmissionTokenClaimsDTO.java
@@ -1,16 +1,18 @@
 package org.truve.platform.ticketing.service.ticketing.dto;
 
+import java.util.UUID;
+
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @AllArgsConstructor
 @Getter
 public class AdmissionTokenClaimsDTO {
-	private Long userId;
+	private UUID userId;
 	private Long showId;
 	private String tokenType;
 
-	public static AdmissionTokenClaimsDTO of(Long userId, Long showId, String tokenType) {
+	public static AdmissionTokenClaimsDTO of(UUID userId, Long showId, String tokenType) {
 		return new  AdmissionTokenClaimsDTO(userId, showId, tokenType);
 	}
 }

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/ticketing/dto/SessionTicketValueDTO.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/ticketing/dto/SessionTicketValueDTO.java
@@ -1,15 +1,17 @@
 package org.truve.platform.ticketing.service.ticketing.dto;
 
+import java.util.UUID;
+
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
 public class SessionTicketValueDTO {
-	private Long userId;
+	private UUID userId;
 	private Long showId;
 
-	public static SessionTicketValueDTO of(Long userId, Long showId) {
+	public static SessionTicketValueDTO of(UUID userId, Long showId) {
 		return new SessionTicketValueDTO(userId, showId);
 	}
 }

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/ticketing/repository/TicketingRedisRepository.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/ticketing/repository/TicketingRedisRepository.java
@@ -1,6 +1,7 @@
 package org.truve.platform.ticketing.service.ticketing.repository;
 
 import java.time.Duration;
+import java.util.UUID;
 
 import org.springframework.stereotype.Repository;
 import org.truve.platform.ticketing.service.ticketing.dto.SessionTicketValueDTO;
@@ -19,11 +20,11 @@ public class TicketingRedisRepository {
 
 	private final RedisSupport redisSupport;
 
-	public boolean consumeAdmissionToken(Long showId, Long userId, String admissionToken) {
+	public boolean consumeAdmissionToken(Long showId, UUID userId, String admissionToken) {
 		return redisSupport.consumeIfEquals(readyUserKey(showId, userId), admissionToken);
 	}
 
-	public void saveSessionToken(String sessionToken, Long userId, Long showId, Duration ttl) {
+	public void saveSessionToken(String sessionToken, UUID userId, Long showId, Duration ttl) {
 		SessionTicketValueDTO value = SessionTicketValueDTO.of(userId, showId);
 		redisSupport.setJsonValueWithTtl(sessionTokenKey(sessionToken), value, ttl);
 	}
@@ -74,7 +75,7 @@ public class TicketingRedisRepository {
 		return TICKET_ACTIVE_SHOW_USER_PREFIX + showId;
 	}
 
-	private String readyUserKey(Long showId, Long userId) {
+	private String readyUserKey(Long showId, UUID userId) {
 		return READY_KEY_PREFIX + showId + ":" + userId;
 	}
 

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/ticketing/service/TicketingService.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/ticketing/service/TicketingService.java
@@ -33,7 +33,7 @@ public class TicketingService {
 	private final ScheduledSeatRepository scheduledSeatRepository;
 	private final ShowScheduledRepository showScheduledRepository;
 
-	public TicketingResponse.Enter enter(Long showScheduleId, Long userId, String admissionToken) {
+	public TicketingResponse.Enter enter(Long showScheduleId, UUID userId, String admissionToken) {
 		AdmissionTokenClaimsDTO claims = admissionTokenService.parseAdmissionToken(admissionToken, showScheduleId, userId);
 
 		boolean consumedAdmissionToken = ticketingRedisRepository.consumeAdmissionToken(claims.getShowId(), claims.getUserId(), admissionToken);
@@ -49,7 +49,7 @@ public class TicketingService {
 		return new TicketingResponse.Enter(sessionToken, sessionTokenTtl);
 	}
 
-	public void heartbeat(Long showScheduleId, Long userId, String sessionToken) {
+	public void heartbeat(Long showScheduleId, UUID userId, String sessionToken) {
 
 		isCorrectSessionToken(showScheduleId, userId, sessionToken);
 
@@ -62,7 +62,7 @@ public class TicketingService {
 		Preconditions.validate(extended, ErrorCode.INVALID_SESSION_TOKEN);
 	}
 
-	public void holdSeat(Long showScheduleId, Long userId, String sessionToken, List<Long> seatIds) {
+	public void holdSeat(Long showScheduleId, UUID userId, String sessionToken, List<Long> seatIds) {
 		heartbeat(showScheduleId, userId, sessionToken);
 
 		Preconditions.validate(seatIds.size() <= 4, ErrorCode.EXCEEDED_MAX_TICKET_COUNT);
@@ -102,7 +102,7 @@ public class TicketingService {
 
 	}
 
-	public void cancelHoldSeat(Long showScheduleId, Long userId, String sessionToken,List<Long> seatIds) {
+	public void cancelHoldSeat(Long showScheduleId, UUID userId, String sessionToken,List<Long> seatIds) {
 
 		heartbeat(showScheduleId, userId, sessionToken);
 
@@ -113,7 +113,7 @@ public class TicketingService {
 		}
 	}
 
-	public TicketingResponse.Show getShow(Long userId, Long showScheduleId, String sessionToken) {
+	public TicketingResponse.Show getShow(UUID userId, Long showScheduleId, String sessionToken) {
 		heartbeat(showScheduleId, userId, sessionToken);
 
 		ShowScheduled schedule = showScheduledRepository.findById(showScheduleId)
@@ -122,7 +122,7 @@ public class TicketingService {
 		return TicketingResponse.Show.of(schedule.getTitle(), schedule.getTitle(), schedule.getStartAt());
 	}
 
-	public TicketingResponse.Seats getSeats(Long showScheduleId, Long userId, String sessionToken) {
+	public TicketingResponse.Seats getSeats(Long showScheduleId, UUID userId, String sessionToken) {
 		heartbeat(showScheduleId, userId, sessionToken);
 
 		showScheduledRepository.findById(showScheduleId).orElseThrow(
@@ -135,7 +135,7 @@ public class TicketingService {
 	}
 
 
-	private void isCorrectSessionToken(Long showScheduleId, Long userId, String sessionToken) {
+	private void isCorrectSessionToken(Long showScheduleId, UUID userId, String sessionToken) {
 		Preconditions.validate(sessionToken != null && !sessionToken.isBlank(), ErrorCode.INVALID_SESSION_TOKEN);
 
 

--- a/ticketing/src/test/java/org/truve/platform/ticketing/service/booking/service/BookingServiceTest.java
+++ b/ticketing/src/test/java/org/truve/platform/ticketing/service/booking/service/BookingServiceTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
 
 import java.util.List;
+import java.util.UUID;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -39,7 +40,7 @@ class BookingServiceTest {
 	@DisplayName("예매 내역과 티켓을 생성하고 예매 번호를 반환한다.")
 	void 예매생성_성공() {
 		// given
-		Long userId = 1L;
+		UUID userId = UUID.fromString("11111111-1111-1111-1111-111111111111");
 		List<Long> seatIds = List.of(10L, 11L, 12L);
 		BookingRequest.Create request = new BookingRequest.Create(seatIds);
 

--- a/ticketing/src/test/java/org/truve/platform/ticketing/service/ticketing/controller/TicketingControllerTest.java
+++ b/ticketing/src/test/java/org/truve/platform/ticketing/service/ticketing/controller/TicketingControllerTest.java
@@ -11,7 +11,6 @@ import java.util.UUID;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentMatchers;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.context.ApplicationEventPublisher;
@@ -30,7 +29,8 @@ import com.truve.platform.common.exception.ApiAdvice;
 import com.truve.platform.common.exception.CustomException;
 import com.truve.platform.common.exception.ErrorCode;
 
-import tools.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 
 @WebMvcTest(controllers = TicketingController.class)
 @Import(ApiAdvice.class)
@@ -42,8 +42,6 @@ class TicketingControllerTest {
 
 	@Autowired
 	private MockMvc mockMvc;
-	@Autowired
-	private ObjectMapper objectMapper;
 
 	@MockitoBean
 	private TicketingService ticketingService;
@@ -51,6 +49,8 @@ class TicketingControllerTest {
 	private JpaMetamodelMappingContext jpaMetamodelMappingContext;
 	@MockitoBean
 	private ApplicationEventPublisher applicationEventPublisher;
+
+	private final ObjectMapper objectMapper = new ObjectMapper();
 
 	@Test
 	@DisplayName("티켓팅 입장 성공")
@@ -223,8 +223,8 @@ class TicketingControllerTest {
 		// then
 		resultActions.andExpect(status().isBadRequest())
 			.andExpect(jsonPath("$.code").value("C02"));
-		verify(ticketingService, never()).holdSeat(anyLong(),
-			UUID.fromString(ArgumentMatchers.anyString()), anyString(), anyList());
+		verify(ticketingService, never())
+			.holdSeat(anyLong(), any(UUID.class), anyString(), anyList());
 	}
 
 	@Test
@@ -236,14 +236,15 @@ class TicketingControllerTest {
 		// when
 		ResultActions resultActions = mockMvc.perform(delete("/api/ticketing/{showScheduleId}/hold/seat", 1L)
 			.contentType(MediaType.APPLICATION_JSON)
-			.header(USER_ID_HEADER, 2L)
+			.header(USER_ID_HEADER, "11111111-1111-1111-1111-111111111111")
 			.header(SESSION_HEADER, "session-token")
 			.content(objectMapper.writeValueAsString(request)));
 
 		// then
 		resultActions.andExpect(status().isBadRequest())
 			.andExpect(jsonPath("$.code").value("C02"));
-		verify(ticketingService, never()).cancelHoldSeat(anyLong(),
-			UUID.fromString(ArgumentMatchers.anyString()), anyString(), anyList());
+
+		verify(ticketingService, never())
+			.cancelHoldSeat(anyLong(), any(UUID.class), anyString(), anyList());
 	}
 }

--- a/ticketing/src/test/java/org/truve/platform/ticketing/service/ticketing/controller/TicketingControllerTest.java
+++ b/ticketing/src/test/java/org/truve/platform/ticketing/service/ticketing/controller/TicketingControllerTest.java
@@ -7,9 +7,11 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.UUID;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentMatchers;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.context.ApplicationEventPublisher;
@@ -55,7 +57,7 @@ class TicketingControllerTest {
 	void 티켓팅_입장() throws Exception {
 		// given
 		Long showScheduleId = 1L;
-		Long userId = 2L;
+		UUID userId = UUID.fromString("11111111-1111-1111-1111-111111111111");
 		TicketingResponse.Enter response = new TicketingResponse.Enter("session-token", 300000L);
 
 		given(ticketingService.enter(showScheduleId, userId, "admission-token")).willReturn(response);
@@ -78,14 +80,14 @@ class TicketingControllerTest {
 	void 세션_하트비트() throws Exception {
 		// when
 		ResultActions resultActions = mockMvc.perform(post("/api/ticketing/{showScheduleId}/heartbeat", 1L)
-			.header(USER_ID_HEADER, 2L)
+			.header(USER_ID_HEADER, "11111111-1111-1111-1111-111111111111")
 			.header(SESSION_HEADER, "session-token"));
 
 		// then
 		resultActions.andExpect(status().isOk())
 			.andExpect(jsonPath("$.code").value("ok"))
 			.andExpect(jsonPath("$.message").value("성공"));
-		verify(ticketingService).heartbeat(1L, 2L, "session-token");
+		verify(ticketingService).heartbeat(1L, UUID.fromString("11111111-1111-1111-1111-111111111111"), "session-token");
 	}
 
 	@Test
@@ -110,11 +112,12 @@ class TicketingControllerTest {
 			)
 		));
 
-		given(ticketingService.getSeats(1L, 2L, "session-token")).willReturn(response);
+		UUID userId = UUID.fromString("11111111-1111-1111-1111-111111111111");
+		given(ticketingService.getSeats(1L, userId, "session-token")).willReturn(response);
 
 		// when
 		ResultActions resultActions = mockMvc.perform(get("/api/ticketing/{showScheduleId}", 1L)
-			.header(USER_ID_HEADER, 2L)
+			.header(USER_ID_HEADER, userId)
 			.header(SESSION_HEADER, "session-token"));
 
 		// then
@@ -122,7 +125,7 @@ class TicketingControllerTest {
 			.andExpect(jsonPath("$.data.sections[0].sectionId").value(1L))
 			.andExpect(jsonPath("$.data.sections[0].rows[0].row").value("A"))
 			.andExpect(jsonPath("$.data.sections[0].rows[0].seats[1].status").value("SOLD"));
-		verify(ticketingService).getSeats(1L, 2L, "session-token");
+		verify(ticketingService).getSeats(1L, userId, "session-token");
 	}
 
 	@Test
@@ -134,14 +137,14 @@ class TicketingControllerTest {
 		// when
 		ResultActions resultActions = mockMvc.perform(post("/api/ticketing/{showScheduleId}/hold/seat", 1L)
 			.contentType(MediaType.APPLICATION_JSON)
-			.header(USER_ID_HEADER, 2L)
+			.header(USER_ID_HEADER, "11111111-1111-1111-1111-111111111111")
 			.header(SESSION_HEADER, "session-token")
 			.content(objectMapper.writeValueAsString(request)));
 
 		// then
 		resultActions.andExpect(status().isOk())
 			.andExpect(jsonPath("$.code").value("ok"));
-		verify(ticketingService).holdSeat(1L, 2L, "session-token", List.of(10L, 11L));
+		verify(ticketingService).holdSeat(1L, UUID.fromString("11111111-1111-1111-1111-111111111111"), "session-token", List.of(10L, 11L));
 	}
 
 	@Test
@@ -153,14 +156,14 @@ class TicketingControllerTest {
 		// when
 		ResultActions resultActions = mockMvc.perform(delete("/api/ticketing/{showScheduleId}/hold/seat", 1L)
 			.contentType(MediaType.APPLICATION_JSON)
-			.header(USER_ID_HEADER, 2L)
+			.header(USER_ID_HEADER, "11111111-1111-1111-1111-111111111111")
 			.header(SESSION_HEADER, "session-token")
 			.content(objectMapper.writeValueAsString(request)));
 
 		// then
 		resultActions.andExpect(status().isOk())
 			.andExpect(jsonPath("$.code").value("ok"));
-		verify(ticketingService).cancelHoldSeat(1L, 2L, "session-token", List.of(10L, 11L));
+		verify(ticketingService).cancelHoldSeat(1L, UUID.fromString("11111111-1111-1111-1111-111111111111"), "session-token", List.of(10L, 11L));
 	}
 
 	@Test
@@ -169,12 +172,13 @@ class TicketingControllerTest {
 		// given
 		LocalDateTime startAt = LocalDateTime.of(2026, 3, 9, 20, 0);
 		TicketingResponse.Show response = new TicketingResponse.Show("지킬앤하이드", "블루스퀘어", startAt);
+		UUID userId = UUID.fromString("11111111-1111-1111-1111-111111111111");
 
-		given(ticketingService.getShow(2L, 1L, "session-token")).willReturn(response);
+		given(ticketingService.getShow(userId, 1L, "session-token")).willReturn(response);
 
 		// when
 		ResultActions resultActions = mockMvc.perform(get("/api/ticketing/shows/{showScheduleId}/seats", 1L)
-			.header(USER_ID_HEADER, 2L)
+			.header(USER_ID_HEADER, userId)
 			.header(SESSION_HEADER, "session-token"));
 
 		// then
@@ -182,19 +186,19 @@ class TicketingControllerTest {
 			.andExpect(jsonPath("$.data.title").value("지킬앤하이드"))
 			.andExpect(jsonPath("$.data.venueName").value("블루스퀘어"))
 			.andExpect(jsonPath("$.data.startAt").value("2026-03-09T20:00:00"));
-		verify(ticketingService).getShow(2L, 1L, "session-token");
+		verify(ticketingService).getShow(userId, 1L, "session-token");
 	}
 
 	@Test
 	@DisplayName("서비스에서 예외가 발생 에러")
 	void 컨트롤러_예외응답() throws Exception {
 		// given
-		given(ticketingService.enter(1L, 2L, "bad-token"))
+		given(ticketingService.enter(1L, UUID.fromString("11111111-1111-1111-1111-111111111111"), "bad-token"))
 			.willThrow(new CustomException(ErrorCode.INVALID_ADMISSION_TOKEN));
 
 		// when
 		ResultActions resultActions = mockMvc.perform(post("/api/ticketing/{showScheduleId}/enter", 1L)
-			.header(USER_ID_HEADER, 2L)
+			.header(USER_ID_HEADER, "11111111-1111-1111-1111-111111111111")
 			.header(ADMISSION_HEADER, "bad-token"));
 
 		// then
@@ -212,14 +216,15 @@ class TicketingControllerTest {
 		// when
 		ResultActions resultActions = mockMvc.perform(post("/api/ticketing/{showScheduleId}/hold/seat", 1L)
 			.contentType(MediaType.APPLICATION_JSON)
-			.header(USER_ID_HEADER, 2L)
+			.header(USER_ID_HEADER, "11111111-1111-1111-1111-111111111111")
 			.header(SESSION_HEADER, "session-token")
 			.content(objectMapper.writeValueAsString(request)));
 
 		// then
 		resultActions.andExpect(status().isBadRequest())
 			.andExpect(jsonPath("$.code").value("C02"));
-		verify(ticketingService, never()).holdSeat(anyLong(), anyLong(), anyString(), anyList());
+		verify(ticketingService, never()).holdSeat(anyLong(),
+			UUID.fromString(ArgumentMatchers.anyString()), anyString(), anyList());
 	}
 
 	@Test
@@ -238,6 +243,7 @@ class TicketingControllerTest {
 		// then
 		resultActions.andExpect(status().isBadRequest())
 			.andExpect(jsonPath("$.code").value("C02"));
-		verify(ticketingService, never()).cancelHoldSeat(anyLong(), anyLong(), anyString(), anyList());
+		verify(ticketingService, never()).cancelHoldSeat(anyLong(),
+			UUID.fromString(ArgumentMatchers.anyString()), anyString(), anyList());
 	}
 }

--- a/ticketing/src/test/java/org/truve/platform/ticketing/service/ticketing/service/TicketingServiceTest.java
+++ b/ticketing/src/test/java/org/truve/platform/ticketing/service/ticketing/service/TicketingServiceTest.java
@@ -9,6 +9,7 @@ import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -54,14 +55,14 @@ class TicketingServiceTest {
 	private TicketingService ticketingService;
 
 	private Long showScheduleId;
-	private Long userId;
+	private UUID userId;
 	private String admissionToken;
 	private String sessionToken;
 
 	@BeforeEach
 	void setUp() {
 		showScheduleId = 1L;
-		userId = 2L;
+		userId = UUID.fromString("11111111-1111-1111-1111-111111111111");
 		admissionToken = "admission-token";
 		sessionToken = "session-token";
 	}
@@ -162,7 +163,7 @@ class TicketingServiceTest {
 		void 하트비트_유저불일치() {
 			// given
 			given(ticketingRedisRepository.getSessionTokenValue(sessionToken))
-				.willReturn(SessionTicketValueDTO.of(999L, showScheduleId));
+				.willReturn(SessionTicketValueDTO.of(UUID.fromString("22222222-2222-2222-2222-222222222222"), showScheduleId));
 
 			// when
 			CustomException exception = assertThrows(


### PR DESCRIPTION
## 변경 사항

추가/변경 사항과 사유를 작성해 주세요.

- [x] 전체 테스트 코드 성공 여부

로컬 빌드 및 전체 테스트 통과 확인했습니다.

### Auth service 내 user table publicId 컬럼 추가
UUID 컬럼 추가하여 생성자에서 UUID 만들어 주입합니다.
연관 기능 또한 전부 고쳤습니다.
- JWT token claim
- 서비스 내 X-User-Id
- 서비스 내 Long userId

이 UUID를 서비스 내에서 식별자로 사용하면 좋을 것 같아요!

이벤트 활용해서 DB 커밋 이전에 이벤트 발행이 필요하다면 공유하고 고민해보면 좋을 것 같습니다!

## 관련 이슈

- resolved: #67 

## 참고사항 (선택)

전체 프로젝트 내 다 변경해서 작업 전후로 rebase 필요할 것 같습니다~!
테스트코드 내에서 ObjectMapper가 Autowired로 주입이 안되어서 직접 생성했습니다..