### PR TITLE
feat(review): 리뷰 작성 API 로직 구현

### DIFF
--- a/common/src/main/java/com/truve/platform/common/exception/ErrorCode.java
+++ b/common/src/main/java/com/truve/platform/common/exception/ErrorCode.java
@@ -54,6 +54,10 @@ public enum ErrorCode {
 	NOT_FOUND_ARTIST(HttpStatus.NOT_FOUND, "존재하지 않는 배우입니다.", "M02"),
 	ALREADY_LIKED_ARTIST(HttpStatus.BAD_REQUEST, "이미 좋아요한 배우입니다.", "M03"),
 
+	ALREADY_EXIST_REVIEW(HttpStatus.BAD_REQUEST, "이미 유저가 리뷰를 작성했습니다.", "MR01"),
+	NOT_CHARM_POINT(HttpStatus.BAD_REQUEST, "매력 포인트가 아닙니다.", "MR02"),
+	NOT_EMOTION_POINT(HttpStatus.BAD_REQUEST, "감정 포인트가 아닙니다.", "MR03"),
+
 	EVENT_SERIALIZATION_FAILED(HttpStatus.BAD_REQUEST, "이벤트 직렬화 오류입니다.", "I01"),
 	EVENT_PUBLISH_FAILED(HttpStatus.BAD_REQUEST, "이벤트 발행 실패입니다.", "I02"),
 	EVENT_USER_SIGNED_UP_FAILED(HttpStatus.BAD_REQUEST, "유저 회원가입 이벤트 소비 실패입니다.", "I03"),

--- a/musical/src/main/java/com/truve/platform/musical/review/controller/ReviewController.java
+++ b/musical/src/main/java/com/truve/platform/musical/review/controller/ReviewController.java
@@ -1,0 +1,40 @@
+package com.truve.platform.musical.review.controller;
+
+import java.util.UUID;
+
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.truve.platform.common.response.ApiResult;
+import com.truve.platform.musical.review.dto.ReviewRequest;
+import com.truve.platform.musical.review.service.ReviewService;
+
+import io.swagger.v3.oas.annotations.Parameter;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/musical/review")
+public class ReviewController {
+
+	private static final String USER_ID_HEADER = "X-User-Id";
+
+	private final ReviewService reviewService;
+
+	@PostMapping("/{showId}")
+	public ApiResult<Void> create(
+		@Parameter(hidden = true)
+		@RequestHeader(value = USER_ID_HEADER) UUID userId,
+		@PathVariable	Long showId,
+		@RequestBody @Valid ReviewRequest.Create request
+	) {
+		reviewService.create(userId, showId, request);
+		return ApiResult.ok();
+	}
+
+}

--- a/musical/src/main/java/com/truve/platform/musical/review/domain/constant/ReviewPointName.java
+++ b/musical/src/main/java/com/truve/platform/musical/review/domain/constant/ReviewPointName.java
@@ -1,0 +1,25 @@
+package com.truve.platform.musical.review.domain.constant;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public enum ReviewPointName {
+
+	STAGE_PRODUCTION(ReviewPointCategory.CHARM, "무대연출"),
+	STORY(ReviewPointCategory.CHARM, "스토리"),
+	ACTING(ReviewPointCategory.CHARM, "배우연기"),
+	DANCE(ReviewPointCategory.CHARM, "안무"),
+	NUMBER(ReviewPointCategory.CHARM, "넘버"),
+
+	IMMERSION(ReviewPointCategory.EMOTION, "몰입감"),
+	TENSION(ReviewPointCategory.EMOTION, "텐션"),
+	ENJOYMENT(ReviewPointCategory.EMOTION, "즐거움"),
+	CATHARSIS(ReviewPointCategory.EMOTION, "카타르시스"),
+	TOUCHING(ReviewPointCategory.EMOTION, "감동"),
+	;
+
+	private final ReviewPointCategory category;
+	private final String label;
+}

--- a/musical/src/main/java/com/truve/platform/musical/review/domain/constant/ReviewPointName.java
+++ b/musical/src/main/java/com/truve/platform/musical/review/domain/constant/ReviewPointName.java
@@ -24,4 +24,12 @@ public enum ReviewPointName {
 	private final String label;
 	private final String code;
 	private final Long order;
+
+	public boolean isCharmPoint() {
+		return this.category == ReviewPointCategory.CHARM;
+	}
+
+	public boolean isEmotionPoint() {
+		return this.category == ReviewPointCategory.EMOTION;
+	}
 }

--- a/musical/src/main/java/com/truve/platform/musical/review/domain/constant/ReviewPointName.java
+++ b/musical/src/main/java/com/truve/platform/musical/review/domain/constant/ReviewPointName.java
@@ -7,19 +7,21 @@ import lombok.RequiredArgsConstructor;
 @Getter
 public enum ReviewPointName {
 
-	STAGE_PRODUCTION(ReviewPointCategory.CHARM, "무대연출"),
-	STORY(ReviewPointCategory.CHARM, "스토리"),
-	ACTING(ReviewPointCategory.CHARM, "배우연기"),
-	DANCE(ReviewPointCategory.CHARM, "안무"),
-	NUMBER(ReviewPointCategory.CHARM, "넘버"),
+	STAGE_PRODUCTION(ReviewPointCategory.CHARM, "무대연출", "C01", 1L),
+	STORY(ReviewPointCategory.CHARM, "스토리", "C02", 2L),
+	ACTING(ReviewPointCategory.CHARM, "배우연기", "C03", 3L),
+	DANCE(ReviewPointCategory.CHARM, "안무", "C04", 4L),
+	NUMBER(ReviewPointCategory.CHARM, "넘버", "C05", 5L),
 
-	IMMERSION(ReviewPointCategory.EMOTION, "몰입감"),
-	TENSION(ReviewPointCategory.EMOTION, "텐션"),
-	ENJOYMENT(ReviewPointCategory.EMOTION, "즐거움"),
-	CATHARSIS(ReviewPointCategory.EMOTION, "카타르시스"),
-	TOUCHING(ReviewPointCategory.EMOTION, "감동"),
+	IMMERSION(ReviewPointCategory.EMOTION, "몰입감", "E01", 1L),
+	TENSION(ReviewPointCategory.EMOTION, "텐션", "E02", 2L),
+	ENJOYMENT(ReviewPointCategory.EMOTION, "즐거움", "E03", 3L),
+	CATHARSIS(ReviewPointCategory.EMOTION, "카타르시스", "E04", 4L),
+	TOUCHING(ReviewPointCategory.EMOTION, "감동", "E05", 5L),
 	;
 
 	private final ReviewPointCategory category;
 	private final String label;
+	private final String code;
+	private final Long order;
 }

--- a/musical/src/main/java/com/truve/platform/musical/review/domain/entity/ReviewPoint.java
+++ b/musical/src/main/java/com/truve/platform/musical/review/domain/entity/ReviewPoint.java
@@ -1,7 +1,6 @@
 package com.truve.platform.musical.review.domain.entity;
 
 import com.truve.platform.common.support.BaseEntity;
-import com.truve.platform.musical.review.domain.constant.ReviewPointName;
 
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.persistence.Entity;
@@ -32,7 +31,7 @@ public class ReviewPoint extends BaseEntity {
 		this.reviewPointType = reviewPointType;
 	}
 
-	public static ReviewPoint of(Review review, ReviewPointType reviewPointType) {
+	public static ReviewPoint create(Review review, ReviewPointType reviewPointType) {
 		return ReviewPoint.builder()
 			.review(review)
 			.reviewPointType(reviewPointType)

--- a/musical/src/main/java/com/truve/platform/musical/review/domain/entity/ReviewPoint.java
+++ b/musical/src/main/java/com/truve/platform/musical/review/domain/entity/ReviewPoint.java
@@ -1,12 +1,14 @@
 package com.truve.platform.musical.review.domain.entity;
 
 import com.truve.platform.common.support.BaseEntity;
+import com.truve.platform.musical.review.domain.constant.ReviewPointName;
 
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.persistence.Entity;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -23,4 +25,17 @@ public class ReviewPoint extends BaseEntity {
 	@ManyToOne
 	@JoinColumn(name = "review_point_type_id")
 	private ReviewPointType reviewPointType;
+
+	@Builder
+	private ReviewPoint(Review review, ReviewPointType reviewPointType) {
+		this.review = review;
+		this.reviewPointType = reviewPointType;
+	}
+
+	public static ReviewPoint of(Review review, ReviewPointType reviewPointType) {
+		return ReviewPoint.builder()
+			.review(review)
+			.reviewPointType(reviewPointType)
+			.build();
+	}
 }

--- a/musical/src/main/java/com/truve/platform/musical/review/domain/entity/ReviewPointType.java
+++ b/musical/src/main/java/com/truve/platform/musical/review/domain/entity/ReviewPointType.java
@@ -26,7 +26,7 @@ public class ReviewPointType extends BaseEntity {
 
 	@Column(nullable = false)
 	@Enumerated(EnumType.STRING)
-	private ReviewPointName name;
+	private ReviewPointName point;
 
 	@Column(nullable = false)
 	private String code;
@@ -35,10 +35,18 @@ public class ReviewPointType extends BaseEntity {
 	private Long order;
 
 	@Builder
-	public ReviewPointType(ReviewPointCategory category, ReviewPointName name, String code, Long order) {
-		this.category = category;
-		this.name = name;
-		this.code = code;
-		this.order = order;
+	public ReviewPointType(ReviewPointName point) {
+		this.category = point.getCategory();
+		this.point = point;
+		this.code = point.getCode();
+		this.order = point.getOrder();
+	}
+
+	public boolean isEmotionPoint() {
+		return this.category ==  ReviewPointCategory.EMOTION;
+	}
+
+	public boolean isCharmPoint() {
+		return this.category ==   ReviewPointCategory.CHARM;
 	}
 }

--- a/musical/src/main/java/com/truve/platform/musical/review/domain/entity/ReviewPointType.java
+++ b/musical/src/main/java/com/truve/platform/musical/review/domain/entity/ReviewPointType.java
@@ -10,7 +10,6 @@ import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -34,19 +33,11 @@ public class ReviewPointType extends BaseEntity {
 	@Column(nullable = false)
 	private Long order;
 
-	@Builder
-	public ReviewPointType(ReviewPointName point) {
-		this.category = point.getCategory();
-		this.point = point;
-		this.code = point.getCode();
-		this.order = point.getOrder();
+	public boolean isEmotionPoint(ReviewPointName point) {
+		return ReviewPointCategory.EMOTION == point.getCategory();
 	}
 
-	public boolean isEmotionPoint() {
-		return this.category ==  ReviewPointCategory.EMOTION;
-	}
-
-	public boolean isCharmPoint() {
-		return this.category ==   ReviewPointCategory.CHARM;
+	public boolean isCharmPoint(ReviewPointName point) {
+		return ReviewPointCategory.CHARM == point.getCategory();
 	}
 }

--- a/musical/src/main/java/com/truve/platform/musical/review/domain/entity/ReviewPointType.java
+++ b/musical/src/main/java/com/truve/platform/musical/review/domain/entity/ReviewPointType.java
@@ -2,6 +2,7 @@ package com.truve.platform.musical.review.domain.entity;
 
 import com.truve.platform.common.support.BaseEntity;
 import com.truve.platform.musical.review.domain.constant.ReviewPointCategory;
+import com.truve.platform.musical.review.domain.constant.ReviewPointName;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -24,7 +25,8 @@ public class ReviewPointType extends BaseEntity {
 	private ReviewPointCategory category;
 
 	@Column(nullable = false)
-	private String name;
+	@Enumerated(EnumType.STRING)
+	private ReviewPointName name;
 
 	@Column(nullable = false)
 	private String code;
@@ -33,7 +35,7 @@ public class ReviewPointType extends BaseEntity {
 	private Long order;
 
 	@Builder
-	public ReviewPointType(ReviewPointCategory category, String name, String code, Long order) {
+	public ReviewPointType(ReviewPointCategory category, ReviewPointName name, String code, Long order) {
 		this.category = category;
 		this.name = name;
 		this.code = code;

--- a/musical/src/main/java/com/truve/platform/musical/review/domain/entity/ReviewPointType.java
+++ b/musical/src/main/java/com/truve/platform/musical/review/domain/entity/ReviewPointType.java
@@ -33,11 +33,11 @@ public class ReviewPointType extends BaseEntity {
 	@Column(nullable = false)
 	private Long order;
 
-	public boolean isEmotionPoint(ReviewPointName point) {
-		return ReviewPointCategory.EMOTION == point.getCategory();
+	public boolean isEmotionPoint() {
+		return this.category == ReviewPointCategory.EMOTION;
 	}
 
 	public boolean isCharmPoint(ReviewPointName point) {
-		return ReviewPointCategory.CHARM == point.getCategory();
+		return this.category ==  ReviewPointCategory.CHARM;
 	}
 }

--- a/musical/src/main/java/com/truve/platform/musical/review/dto/ReviewRequest.java
+++ b/musical/src/main/java/com/truve/platform/musical/review/dto/ReviewRequest.java
@@ -1,0 +1,34 @@
+package com.truve.platform.musical.review.dto;
+
+import java.util.List;
+
+import com.truve.platform.musical.review.domain.constant.ReviewPointName;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+public class ReviewRequest {
+
+	@AllArgsConstructor
+	@Getter
+	public static class Create {
+
+		@NotNull
+		Boolean isPositive;
+
+		@NotNull
+		@Size(min = 1, max = 5)
+		List<ReviewPointName> emotionPoints;
+
+		@NotNull
+		@Size(min = 1, max = 5)
+		List<ReviewPointName> charmPoints;
+
+		@NotBlank
+		String content;
+
+	}
+}

--- a/musical/src/main/java/com/truve/platform/musical/review/repository/ReviewPointTypeRepository.java
+++ b/musical/src/main/java/com/truve/platform/musical/review/repository/ReviewPointTypeRepository.java
@@ -1,8 +1,12 @@
 package com.truve.platform.musical.review.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import com.truve.platform.musical.review.domain.constant.ReviewPointName;
 import com.truve.platform.musical.review.domain.entity.ReviewPointType;
 
 public interface ReviewPointTypeRepository extends JpaRepository<ReviewPointType, Long> {
+	Optional<ReviewPointType> findByPoint(ReviewPointName name);
 }

--- a/musical/src/main/java/com/truve/platform/musical/review/repository/ReviewRepository.java
+++ b/musical/src/main/java/com/truve/platform/musical/review/repository/ReviewRepository.java
@@ -1,8 +1,12 @@
 package com.truve.platform.musical.review.repository;
 
+import java.util.UUID;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.truve.platform.musical.review.domain.entity.Review;
 
 public interface ReviewRepository extends JpaRepository<Review, Long> {
+
+	boolean existsByUserIdAndShowId(UUID userId,  Long showId);
 }

--- a/musical/src/main/java/com/truve/platform/musical/review/service/ReviewService.java
+++ b/musical/src/main/java/com/truve/platform/musical/review/service/ReviewService.java
@@ -11,6 +11,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.truve.platform.common.exception.CustomException;
 import com.truve.platform.common.exception.ErrorCode;
 import com.truve.platform.common.support.Preconditions;
+import com.truve.platform.musical.review.domain.constant.ReviewPointName;
 import com.truve.platform.musical.review.domain.entity.Review;
 import com.truve.platform.musical.review.domain.entity.ReviewPoint;
 import com.truve.platform.musical.review.domain.entity.ReviewPointType;
@@ -38,19 +39,8 @@ public class ReviewService {
 			ErrorCode.ALREADY_EXIST_REVIEW
 		);
 
-		List<ReviewPointType> emotionPoints = request.getEmotionPoints().stream()
-			.map(emotionPoint -> {
-			Preconditions.validate(emotionPoint.isEmotionPoint(), ErrorCode.NOT_EMOTION_POINT);
-			return reviewPointTypeRepository.findByPoint(emotionPoint)
-				.orElseThrow(() -> new CustomException(ErrorCode.NOT_EMOTION_POINT));
-			}).toList();
-
-		List<ReviewPointType> charmPoints = request.getCharmPoints().stream()
-			.map(charmPoint -> {
-				Preconditions.validate(charmPoint.isCharmPoint(), ErrorCode.NOT_CHARM_POINT);
-				return reviewPointTypeRepository.findByPoint(charmPoint)
-					.orElseThrow(() -> new CustomException(ErrorCode.NOT_CHARM_POINT));
-			}).toList();
+		List<ReviewPointType> emotionPoints = getEmotionPoints(request.getCharmPoints());
+		List<ReviewPointType> charmPoints = getCharmPoints(request.getEmotionPoints());
 
 
 		Review review = Review.builder().
@@ -68,13 +58,33 @@ public class ReviewService {
 
 
 		emotionPoints.forEach(emotionPoint -> {
-			reviewPoints.add(ReviewPoint.of(savedReview, emotionPoint));
+			reviewPoints.add(ReviewPoint.create(savedReview, emotionPoint));
 		});
 
 		charmPoints.forEach(charmPoint -> {
-			reviewPoints.add(ReviewPoint.of(savedReview, charmPoint));
+			reviewPoints.add(ReviewPoint.create(savedReview, charmPoint));
 		});
 
 		reviewPointRepository.saveAll(reviewPoints);
 	}
+
+
+	private List<ReviewPointType> getCharmPoints(List<ReviewPointName> charmPoints) {
+		return charmPoints.stream()
+			.map(charmPoint -> {
+				Preconditions.validate(charmPoint.isCharmPoint(), ErrorCode.NOT_CHARM_POINT);
+				return reviewPointTypeRepository.findByPoint(charmPoint)
+					.orElseThrow(() -> new CustomException(ErrorCode.NOT_CHARM_POINT));
+			}).toList();
+	}
+
+	private List<ReviewPointType> getEmotionPoints(List<ReviewPointName> emotionPoints) {
+		return emotionPoints.stream()
+			.map(emotionPoint -> {
+				Preconditions.validate(emotionPoint.isEmotionPoint(), ErrorCode.NOT_EMOTION_POINT);
+				return reviewPointTypeRepository.findByPoint(emotionPoint)
+					.orElseThrow(() -> new CustomException(ErrorCode.NOT_EMOTION_POINT));
+			}).toList();
+	}
+
 }

--- a/musical/src/main/java/com/truve/platform/musical/review/service/ReviewService.java
+++ b/musical/src/main/java/com/truve/platform/musical/review/service/ReviewService.java
@@ -1,0 +1,80 @@
+package com.truve.platform.musical.review.service;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.truve.platform.common.exception.CustomException;
+import com.truve.platform.common.exception.ErrorCode;
+import com.truve.platform.common.support.Preconditions;
+import com.truve.platform.musical.review.domain.entity.Review;
+import com.truve.platform.musical.review.domain.entity.ReviewPoint;
+import com.truve.platform.musical.review.domain.entity.ReviewPointType;
+import com.truve.platform.musical.review.dto.ReviewRequest;
+import com.truve.platform.musical.review.repository.ReviewPointRepository;
+import com.truve.platform.musical.review.repository.ReviewPointTypeRepository;
+import com.truve.platform.musical.review.repository.ReviewRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class ReviewService {
+
+	private final ReviewRepository reviewRepository;
+	private final ReviewPointTypeRepository reviewPointTypeRepository;
+	private final ReviewPointRepository reviewPointRepository;
+
+
+	@Transactional
+	public void create(UUID userId, Long showId, ReviewRequest.Create request) {
+
+		Preconditions.validate(
+			!reviewRepository.existsByUserIdAndShowId(userId, showId),
+			ErrorCode.ALREADY_EXIST_REVIEW
+		);
+
+		List<ReviewPointType> emotionPoints = request.getEmotionPoints().stream()
+			.map(emotionPoint -> {
+			Preconditions.validate(emotionPoint.isEmotionPoint(), ErrorCode.NOT_EMOTION_POINT);
+			return reviewPointTypeRepository.findByPoint(emotionPoint)
+				.orElseThrow(() -> new CustomException(ErrorCode.NOT_EMOTION_POINT));
+			}).toList();
+
+		List<ReviewPointType> charmPoints = request.getCharmPoints().stream()
+			.map(charmPoint -> {
+				Preconditions.validate(charmPoint.isCharmPoint(), ErrorCode.NOT_CHARM_POINT);
+				return reviewPointTypeRepository.findByPoint(charmPoint)
+					.orElseThrow(() -> new CustomException(ErrorCode.NOT_CHARM_POINT));
+			}).toList();
+
+
+		Review review = Review.builder().
+			showId(showId).
+			userId(userId).
+			content(request.getContent()).
+			isPositive(request.getIsPositive()).
+			// TODO: 티켓 및 예매 완료 시 연동
+				watchedAt(LocalDateTime.now()).
+			build();
+
+		Review savedReview =  reviewRepository.save(review);
+
+		List<ReviewPoint> reviewPoints = new ArrayList<>();
+
+
+		emotionPoints.forEach(emotionPoint -> {
+			reviewPoints.add(ReviewPoint.of(savedReview, emotionPoint));
+		});
+
+		charmPoints.forEach(charmPoint -> {
+			reviewPoints.add(ReviewPoint.of(savedReview, charmPoint));
+		});
+
+		reviewPointRepository.saveAll(reviewPoints);
+	}
+}

--- a/musical/src/main/java/com/truve/platform/musical/review/service/ReviewService.java
+++ b/musical/src/main/java/com/truve/platform/musical/review/service/ReviewService.java
@@ -39,8 +39,8 @@ public class ReviewService {
 			ErrorCode.ALREADY_EXIST_REVIEW
 		);
 
-		List<ReviewPointType> emotionPoints = getEmotionPoints(request.getCharmPoints());
-		List<ReviewPointType> charmPoints = getCharmPoints(request.getEmotionPoints());
+		List<ReviewPointType> emotionPoints = getEmotionPoints(request.getEmotionPoints());
+		List<ReviewPointType> charmPoints = getCharmPoints(request.getCharmPoints());
 
 
 		Review review = Review.builder().

--- a/musical/src/test/java/com/truve/platform/musical/review/controller/ReviewControllerTest.java
+++ b/musical/src/test/java/com/truve/platform/musical/review/controller/ReviewControllerTest.java
@@ -1,0 +1,49 @@
+package com.truve.platform.musical.review.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.truve.platform.common.response.ApiResult;
+import com.truve.platform.musical.review.domain.constant.ReviewPointName;
+import com.truve.platform.musical.review.dto.ReviewRequest;
+import com.truve.platform.musical.review.service.ReviewService;
+
+@ExtendWith(MockitoExtension.class)
+class ReviewControllerTest {
+
+	@Mock
+	private ReviewService reviewService;
+
+	@InjectMocks
+	private ReviewController reviewController;
+
+	@Test
+	@DisplayName("리뷰 생성 요청을 서비스에 위임하고 성공 응답을 반환한다.")
+	void 리뷰_생성_성공() {
+		UUID userId = UUID.fromString("11111111-1111-1111-1111-111111111111");
+		Long showId = 1L;
+		ReviewRequest.Create request = new ReviewRequest.Create(
+			true,
+			List.of(ReviewPointName.IMMERSION, ReviewPointName.TOUCHING),
+			List.of(ReviewPointName.STORY, ReviewPointName.ACTING),
+			"재밌게 봤어요"
+		);
+
+		ApiResult<Void> response = reviewController.create(userId, showId, request);
+
+		verify(reviewService).create(userId, showId, request);
+		assertThat(response.getCode()).isEqualTo("ok");
+		assertThat(response.getMessage()).isEqualTo("성공");
+		assertThat(response.getData()).isNull();
+	}
+}

--- a/musical/src/test/java/com/truve/platform/musical/review/domain/entity/ReviewPointTypeTest.java
+++ b/musical/src/test/java/com/truve/platform/musical/review/domain/entity/ReviewPointTypeTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import com.truve.platform.musical.review.domain.constant.ReviewPointCategory;
+import com.truve.platform.musical.review.domain.constant.ReviewPointName;
 
 class ReviewPointTypeTest {
 
@@ -14,17 +15,14 @@ class ReviewPointTypeTest {
 	@DisplayName("ReviewPointType을 생성한다.")
 	void 리뷰포인트타입_생성_성공() {
 		ReviewPointType reviewPointType = ReviewPointType.builder()
-			.category(ReviewPointCategory.CHARM)
-			.name("감동")
-			.code("TOUCHED")
-			.order(1L)
+			.point(ReviewPointName.TOUCHING)
 			.build();
 
 		assertAll(
 			() -> assertThat(reviewPointType.getCategory()).isEqualTo(ReviewPointCategory.CHARM),
-			() -> assertThat(reviewPointType.getName()).isEqualTo("감동"),
-			() -> assertThat(reviewPointType.getCode()).isEqualTo("TOUCHED"),
-			() -> assertThat(reviewPointType.getOrder()).isEqualTo(1L)
+			() -> assertThat(reviewPointType.getPoint()).isEqualTo("감동"),
+			() -> assertThat(reviewPointType.getCode()).isEqualTo("E05"),
+			() -> assertThat(reviewPointType.getOrder()).isEqualTo(5L)
 		);
 	}
 }

--- a/musical/src/test/java/com/truve/platform/musical/review/domain/entity/ReviewPointTypeTest.java
+++ b/musical/src/test/java/com/truve/platform/musical/review/domain/entity/ReviewPointTypeTest.java
@@ -27,7 +27,7 @@ class ReviewPointTypeTest {
 			() -> assertThat(reviewPointType.getCode()).isEqualTo("E05"),
 			() -> assertThat(reviewPointType.getOrder()).isEqualTo(5L),
 			() -> assertThat(reviewPointType.isEmotionPoint()).isTrue(),
-			() -> assertThat(reviewPointType.isCharmPoint(ReviewPointName.STORY)).isTrue()
+			() -> assertThat(reviewPointType.isCharmPoint(ReviewPointName.STORY)).isFalse()
 		);
 	}
 }

--- a/musical/src/test/java/com/truve/platform/musical/review/domain/entity/ReviewPointTypeTest.java
+++ b/musical/src/test/java/com/truve/platform/musical/review/domain/entity/ReviewPointTypeTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import com.truve.platform.musical.review.domain.constant.ReviewPointCategory;
 import com.truve.platform.musical.review.domain.constant.ReviewPointName;
@@ -14,15 +15,19 @@ class ReviewPointTypeTest {
 	@Test
 	@DisplayName("ReviewPointType을 생성한다.")
 	void 리뷰포인트타입_생성_성공() {
-		ReviewPointType reviewPointType = ReviewPointType.builder()
-			.point(ReviewPointName.TOUCHING)
-			.build();
+		ReviewPointType reviewPointType = new ReviewPointType();
+		ReflectionTestUtils.setField(reviewPointType, "category", ReviewPointCategory.EMOTION);
+		ReflectionTestUtils.setField(reviewPointType, "point", ReviewPointName.TOUCHING);
+		ReflectionTestUtils.setField(reviewPointType, "code", "E05");
+		ReflectionTestUtils.setField(reviewPointType, "order", 5L);
 
 		assertAll(
-			() -> assertThat(reviewPointType.getCategory()).isEqualTo(ReviewPointCategory.CHARM),
-			() -> assertThat(reviewPointType.getPoint()).isEqualTo("감동"),
+			() -> assertThat(reviewPointType.getCategory()).isEqualTo(ReviewPointCategory.EMOTION),
+			() -> assertThat(reviewPointType.getPoint()).isEqualTo(ReviewPointName.TOUCHING),
 			() -> assertThat(reviewPointType.getCode()).isEqualTo("E05"),
-			() -> assertThat(reviewPointType.getOrder()).isEqualTo(5L)
+			() -> assertThat(reviewPointType.getOrder()).isEqualTo(5L),
+			() -> assertThat(reviewPointType.isEmotionPoint(ReviewPointName.TOUCHING)).isTrue(),
+			() -> assertThat(reviewPointType.isCharmPoint(ReviewPointName.STORY)).isTrue()
 		);
 	}
 }

--- a/musical/src/test/java/com/truve/platform/musical/review/domain/entity/ReviewPointTypeTest.java
+++ b/musical/src/test/java/com/truve/platform/musical/review/domain/entity/ReviewPointTypeTest.java
@@ -26,7 +26,7 @@ class ReviewPointTypeTest {
 			() -> assertThat(reviewPointType.getPoint()).isEqualTo(ReviewPointName.TOUCHING),
 			() -> assertThat(reviewPointType.getCode()).isEqualTo("E05"),
 			() -> assertThat(reviewPointType.getOrder()).isEqualTo(5L),
-			() -> assertThat(reviewPointType.isEmotionPoint(ReviewPointName.TOUCHING)).isTrue(),
+			() -> assertThat(reviewPointType.isEmotionPoint()).isTrue(),
 			() -> assertThat(reviewPointType.isCharmPoint(ReviewPointName.STORY)).isTrue()
 		);
 	}

--- a/musical/src/test/java/com/truve/platform/musical/review/service/ReviewServiceTest.java
+++ b/musical/src/test/java/com/truve/platform/musical/review/service/ReviewServiceTest.java
@@ -1,0 +1,152 @@
+package com.truve.platform.musical.review.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.truve.platform.common.exception.CustomException;
+import com.truve.platform.common.exception.ErrorCode;
+import com.truve.platform.musical.review.domain.constant.ReviewPointName;
+import com.truve.platform.musical.review.domain.entity.Review;
+import com.truve.platform.musical.review.domain.entity.ReviewPoint;
+import com.truve.platform.musical.review.domain.entity.ReviewPointType;
+import com.truve.platform.musical.review.dto.ReviewRequest;
+import com.truve.platform.musical.review.repository.ReviewPointRepository;
+import com.truve.platform.musical.review.repository.ReviewPointTypeRepository;
+import com.truve.platform.musical.review.repository.ReviewRepository;
+
+@ExtendWith(MockitoExtension.class)
+class ReviewServiceTest {
+
+	@Mock
+	private ReviewRepository reviewRepository;
+	@Mock
+	private ReviewPointTypeRepository reviewPointTypeRepository;
+	@Mock
+	private ReviewPointRepository reviewPointRepository;
+
+	@InjectMocks
+	private ReviewService reviewService;
+
+	@Test
+	@DisplayName("리뷰 저장에 성공하면 카테고리를 저장한다.")
+	void 리뷰_저장_성공() {
+		UUID userId = UUID.fromString("11111111-1111-1111-1111-111111111111");
+		Long showId = 1L;
+		ReviewRequest.Create request = new ReviewRequest.Create(
+			true,
+			List.of(ReviewPointName.IMMERSION, ReviewPointName.TOUCHING),
+			List.of(ReviewPointName.STORY, ReviewPointName.ACTING),
+			"재밌게 봤어요"
+		);
+
+		ReviewPointType immersion = reviewPointType(ReviewPointName.IMMERSION);
+		ReviewPointType touching = reviewPointType(ReviewPointName.TOUCHING);
+		ReviewPointType story = reviewPointType(ReviewPointName.STORY);
+		ReviewPointType acting = reviewPointType(ReviewPointName.ACTING);
+
+		given(reviewRepository.existsByUserIdAndShowId(userId, showId)).willReturn(false);
+		given(reviewPointTypeRepository.findByPoint(ReviewPointName.IMMERSION)).willReturn(Optional.of(immersion));
+		given(reviewPointTypeRepository.findByPoint(ReviewPointName.TOUCHING)).willReturn(Optional.of(touching));
+		given(reviewPointTypeRepository.findByPoint(ReviewPointName.STORY)).willReturn(Optional.of(story));
+		given(reviewPointTypeRepository.findByPoint(ReviewPointName.ACTING)).willReturn(Optional.of(acting));
+		given(reviewRepository.save(any(Review.class))).willAnswer(invocation -> {
+			Review review = invocation.getArgument(0);
+			ReflectionTestUtils.setField(review, "id", 100L);
+			return review;
+		});
+
+		reviewService.create(userId, showId, request);
+
+		ArgumentCaptor<Review> reviewCaptor = ArgumentCaptor.forClass(Review.class);
+		ArgumentCaptor<List<ReviewPoint>> reviewPointsCaptor = ArgumentCaptor.forClass(List.class);
+
+		verify(reviewRepository).save(reviewCaptor.capture());
+		verify(reviewPointRepository).saveAll(reviewPointsCaptor.capture());
+
+		Review savedReview = reviewCaptor.getValue();
+		List<ReviewPoint> savedPoints = reviewPointsCaptor.getValue();
+
+		assertAll(
+			() -> assertThat(savedReview.getShowId()).isEqualTo(showId),
+			() -> assertThat(savedReview.getUserId()).isEqualTo(userId),
+			() -> assertThat(savedReview.getContent()).isEqualTo("재밌게 봤어요"),
+			() -> assertThat(savedReview.getIsPositive()).isTrue(),
+			() -> assertThat(savedReview.getWatchedAt()).isNotNull(),
+			() -> assertThat(savedPoints).hasSize(4),
+			() -> assertThat(savedPoints).extracting(point -> point.getReviewPointType().getPoint())
+				.containsExactly(ReviewPointName.IMMERSION, ReviewPointName.TOUCHING, ReviewPointName.STORY, ReviewPointName.ACTING)
+		);
+	}
+
+	@Test
+	@DisplayName("이미 같은 공연의 리뷰가 존재하면 예외가 발생한다.")
+	void 리뷰_중복_실패() {
+		UUID userId = UUID.fromString("11111111-1111-1111-1111-111111111111");
+		Long showId = 1L;
+		ReviewRequest.Create request = new ReviewRequest.Create(
+			true,
+			List.of(ReviewPointName.IMMERSION),
+			List.of(ReviewPointName.STORY),
+			"재밌게 봤어요"
+		);
+
+		given(reviewRepository.existsByUserIdAndShowId(userId, showId)).willReturn(true);
+
+		CustomException exception = assertThrows(
+			CustomException.class,
+			() -> reviewService.create(userId, showId, request)
+		);
+
+		assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.ALREADY_EXIST_REVIEW);
+		verify(reviewRepository, never()).save(any());
+		verify(reviewPointRepository, never()).saveAll(any());
+	}
+
+	@Test
+	@DisplayName("감정 포인트 자리에 매력 포인트가 들어오면 예외가 발생한다.")
+	void 감정포인트_검증_실패() {
+		UUID userId = UUID.fromString("11111111-1111-1111-1111-111111111111");
+		ReviewRequest.Create request = new ReviewRequest.Create(
+			true,
+			List.of(ReviewPointName.STORY),
+			List.of(ReviewPointName.ACTING),
+			"재밌게 봤어요"
+		);
+
+		given(reviewRepository.existsByUserIdAndShowId(userId, 1L)).willReturn(false);
+
+		CustomException exception = assertThrows(
+			CustomException.class,
+			() -> reviewService.create(userId, 1L, request)
+		);
+
+		assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.NOT_EMOTION_POINT);
+		verify(reviewRepository, never()).save(any());
+	}
+
+	private ReviewPointType reviewPointType(ReviewPointName point) {
+		ReviewPointType reviewPointType = mock(ReviewPointType.class);
+		when(reviewPointType.getPoint()).thenReturn(point);
+		return reviewPointType;
+	}
+}


### PR DESCRIPTION
## 변경 사항

추가/변경 사항과 사유를 작성해 주세요.

- [x] 전체 테스트 코드 성공 여부
- 서비스, 컨트롤러 테스트코드 작업해서 올리겠습니다.

### Review create API 구현
감정포인트/매력포인트로 구분된 것들이 다수 입력이 가능해 코드가 복잡해졌습니다.
리팩토링 가능한 부분들 금일 중으로 찾아보고 작업하겠습니다.

`ReviewPointType` 엔티티가 매핑이 되어야하지만, 주문-상품처럼 수시로 변경되는 것이 아니라
DB에 저장되어 변경이 거의 없을 값이라 enum과 책임이 모호해졌습니다. 이 부분도 좀 더 생각해볼게요!


## 관련 이슈

- Notion Ticket: [#69](https://www.notion.so/API-3209e3e335cc807082f9cf0ae80897b6?source=copy_link)

## 참고사항 (선택)

<img width="631" height="477" alt="image" src="https://github.com/user-attachments/assets/117d8c08-51d1-4cd7-9fa8-d2e456a70f88" />
