### PR TITLE
feat(payment): 결제 승인 상태 변화 이벤트 발행 및 소비 로직 구현

### DIFF
--- a/common/src/main/java/com/truve/platform/common/event/KafkaEventPublisher.java
+++ b/common/src/main/java/com/truve/platform/common/event/KafkaEventPublisher.java
@@ -10,9 +10,11 @@ import com.truve.platform.common.exception.CustomException;
 import com.truve.platform.common.exception.ErrorCode;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Component
 @RequiredArgsConstructor
+@Slf4j
 public class KafkaEventPublisher implements EventPublisher {
 
 	private final KafkaTemplate<String, String> kafkaTemplate;
@@ -22,6 +24,8 @@ public class KafkaEventPublisher implements EventPublisher {
 	public void publish(String topic, String key, Object event) {
 		try {
 			String payload = objectMapper.writeValueAsString(event);
+			log.info("[Kafka Publish] Start - Topic: {}, Key: {}, Payload: {}", topic, key, payload);
+			
 			kafkaTemplate.send(topic, key, payload);
 		} catch (JsonProcessingException exception) {
 			throw new CustomException(ErrorCode.EVENT_SERIALIZATION_FAILED);
@@ -34,6 +38,7 @@ public class KafkaEventPublisher implements EventPublisher {
 	public void publish(String topic, String key, String type, Object event) {
 		try {
 			String payload = objectMapper.writeValueAsString(event);
+			log.info("[Kafka Publish With Header] Topic: {}, event-type: {}, Payload: {}", topic, type, payload);
 
 			ProducerRecord<String, String> record = new ProducerRecord<>(topic, key, payload);
 			record.headers().add("event-type", type.getBytes());

--- a/payment/src/main/java/com/truve/platform/payment/service/controller/PaymentController.java
+++ b/payment/src/main/java/com/truve/platform/payment/service/controller/PaymentController.java
@@ -2,7 +2,6 @@ package com.truve.platform.payment.service.controller;
 
 import java.util.List;
 
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -29,12 +28,6 @@ import lombok.RequiredArgsConstructor;
 @RequestMapping("/api/payments")
 public class PaymentController {
 	private final PaymentService paymentService;
-
-	@Value("${app.frontend.success-url}")
-	private String successUrl;
-
-	@Value("${app.frontend.fail-url}")
-	private String failUrl;
 
 	@Operation(summary = "결제 정보 상세 조회", description = "주문 ID로 결제 정보를 조회합니다.")
 	@GetMapping("/{orderId}")

--- a/payment/src/main/java/com/truve/platform/payment/service/controller/PaymentController.java
+++ b/payment/src/main/java/com/truve/platform/payment/service/controller/PaymentController.java
@@ -42,7 +42,7 @@ public class PaymentController {
 
 	@Operation(summary = "결제 승인", description = "결제를 승인 처리합니다.")
 	@PostMapping("/confirm")
-	public ApiResult<PaymentResponse.OrderId> confirm(PaymentRequest.Confirm request) {
+	public ApiResult<PaymentResponse.OrderId> confirm(@RequestBody @Valid PaymentRequest.Confirm request) {
 		return ApiResult.ok(paymentService.confirm(request));
 	}
 

--- a/payment/src/main/java/com/truve/platform/payment/service/controller/PaymentController.java
+++ b/payment/src/main/java/com/truve/platform/payment/service/controller/PaymentController.java
@@ -8,7 +8,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.truve.platform.common.response.ApiResult;
@@ -42,13 +41,9 @@ public class PaymentController {
 	}
 
 	@Operation(summary = "결제 승인", description = "결제를 승인 처리합니다.")
-	@GetMapping("/confirm")
-	public ApiResult<PaymentResponse.OrderId> confirm(
-		@RequestParam String orderId,
-		@RequestParam String paymentKey,
-		@RequestParam Long amount
-	) {
-		return ApiResult.ok(paymentService.confirm(orderId, paymentKey, amount));
+	@PostMapping("/confirm")
+	public ApiResult<PaymentResponse.OrderId> confirm(PaymentRequest.Confirm request) {
+		return ApiResult.ok(paymentService.confirm(request));
 	}
 
 	@Operation(summary = "결제 취소",

--- a/payment/src/main/java/com/truve/platform/payment/service/controller/PaymentController.java
+++ b/payment/src/main/java/com/truve/platform/payment/service/controller/PaymentController.java
@@ -53,20 +53,14 @@ public class PaymentController {
 		return ApiResult.ok(paymentService.getBankList());
 	}
 
-	@Operation(summary = "결제 승인",
-		description = "Toss Payments에서 결제 요청 승인 후 successUrl로 호출하는 API입니다. 프론트엔드의 성공 페이지로 orderId를 담아 리다이렉트 합니다.")
+	@Operation(summary = "결제 승인", description = "결제를 승인 처리합니다.")
 	@GetMapping("/confirm")
-	@ApiResponse(responseCode = "302")
-	public ResponseEntity<Void> confirm(
+	public ApiResult<PaymentResponse.OrderId> confirm(
 		@RequestParam String orderId,
 		@RequestParam String paymentKey,
 		@RequestParam Long amount
 	) {
-		paymentService.confirm(orderId, paymentKey, amount);
-
-		return ResponseEntity.status(HttpStatus.FOUND)
-			.location(URI.create(successUrl + "?orderId=" + orderId))
-			.build();
+		return ApiResult.ok(paymentService.confirm(orderId, paymentKey, amount));
 	}
 
 	@Operation(summary = "결제 실패",

--- a/payment/src/main/java/com/truve/platform/payment/service/controller/PaymentController.java
+++ b/payment/src/main/java/com/truve/platform/payment/service/controller/PaymentController.java
@@ -1,11 +1,8 @@
 package com.truve.platform.payment.service.controller;
 
-import java.net.URI;
 import java.util.List;
 
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -14,7 +11,6 @@ import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.util.UriComponentsBuilder;
 
 import com.truve.platform.common.response.ApiResult;
 import com.truve.platform.payment.service.dto.PaymentRequest;
@@ -25,7 +21,6 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
@@ -61,27 +56,6 @@ public class PaymentController {
 		@RequestParam Long amount
 	) {
 		return ApiResult.ok(paymentService.confirm(orderId, paymentKey, amount));
-	}
-
-	@Operation(summary = "결제 실패",
-		description = "Toss Payments에서 결제 요청이 실패했을 때 failUrl로 호출하는 API입니다. 프론트엔드의 실패 페이지로 code, message, orderId를 담아 리다이렉트합니다.")
-	@GetMapping("/fail")
-	@ApiResponse(responseCode = "302")
-	public ResponseEntity<Void> fail(
-		@RequestParam String code,
-		@RequestParam String message,
-		@RequestParam String orderId
-	) {
-		String redirectUrl = UriComponentsBuilder.fromPath(failUrl)
-			.queryParam("code", code)
-			.queryParam("message", message)
-			.queryParam("orderId", orderId)
-			.build()
-			.toUriString();
-
-		return ResponseEntity.status(HttpStatus.FOUND)
-			.location(URI.create(redirectUrl))
-			.build();
 	}
 
 	@Operation(summary = "결제 취소",

--- a/payment/src/main/java/com/truve/platform/payment/service/dto/PaymentRequest.java
+++ b/payment/src/main/java/com/truve/platform/payment/service/dto/PaymentRequest.java
@@ -23,6 +23,19 @@ public class PaymentRequest {
 	@Getter
 	@AllArgsConstructor
 	@NoArgsConstructor
+	public static class Confirm {
+		@NotBlank
+		private String orderId;
+		@NotBlank
+		private String paymentKey;
+		@NotNull
+		@Positive
+		private Long amount;
+	}
+
+	@Getter
+	@AllArgsConstructor
+	@NoArgsConstructor
 	@Schema(name = "CancelRequest")
 	public static class Cancel {
 		@NotNull

--- a/payment/src/main/java/com/truve/platform/payment/service/dto/PaymentResponse.java
+++ b/payment/src/main/java/com/truve/platform/payment/service/dto/PaymentResponse.java
@@ -43,7 +43,7 @@ public class PaymentResponse {
 	@Getter
 	@AllArgsConstructor
 	public static class OrderId {
-		private final Long orderId;
+		private final String orderId;
 	}
 
 	@Getter

--- a/payment/src/main/java/com/truve/platform/payment/service/dto/PaymentResponse.java
+++ b/payment/src/main/java/com/truve/platform/payment/service/dto/PaymentResponse.java
@@ -41,6 +41,12 @@ public class PaymentResponse {
 	}
 
 	@Getter
+	@AllArgsConstructor
+	public static class OrderId {
+		private final Long orderId;
+	}
+
+	@Getter
 	@Builder
 	@Schema(name = "CancelResponse")
 	public static class Cancel {

--- a/payment/src/main/java/com/truve/platform/payment/service/event/PaymentUpdated.java
+++ b/payment/src/main/java/com/truve/platform/payment/service/event/PaymentUpdated.java
@@ -27,4 +27,19 @@ public class PaymentUpdated {
 			);
 		}
 	}
+
+	@Getter
+	@AllArgsConstructor
+	@NoArgsConstructor
+	public static class DepositReceived {
+		private String orderId;
+		private LocalDateTime approvedAt;
+
+		public static DepositReceived of(Payment payment) {
+			return new DepositReceived(
+				payment.getOrderId(),
+				payment.getApprovedAt()
+			);
+		}
+	}
 }

--- a/payment/src/main/java/com/truve/platform/payment/service/event/PaymentUpdated.java
+++ b/payment/src/main/java/com/truve/platform/payment/service/event/PaymentUpdated.java
@@ -1,0 +1,30 @@
+package com.truve.platform.payment.service.event;
+
+import java.time.LocalDateTime;
+
+import com.truve.platform.payment.service.domain.constant.PaymentStatus;
+import com.truve.platform.payment.service.domain.entity.Payment;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class PaymentUpdated {
+
+	@Getter
+	@AllArgsConstructor
+	@NoArgsConstructor
+	public static class Confirmed {
+		private String orderId;
+		private LocalDateTime approvedAt;
+		private PaymentStatus status;
+
+		public static Confirmed of(Payment payment) {
+			return new Confirmed(
+				payment.getOrderId(),
+				payment.getApprovedAt(),
+				payment.getStatus()
+			);
+		}
+	}
+}

--- a/payment/src/main/java/com/truve/platform/payment/service/event/PaymentUpdatedListener.java
+++ b/payment/src/main/java/com/truve/platform/payment/service/event/PaymentUpdatedListener.java
@@ -26,4 +26,14 @@ public class PaymentUpdatedListener {
 			)
 		);
 	}
+
+	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+	public void onDepositReceived(PaymentUpdated.DepositReceived event) {
+		bookingPublisher.publish(
+			new BookingEventCommand.DepositReceived(
+				event.getOrderId(),
+				event.getApprovedAt()
+			)
+		);
+	}
 }

--- a/payment/src/main/java/com/truve/platform/payment/service/event/PaymentUpdatedListener.java
+++ b/payment/src/main/java/com/truve/platform/payment/service/event/PaymentUpdatedListener.java
@@ -1,0 +1,29 @@
+package com.truve.platform.payment.service.event;
+
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import com.truve.platform.payment.service.domain.constant.PaymentStatus;
+import com.truve.platform.payment.service.external.kafka.BookingEventCommand;
+import com.truve.platform.payment.service.external.kafka.BookingPublisher;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class PaymentUpdatedListener {
+
+	private final BookingPublisher bookingPublisher;
+
+	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+	public void onConfirmed(PaymentUpdated.Confirmed event) {
+		bookingPublisher.publish(
+			new BookingEventCommand.Confirmed(
+				event.getOrderId(),
+				event.getApprovedAt(),
+				event.getStatus() == PaymentStatus.WAITING_FOR_DEPOSIT
+			)
+		);
+	}
+}

--- a/payment/src/main/java/com/truve/platform/payment/service/external/client/TossRequest.java
+++ b/payment/src/main/java/com/truve/platform/payment/service/external/client/TossRequest.java
@@ -16,6 +16,14 @@ public class TossRequest {
 		private String orderId;
 		private Long amount;
 		private String paymentKey;
+
+		public static Confirm of(PaymentRequest.Confirm request) {
+			return new Confirm(
+				request.getOrderId(),
+				request.getAmount(),
+				request.getPaymentKey()
+			);
+		}
 	}
 
 	@Getter

--- a/payment/src/main/java/com/truve/platform/payment/service/external/kafka/BookingEventCommand.java
+++ b/payment/src/main/java/com/truve/platform/payment/service/external/kafka/BookingEventCommand.java
@@ -3,6 +3,7 @@ package com.truve.platform.payment.service.external.kafka;
 import java.time.LocalDateTime;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import lombok.AllArgsConstructor;
@@ -11,14 +12,40 @@ import lombok.NoArgsConstructor;
 
 public class BookingEventCommand {
 
+	@JsonIgnoreProperties(value = {"eventType"})
+	public interface BookingEvent {
+		String getReservationNumber();
+
+		String getEventType();
+	}
+
 	@Getter
 	@AllArgsConstructor
 	@NoArgsConstructor
-	public static class Confirmed {
+	public static class Confirmed implements BookingEvent {
 		private String reservationNumber;
 		@JsonFormat(shape = JsonFormat.Shape.ARRAY)
 		private LocalDateTime paidAt;
 		@JsonProperty("depositPending")
 		private boolean isDepositPending;
+
+		@Override
+		public String getEventType() {
+			return "CONFIRMED";
+		}
+	}
+
+	@Getter
+	@AllArgsConstructor
+	@NoArgsConstructor
+	public static class DepositReceived implements BookingEvent {
+		private String reservationNumber;
+		@JsonFormat(shape = JsonFormat.Shape.ARRAY)
+		private LocalDateTime paidAt;
+
+		@Override
+		public String getEventType() {
+			return "DEPOSIT_RECEIVED";
+		}
 	}
 }

--- a/payment/src/main/java/com/truve/platform/payment/service/external/kafka/BookingEventCommand.java
+++ b/payment/src/main/java/com/truve/platform/payment/service/external/kafka/BookingEventCommand.java
@@ -1,0 +1,24 @@
+package com.truve.platform.payment.service.external.kafka;
+
+import java.time.LocalDateTime;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class BookingEventCommand {
+
+	@Getter
+	@AllArgsConstructor
+	@NoArgsConstructor
+	public static class Confirmed {
+		private String reservationNumber;
+		@JsonFormat(shape = JsonFormat.Shape.ARRAY)
+		private LocalDateTime paidAt;
+		@JsonProperty("depositPending")
+		private boolean isDepositPending;
+	}
+}

--- a/payment/src/main/java/com/truve/platform/payment/service/external/kafka/BookingPublisher.java
+++ b/payment/src/main/java/com/truve/platform/payment/service/external/kafka/BookingPublisher.java
@@ -1,0 +1,20 @@
+package com.truve.platform.payment.service.external.kafka;
+
+import org.springframework.stereotype.Component;
+
+import com.truve.platform.common.event.EventPublisher;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class BookingPublisher {
+	private static final String TOPIC = "payment.booking";
+	private static final String CONFIRMED_EVENT_TYPE = "CONFIRMED";
+
+	private final EventPublisher eventPublisher;
+
+	public void publish(BookingEventCommand.Confirmed command) {
+		eventPublisher.publish(TOPIC, command.getReservationNumber(), CONFIRMED_EVENT_TYPE, command);
+	}
+}

--- a/payment/src/main/java/com/truve/platform/payment/service/external/kafka/BookingPublisher.java
+++ b/payment/src/main/java/com/truve/platform/payment/service/external/kafka/BookingPublisher.java
@@ -10,11 +10,10 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class BookingPublisher {
 	private static final String TOPIC = "payment.booking";
-	private static final String CONFIRMED_EVENT_TYPE = "CONFIRMED";
 
 	private final EventPublisher eventPublisher;
 
-	public void publish(BookingEventCommand.Confirmed command) {
-		eventPublisher.publish(TOPIC, command.getReservationNumber(), CONFIRMED_EVENT_TYPE, command);
+	public void publish(BookingEventCommand.BookingEvent command) {
+		eventPublisher.publish(TOPIC, command.getReservationNumber(), command.getEventType(), command);
 	}
 }

--- a/payment/src/main/java/com/truve/platform/payment/service/service/PaymentService.java
+++ b/payment/src/main/java/com/truve/platform/payment/service/service/PaymentService.java
@@ -70,13 +70,13 @@ public class PaymentService {
 	}
 
 	@Transactional
-	public PaymentResponse.OrderId confirm(String orderId, String paymentKey, Long amount) {
-		Payment payment = paymentRepository.getByOrderIdWithLock(orderId);
+	public PaymentResponse.OrderId confirm(PaymentRequest.Confirm request) {
+		Payment payment = paymentRepository.getByOrderIdWithLock(request.getOrderId());
 
 		Preconditions.validate(payment.isNotDone(), ErrorCode.ALREADY_DONE_PAYMENT);
-		payment.validateAmount(amount);
+		payment.validateAmount(request.getAmount());
 
-		TossResponse.Payment response = tossClient.confirm(new TossRequest.Confirm(orderId, amount, paymentKey));
+		TossResponse.Payment response = tossClient.confirm(TossRequest.Confirm.of(request));
 
 		payment.confirm(
 			response.getPaymentKey(),

--- a/payment/src/main/java/com/truve/platform/payment/service/service/PaymentService.java
+++ b/payment/src/main/java/com/truve/platform/payment/service/service/PaymentService.java
@@ -5,6 +5,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.stream.Stream;
 
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
@@ -18,6 +19,7 @@ import com.truve.platform.payment.service.domain.entity.Payment;
 import com.truve.platform.payment.service.domain.entity.PaymentCancel;
 import com.truve.platform.payment.service.dto.PaymentRequest;
 import com.truve.platform.payment.service.dto.PaymentResponse;
+import com.truve.platform.payment.service.event.PaymentUpdated;
 import com.truve.platform.payment.service.external.client.TossClient;
 import com.truve.platform.payment.service.external.client.TossRequest;
 import com.truve.platform.payment.service.external.client.TossResponse;
@@ -37,6 +39,7 @@ public class PaymentService {
 	private final PaymentRepository paymentRepository;
 	private final PaymentCancelRepository paymentCancelRepository;
 	private final TossClient tossClient;
+	private final ApplicationEventPublisher eventPublisher;
 
 	@Transactional(readOnly = true)
 	public PaymentResponse.Details details(String orderId) {
@@ -84,6 +87,8 @@ public class PaymentService {
 			parseTime(response.getRequestedAt()),
 			parseTime(response.getApprovedAt())
 		);
+
+		eventPublisher.publishEvent(PaymentUpdated.Confirmed.of(payment));
 
 		return new PaymentResponse.OrderId(payment.getId());
 	}

--- a/payment/src/main/java/com/truve/platform/payment/service/service/PaymentService.java
+++ b/payment/src/main/java/com/truve/platform/payment/service/service/PaymentService.java
@@ -90,7 +90,7 @@ public class PaymentService {
 
 		eventPublisher.publishEvent(PaymentUpdated.Confirmed.of(payment));
 
-		return new PaymentResponse.OrderId(payment.getId());
+		return new PaymentResponse.OrderId(payment.getOrderId());
 	}
 
 	@Transactional
@@ -100,7 +100,7 @@ public class PaymentService {
 		Preconditions.validate(payment.isNotDone(), ErrorCode.ALREADY_DONE_PAYMENT);
 
 		payment.completeDeposit(parseTime(approvedAt));
-		
+
 		eventPublisher.publishEvent(PaymentUpdated.DepositReceived.of(payment));
 	}
 

--- a/payment/src/main/java/com/truve/platform/payment/service/service/PaymentService.java
+++ b/payment/src/main/java/com/truve/platform/payment/service/service/PaymentService.java
@@ -100,6 +100,8 @@ public class PaymentService {
 		Preconditions.validate(payment.isNotDone(), ErrorCode.ALREADY_DONE_PAYMENT);
 
 		payment.completeDeposit(parseTime(approvedAt));
+		
+		eventPublisher.publishEvent(PaymentUpdated.DepositReceived.of(payment));
 	}
 
 	@Transactional

--- a/payment/src/main/java/com/truve/platform/payment/service/service/PaymentService.java
+++ b/payment/src/main/java/com/truve/platform/payment/service/service/PaymentService.java
@@ -70,7 +70,7 @@ public class PaymentService {
 	}
 
 	@Transactional
-	public void confirm(String orderId, String paymentKey, Long amount) {
+	public PaymentResponse.OrderId confirm(String orderId, String paymentKey, Long amount) {
 		Payment payment = paymentRepository.getByOrderIdWithLock(orderId);
 
 		Preconditions.validate(payment.isNotDone(), ErrorCode.ALREADY_DONE_PAYMENT);
@@ -84,6 +84,8 @@ public class PaymentService {
 			parseTime(response.getRequestedAt()),
 			parseTime(response.getApprovedAt())
 		);
+
+		return new PaymentResponse.OrderId(payment.getId());
 	}
 
 	@Transactional

--- a/payment/src/main/resources/application.yml
+++ b/payment/src/main/resources/application.yml
@@ -31,8 +31,3 @@ toss:
   payment:
     secret-key: ${TOSS_SECRET_KEY:test_sk_tempKey}
     base-url: https://api.tosspayments.com/v1/payments/
-
-app:
-  frontend:
-    success-url: ${FRONT_SUCCESS_URL:/success-temp.html}
-    fail-url: ${FRONT_FAIL_URL:/fail-temp.html}

--- a/payment/src/main/resources/static/index.html
+++ b/payment/src/main/resources/static/index.html
@@ -109,25 +109,6 @@
         const method = document.getElementById('method').value;
 
         try {
-            console.log("1. 서버에 주문 정보 저장 중...");
-            const response = await fetch('/api/payments', {
-                method: 'POST',
-                headers: {'Content-Type': 'application/json'},
-                body: JSON.stringify({
-                    orderId: orderId,
-                    amount: amount,
-                    method: method
-                })
-            });
-
-            if (!response.ok) {
-                const errorData = await response.text();
-                throw new Error('서버 주문 저장 실패: ' + errorData);
-            }
-
-            console.log("2. 서버 저장 완료! 토스 결제창 호출...");
-
-            // B. 토스 결제창 띄우기 (V2 Standard 방식)
             const payment = tossPayments.payment({
                 customerKey: "GUEST_" + Math.random().toString(36).substring(2, 11), // 비회원용 랜덤 키
             });

--- a/payment/src/test/java/com/truve/platform/payment/service/service/PaymentServiceTest.java
+++ b/payment/src/test/java/com/truve/platform/payment/service/service/PaymentServiceTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import com.truve.platform.payment.service.domain.constant.PaymentStatus;
@@ -35,6 +36,8 @@ class PaymentServiceTest {
 	private PaymentCancelRepository paymentCancelRepository;
 	@Mock
 	private TossClient tossClient;
+	@Mock
+	private ApplicationEventPublisher applicationEventPublisher;
 
 	@InjectMocks
 	private PaymentService paymentService;

--- a/payment/src/test/java/com/truve/platform/payment/service/service/PaymentServiceTest.java
+++ b/payment/src/test/java/com/truve/platform/payment/service/service/PaymentServiceTest.java
@@ -107,6 +107,8 @@ class PaymentServiceTest {
 			Payment payment = Payment.builder().orderId(orderId).amount(amount).build();
 			given(paymentRepository.getByOrderIdWithLock(orderId)).willReturn(payment);
 
+			PaymentRequest.Confirm request = new PaymentRequest.Confirm(orderId, "paymentKey", amount);
+
 			TossResponse.Payment tossResponse = mock(TossResponse.Payment.class);
 			given(tossResponse.getMethodDetailsEntity()).willReturn(
 				EasyPay.builder().provider("토스").discountAmount(0L).build());
@@ -115,7 +117,7 @@ class PaymentServiceTest {
 			given(tossClient.confirm(any())).willReturn(tossResponse);
 
 			// when
-			paymentService.confirm(orderId, "paymentKey", amount);
+			paymentService.confirm(request);
 
 			// then
 			assertThat(payment.getStatus()).isNotEqualTo(PaymentStatus.READY);

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/domain/constant/ReservationStatus.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/domain/constant/ReservationStatus.java
@@ -8,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 public enum ReservationStatus {
 	CREATED("생성"),
 	PENDING_PAYMENT("결제 진행 중"),
+	PENDING_DEPOSIT("입금대기"),
 	CONFIRMED("예매확정"),
 	COMPLETED("관람완료"),
 	PARTIAL_CANCELED("부분취소"),

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/domain/entity/Reservation.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/domain/entity/Reservation.java
@@ -7,9 +7,7 @@ import java.util.UUID;
 
 import org.truve.platform.ticketing.service.booking.domain.constant.ReservationStatus;
 
-import com.truve.platform.common.exception.ErrorCode;
 import com.truve.platform.common.support.BaseEntity;
-import com.truve.platform.common.support.Preconditions;
 
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
@@ -79,8 +77,6 @@ public class Reservation extends BaseEntity {
 	}
 
 	public void readyForPayment(Applicant applicant) {
-		Preconditions.validate(this.status == ReservationStatus.CREATED, ErrorCode.INVALID_RESERVATION_STATUS);
-
 		this.applicant = applicant;
 		this.status = ReservationStatus.PENDING_PAYMENT;
 	}

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/domain/entity/Reservation.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/domain/entity/Reservation.java
@@ -85,4 +85,9 @@ public class Reservation extends BaseEntity {
 		this.paidAt = paidAt;
 		this.status = isDepositPending ? ReservationStatus.PENDING_DEPOSIT : ReservationStatus.CONFIRMED;
 	}
+
+	public void depositReceive(LocalDateTime paidAt) {
+		this.paidAt = paidAt;
+		this.status = ReservationStatus.CONFIRMED;
+	}
 }

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/domain/entity/Reservation.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/domain/entity/Reservation.java
@@ -80,4 +80,9 @@ public class Reservation extends BaseEntity {
 		this.applicant = applicant;
 		this.status = ReservationStatus.PENDING_PAYMENT;
 	}
+
+	public void confirm(LocalDateTime paidAt, boolean isDepositPending) {
+		this.paidAt = paidAt;
+		this.status = isDepositPending ? ReservationStatus.PENDING_DEPOSIT : ReservationStatus.CONFIRMED;
+	}
 }

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/external/kafka/BookingEventCommand.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/external/kafka/BookingEventCommand.java
@@ -3,6 +3,7 @@ package org.truve.platform.ticketing.service.booking.external.kafka;
 import java.time.LocalDateTime;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import lombok.AllArgsConstructor;
@@ -11,15 +12,41 @@ import lombok.NoArgsConstructor;
 
 public class BookingEventCommand {
 
+	@JsonIgnoreProperties(value = {"eventType"})
+	public interface BookingEvent {
+		String getReservationNumber();
+
+		String getEventType();
+	}
+
 	@Getter
 	@AllArgsConstructor
 	@NoArgsConstructor
-	public static class Confirmed {
+	public static class Confirmed implements BookingEvent {
 		private String reservationNumber;
 		@JsonFormat(shape = JsonFormat.Shape.ARRAY)
 		private LocalDateTime paidAt;
 		@JsonProperty("depositPending")
 		private boolean isDepositPending;
+
+		@Override
+		public String getEventType() {
+			return "CONFIRMED";
+		}
+	}
+
+	@Getter
+	@AllArgsConstructor
+	@NoArgsConstructor
+	public static class DepositReceived implements BookingEvent {
+		private String reservationNumber;
+		@JsonFormat(shape = JsonFormat.Shape.ARRAY)
+		private LocalDateTime paidAt;
+
+		@Override
+		public String getEventType() {
+			return "DEPOSIT_RECEIVED";
+		}
 	}
 }
 

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/external/kafka/BookingEventCommand.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/external/kafka/BookingEventCommand.java
@@ -1,0 +1,25 @@
+package org.truve.platform.ticketing.service.booking.external.kafka;
+
+import java.time.LocalDateTime;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class BookingEventCommand {
+
+	@Getter
+	@AllArgsConstructor
+	@NoArgsConstructor
+	public static class Confirmed {
+		private String reservationNumber;
+		@JsonFormat(shape = JsonFormat.Shape.ARRAY)
+		private LocalDateTime paidAt;
+		@JsonProperty("depositPending")
+		private boolean isDepositPending;
+	}
+}
+

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/external/kafka/PaymentConsumer.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/external/kafka/PaymentConsumer.java
@@ -23,12 +23,10 @@ public class PaymentConsumer {
 	@KafkaListener(topics = TOPIC, groupId = GROUP)
 	public void consume(String payload, @Header("event-type") String type) {
 		switch (type) {
-			case "CONFIRMED" -> handleConfirmed(payload);
+			case "CONFIRMED" -> bookingService.confirm(jsonConverter.convert(payload, BookingEventCommand.Confirmed.class));
+			case "DEPOSIT_RECEIVED" ->
+				bookingService.depositReceive(jsonConverter.convert(payload, BookingEventCommand.DepositReceived.class));
+			default -> log.warn("[Kafka Consumer] Unknown event type: {}", type);
 		}
-	}
-
-	private void handleConfirmed(String payload) {
-		BookingEventCommand.Confirmed request = jsonConverter.convert(payload, BookingEventCommand.Confirmed.class);
-		bookingService.confirm(request);
 	}
 }

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/external/kafka/PaymentConsumer.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/external/kafka/PaymentConsumer.java
@@ -1,0 +1,34 @@
+package org.truve.platform.ticketing.service.booking.external.kafka;
+
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.messaging.handler.annotation.Header;
+import org.springframework.stereotype.Component;
+import org.truve.platform.ticketing.service.booking.service.BookingService;
+
+import com.truve.platform.common.support.JsonConverter;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class PaymentConsumer {
+	public static final String TOPIC = "payment.booking";
+	public static final String GROUP = "payment-booking-group";
+
+	private final JsonConverter jsonConverter;
+	private final BookingService bookingService;
+
+	@KafkaListener(topics = TOPIC, groupId = GROUP)
+	public void consume(String payload, @Header("event-type") String type) {
+		switch (type) {
+			case "CONFIRMED" -> handleConfirmed(payload);
+		}
+	}
+
+	private void handleConfirmed(String payload) {
+		BookingEventCommand.Confirmed request = jsonConverter.convert(payload, BookingEventCommand.Confirmed.class);
+		bookingService.confirm(request);
+	}
+}

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/service/BookingService.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/service/BookingService.java
@@ -106,4 +106,10 @@ public class BookingService {
 		Reservation reservation = reservationRepository.findByNumber(event.getReservationNumber());
 		reservation.confirm(event.getPaidAt(), event.isDepositPending());
 	}
+
+	@Transactional
+	public void depositReceive(BookingEventCommand.DepositReceived event) {
+		Reservation reservation = reservationRepository.findByNumber(event.getReservationNumber());
+		reservation.depositReceive(event.getPaidAt());
+	}
 }

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/service/BookingService.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/service/BookingService.java
@@ -13,6 +13,7 @@ import org.truve.platform.ticketing.service.booking.dto.BookingRequest;
 import org.truve.platform.ticketing.service.booking.dto.BookingResponse;
 import org.truve.platform.ticketing.service.booking.external.client.TicketingClient;
 import org.truve.platform.ticketing.service.booking.external.client.TicketingResponse;
+import org.truve.platform.ticketing.service.booking.external.kafka.BookingEventCommand;
 import org.truve.platform.ticketing.service.booking.external.kafka.PaymentEventCommand;
 import org.truve.platform.ticketing.service.booking.external.kafka.PaymentPublisher;
 import org.truve.platform.ticketing.service.booking.repository.ReservationRepository;
@@ -98,5 +99,11 @@ public class BookingService {
 		reservation.readyForPayment(request.toEntity());
 
 		paymentPublisher.publish(PaymentEventCommand.Create.of(reservation));
+	}
+
+	@Transactional
+	public void confirm(BookingEventCommand.Confirmed event) {
+		Reservation reservation = reservationRepository.findByNumber(event.getReservationNumber());
+		reservation.confirm(event.getPaidAt(), event.isDepositPending());
 	}
 }


### PR DESCRIPTION
## 변경 사항

---
### 결제 승인 (Confirm) 로직 변경

- 프론트 리다이렉트 로직을 제거하고 주문 ID를 반환하도록 변경했습니다.
- 리다이렉트 로직이 삭제됨에 따라 /fail API 삭제 및 URL 설정 삭제 처리했습니다.
- 요청 데이터 타입을 JSON으로 변경했습니다.
- 결제 승인 이후 Booking 서버에 상태 변화 이벤트 발행 및 소비 로직을 구현했습니다.

### 입금 완료 로직 변경

- 입금 완료시 Booking 서버에 상태 변화 이벤트 발행 및 소비 로직을 구현했습니다.

### KafkaEventPublisher 로깅 추가

- 이벤트 발행시 Topic, Key, event-type(Header), Payload를 로깅하는 코드를 추가했습니다.
 
- [x] 전체 테스트 코드 성공 여부

## 관련 이슈

---
- Notion Ticket: # 67

## 참고사항 (선택)

---
구조가 좀 복잡해져서 리뷰 참고사항 남깁니다.

Payment 상태 변경시 바로 Kafka BookingEvent를 발행하지 않고 내부 이벤트(`PaymentUpdated`)를 거쳐 발행하도록 구현했습니다!

1. Transaction Commit 이후에 Kafka 상태 변경 이벤트를 발행하기 위함
2. 결제 비즈니스 로직과 외부 통신 분리 
3. 추후 카프카 관련 DTO 분리를 대비해 결합도를 가능한 낮추기 위함

개발하다가 생각이 많아져서 새로운 시도도 많이 하고 코드가 좀 난해해진 거 같은데.. 차차 개선해보겠습니다..

