### PR TITLE
feat(reservation): 예매 서비스 수수료 추가

### DIFF
--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/domain/entity/Reservation.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/domain/entity/Reservation.java
@@ -38,6 +38,9 @@ public class Reservation extends BaseEntity {
 	private Long totalAmount;
 
 	@Column(nullable = false)
+	private Long serviceFee;
+
+	@Column(nullable = false)
 	private String gradeSummary;
 
 	@Column(nullable = false)
@@ -54,20 +57,22 @@ public class Reservation extends BaseEntity {
 	private List<Ticket> tickets = new ArrayList<>();
 
 	@Builder
-	private Reservation(UUID userId, String number, Long totalAmount, String gradeSummary) {
+	private Reservation(UUID userId, String number, Long totalAmount, Long serviceFee, String gradeSummary) {
 
 		this.userId = userId;
 		this.number = number;
 		this.totalAmount = totalAmount;
+		this.serviceFee = serviceFee;
 		this.gradeSummary = gradeSummary;
 		this.status = ReservationStatus.CREATED;
 	}
 
-	public static Reservation create(UUID userId, String number, Long totalAmount, String gradeSummary) {
+	public static Reservation create(UUID userId, String number, Long totalAmount, Long serviceFee, String gradeSummary) {
 		return Reservation.builder()
 			.userId(userId)
 			.number(number)
 			.totalAmount(totalAmount)
+			.serviceFee(serviceFee)
 			.gradeSummary(gradeSummary)
 			.build();
 	}

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/external/kafka/PaymentEventCommand.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/external/kafka/PaymentEventCommand.java
@@ -18,7 +18,7 @@ public class PaymentEventCommand {
 		public static Create of(Reservation reservation) {
 			return Create.builder()
 				.orderId(reservation.getNumber())
-				.amount(reservation.getTotalAmount())
+				.amount(reservation.getTotalAmount() + reservation.getServiceFee())
 				.build();
 		}
 	}

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/service/BookingService.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/service/BookingService.java
@@ -24,6 +24,7 @@ import lombok.RequiredArgsConstructor;
 @Service
 @RequiredArgsConstructor
 public class BookingService {
+	private static final Long TICKET_SERVICE_FEE = 2000L;
 	private static final String GRADE_SUMMARY_FORMAT = "%s석 %d인";
 	private static final String LINE_BREAK = "\n";
 	private static final String SEAT_DETAIL_FORMAT = "%d층 %s구역 %s열 %d번";
@@ -50,6 +51,7 @@ public class BookingService {
 			userId,
 			numberGenerator.generateReservationNumber(),
 			calculateTotalAmount(seatInfos),
+			TICKET_SERVICE_FEE * seatInfos.size(),
 			createGradeSummary(seatInfos)
 		);
 	}

--- a/ticketing/src/test/java/org/truve/platform/ticketing/service/booking/service/BookingServiceTest.java
+++ b/ticketing/src/test/java/org/truve/platform/ticketing/service/booking/service/BookingServiceTest.java
@@ -71,6 +71,7 @@ class BookingServiceTest {
 			() -> assertThat(savedReservation.getTotalAmount()).isEqualTo(60000L),
 			() -> assertThat(savedReservation.getGradeSummary()).isEqualTo("VIP석 2인\nS석 1인"),
 			() -> assertThat(savedReservation.getTickets()).hasSize(3),
+			() -> assertThat(savedReservation.getServiceFee()).isEqualTo(6000L),
 			() -> {
 				assertNotNull(savedReservation.getTickets());
 				assertThat(savedReservation.getTickets().getFirst().getNumber()).isEqualTo(ticketNumber1);


### PR DESCRIPTION
## 변경 사항

---
<img width="629" height="495" alt="스크린샷 2026-03-13 오후 3 56 01" src="https://github.com/user-attachments/assets/6c409d0a-d39d-4309-8479-c7aa1dd4c483" />

- `티켓 수량 * 2000`으로 계산된 총 서비스 수수료를 저장하는 로직을 추가했습니다.
- Payment 서버에 결제 요청을 보낼 때, 총 금액 + 수수료를 보내도록 변경했습니다.

- [x] 전체 테스트 코드 성공 여부

## 관련 이슈

---
- Notion Ticket: # 71

## 참고사항 (선택)

---