### PR TITLE
feat(reservation): Reservation 공연 정보 저장 구현

### DIFF
--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/domain/entity/Reservation.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/domain/entity/Reservation.java
@@ -48,6 +48,9 @@ public class Reservation extends BaseEntity {
 	private LocalDateTime paidAt;
 
 	@Embedded
+	private ShowInfo showInfo;
+
+	@Embedded
 	private Applicant applicant;
 
 	@OneToMany(mappedBy = "reservation", cascade = CascadeType.ALL)

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/domain/entity/Reservation.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/domain/entity/Reservation.java
@@ -57,21 +57,29 @@ public class Reservation extends BaseEntity {
 	private List<Ticket> tickets = new ArrayList<>();
 
 	@Builder
-	private Reservation(UUID userId, String number, Long totalAmount, String gradeSummary) {
+	private Reservation(UUID userId, String number, Long totalAmount, String gradeSummary, ShowInfo showInfo) {
 
 		this.userId = userId;
 		this.number = number;
 		this.totalAmount = totalAmount;
 		this.gradeSummary = gradeSummary;
+		this.showInfo = showInfo;
 		this.status = ReservationStatus.CREATED;
 	}
 
-	public static Reservation create(UUID userId, String number, Long totalAmount, String gradeSummary) {
+	public static Reservation create(
+		UUID userId,
+		String number,
+		Long totalAmount,
+		String gradeSummary,
+		ShowInfo showInfo
+	) {
 		return Reservation.builder()
 			.userId(userId)
 			.number(number)
 			.totalAmount(totalAmount)
 			.gradeSummary(gradeSummary)
+			.showInfo(showInfo)
 			.build();
 	}
 

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/domain/entity/ShowInfo.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/domain/entity/ShowInfo.java
@@ -20,7 +20,7 @@ public class ShowInfo {
 	@Column(nullable = false)
 	private String title;
 
-	@Column
+	@Column(nullable = false)
 	private String venueName;
 
 	@Column(nullable = false)

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/domain/entity/ShowInfo.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/domain/entity/ShowInfo.java
@@ -26,11 +26,15 @@ public class ShowInfo {
 	@Column(nullable = false)
 	private LocalDateTime startAt;
 
+	@Column(nullable = false)
+	private String posterImg;
+
 	@Builder
-	public ShowInfo(Long showId, String title, String venueName, LocalDateTime startAt) {
+	public ShowInfo(Long showId, String title, String venueName, LocalDateTime startAt, String posterImg) {
 		this.showId = showId;
 		this.title = title;
 		this.venueName = venueName;
 		this.startAt = startAt;
+		this.posterImg = posterImg;
 	}
 }

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/domain/entity/ShowInfo.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/domain/entity/ShowInfo.java
@@ -1,0 +1,36 @@
+package org.truve.platform.ticketing.service.booking.domain.entity;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class ShowInfo {
+
+	@Column(nullable = false)
+	private Long showId;
+
+	@Column(nullable = false)
+	private String title;
+
+	@Column
+	private String venueName;
+
+	@Column(nullable = false)
+	private LocalDateTime startAt;
+
+	@Builder
+	public ShowInfo(Long showId, String title, String venueName, LocalDateTime startAt) {
+		this.showId = showId;
+		this.title = title;
+		this.venueName = venueName;
+		this.startAt = startAt;
+	}
+}

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/domain/entity/Ticket.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/domain/entity/Ticket.java
@@ -36,6 +36,9 @@ public class Ticket extends BaseEntity {
 	private Long priceSnapshot;
 
 	@Column(nullable = false)
+	private String grade;
+
+	@Column(nullable = false)
 	private String seatDetail;
 
 	@Column(nullable = false)
@@ -46,18 +49,25 @@ public class Ticket extends BaseEntity {
 	private LocalDateTime usedAt;
 
 	@Builder
-	private Ticket(Reservation reservation, String number, Long priceSnapshot, String seatDetail) {
+	private Ticket(Reservation reservation, String number, String grade, Long priceSnapshot, String seatDetail) {
 		this.reservation = reservation;
 		this.number = number;
+		this.grade = grade;
 		this.priceSnapshot = priceSnapshot;
 		this.seatDetail = seatDetail;
 		this.status = TicketStatus.ISSUED;
 	}
 
-	public static Ticket create(Reservation reservation, String number, Long priceSnapshot, String seatDetail) {
+	public static Ticket create(
+		Reservation reservation,
+		String number,
+		String grade,
+		Long priceSnapshot,
+		String seatDetail) {
 		return Ticket.builder()
 			.reservation(reservation)
 			.number(number)
+			.grade(grade)
 			.priceSnapshot(priceSnapshot)
 			.seatDetail(seatDetail)
 			.build();

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/external/client/TicketingClient.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/external/client/TicketingClient.java
@@ -1,10 +1,11 @@
 package org.truve.platform.ticketing.service.booking.external.client;
 
+import static org.truve.platform.ticketing.service.booking.external.client.TicketingResponse.*;
+
 import java.util.List;
 
 import org.springframework.stereotype.Component;
-import org.truve.platform.ticketing.service.ticketing.domain.entity.Seat;
-import org.truve.platform.ticketing.service.ticketing.repository.SeatRepository;
+import org.truve.platform.ticketing.service.ticketing.repository.ScheduledSeatRepository;
 
 import lombok.RequiredArgsConstructor;
 
@@ -12,19 +13,22 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class TicketingClient {
 
-	private final SeatRepository seatRepository;
+	private final ScheduledSeatRepository scheduledSeatRepository;
 
 	/*
 	TODO: 통신 방식 정한 후 관련 메서드 삭제 및 수정 예정
 	현재는 임시로 같은 서버의 Seat 테이블에서 정보를 조회함
 
 	[관련 임시 메서드]
-	SeatRepository.findAllWithSectionByIds
-	ScheduleResponse.SeatInfo.from
+	ScheduledSeatRepository.findFlatInfoById
+	TicketingResponse
 	 */
-	public List<TicketingResponse.SeatInfo> getSeatInfos(List<Long> seatIds) {
-		List<Seat> seats = seatRepository.findAllWithSectionByIds(seatIds);
+	public SeatInfo getSeatInfo(List<Long> seatIds) {
+		List<FlatSeatInfo> flatList = scheduledSeatRepository.findFlatInfoById(seatIds);
 
-		return seats.stream().map(TicketingResponse.SeatInfo::from).toList();
+		FlatSeatInfo first = flatList.getFirst();
+		List<Seat> seats = flatList.stream().map(Seat::from).toList();
+
+		return SeatInfo.from(first, seats);
 	}
 }

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/external/client/TicketingResponse.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/external/client/TicketingResponse.java
@@ -17,6 +17,8 @@ public class TicketingResponse {
 
 		LocalDateTime getStartAt();
 
+		String getPosterImg();
+
 		String getSectionName();
 
 		Long getFloor();
@@ -37,6 +39,7 @@ public class TicketingResponse {
 		private final String showTitle;
 		private final String venueName;
 		private final LocalDateTime startAt;
+		private final String posterImg;
 		private final List<Seat> seats;
 
 		public static SeatInfo from(FlatSeatInfo flat, List<Seat> seats) {
@@ -45,6 +48,7 @@ public class TicketingResponse {
 				flat.getShowTitle(),
 				flat.getVenueName(),
 				flat.getStartAt(),
+				flat.getPosterImg(),
 				seats
 			);
 		}

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/external/client/TicketingResponse.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/external/client/TicketingResponse.java
@@ -1,15 +1,58 @@
 package org.truve.platform.ticketing.service.booking.external.client;
 
-import org.truve.platform.ticketing.service.ticketing.domain.entity.Seat;
+import java.time.LocalDateTime;
+import java.util.List;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 public class TicketingResponse {
 
+	public interface FlatSeatInfo {
+		Long getShowId();
+
+		String getShowTitle();
+
+		String getVenueName();
+
+		LocalDateTime getStartAt();
+
+		String getSectionName();
+
+		Long getFloor();
+
+		String getGradeName();
+
+		String getSeatRow();
+
+		Long getSeatNumber();
+
+		Long getPrice();
+	}
+
 	@Getter
 	@AllArgsConstructor
 	public static class SeatInfo {
+		private final Long showId;
+		private final String showTitle;
+		private final String venueName;
+		private final LocalDateTime startAt;
+		private final List<Seat> seats;
+
+		public static SeatInfo from(FlatSeatInfo flat, List<Seat> seats) {
+			return new SeatInfo(
+				flat.getShowId(),
+				flat.getShowTitle(),
+				flat.getVenueName(),
+				flat.getStartAt(),
+				seats
+			);
+		}
+	}
+
+	@Getter
+	@AllArgsConstructor
+	public static class Seat {
 		private final String sectionName;
 		private final Long floor;
 		private final String gradeName;
@@ -17,14 +60,14 @@ public class TicketingResponse {
 		private final Long seatNumber;
 		private final Long price;
 
-		public static SeatInfo from(Seat seat) {
-			return new SeatInfo(
-				seat.getSeatSection().getName(),
-				seat.getSeatSection().getFloor(),
-				seat.getSeatSection().getGradeName(),
-				seat.getSeatRow(),
-				seat.getSeatNumber(),
-				seat.getSeatSection().getPrice()
+		public static Seat from(FlatSeatInfo flat) {
+			return new Seat(
+				flat.getSectionName(),
+				flat.getFloor(),
+				flat.getGradeName(),
+				flat.getSeatRow(),
+				flat.getSeatNumber(),
+				flat.getPrice()
 			);
 		}
 	}

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/service/BookingService.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/service/BookingService.java
@@ -92,6 +92,7 @@ public class BookingService {
 			.title(seatInfo.getShowTitle())
 			.venueName(seatInfo.getVenueName())
 			.startAt(seatInfo.getStartAt())
+			.posterImg(seatInfo.getPosterImg())
 			.build();
 	}
 

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/service/BookingService.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/service/BookingService.java
@@ -59,6 +59,7 @@ public class BookingService {
 			seatInfo -> Ticket.create(
 				reservation,
 				numberGenerator.generateTicketNumber(),
+				seatInfo.getGradeName(),
 				seatInfo.getPrice(),
 				createSeatDetail(seatInfo)
 			)

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/service/BookingService.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/service/BookingService.java
@@ -52,7 +52,7 @@ public class BookingService {
 			userId,
 			numberGenerator.generateReservationNumber(),
 			calculateTotalAmount(seatInfo),
-      TICKET_SERVICE_FEE * seatInfos.size(),
+			TICKET_SERVICE_FEE * seatInfo.getSeats().size(),
 			createGradeSummary(seatInfo),
 			createShowInfo(seatInfo)
 		);

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/service/BookingService.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/service/BookingService.java
@@ -8,6 +8,7 @@ import java.util.stream.Collectors;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.truve.platform.ticketing.service.booking.domain.entity.Reservation;
+import org.truve.platform.ticketing.service.booking.domain.entity.ShowInfo;
 import org.truve.platform.ticketing.service.booking.domain.entity.Ticket;
 import org.truve.platform.ticketing.service.booking.dto.BookingRequest;
 import org.truve.platform.ticketing.service.booking.dto.BookingResponse;
@@ -35,47 +36,48 @@ public class BookingService {
 
 	@Transactional
 	public BookingResponse.Create create(UUID userId, BookingRequest.Create request) {
-		List<TicketingResponse.SeatInfo> seatInfos = ticketingClient.getSeatInfos(request.getSeatIds());
+		TicketingResponse.SeatInfo seatInfo = ticketingClient.getSeatInfo(request.getSeatIds());
 
-		Reservation reservation = createReservation(userId, seatInfos);
-		List<Ticket> tickets = createTickets(seatInfos, reservation);
+		Reservation reservation = createReservation(userId, seatInfo);
+		List<Ticket> tickets = createTickets(seatInfo, reservation);
 		reservation.addTickets(tickets);
 
 		reservationRepository.save(reservation);
 		return new BookingResponse.Create(reservation.getNumber());
 	}
 
-	private Reservation createReservation(UUID userId, List<TicketingResponse.SeatInfo> seatInfos) {
+	private Reservation createReservation(UUID userId, TicketingResponse.SeatInfo seatInfo) {
 		return Reservation.create(
 			userId,
 			numberGenerator.generateReservationNumber(),
-			calculateTotalAmount(seatInfos),
-			createGradeSummary(seatInfos)
+			calculateTotalAmount(seatInfo),
+			createGradeSummary(seatInfo),
+			createShowInfo(seatInfo)
 		);
 	}
 
-	private List<Ticket> createTickets(List<TicketingResponse.SeatInfo> seatInfos, Reservation reservation) {
-		return seatInfos.stream().map(
-			seatInfo -> Ticket.create(
+	private List<Ticket> createTickets(TicketingResponse.SeatInfo seatInfo, Reservation reservation) {
+		return seatInfo.getSeats().stream().map(
+			seat -> Ticket.create(
 				reservation,
 				numberGenerator.generateTicketNumber(),
-				seatInfo.getGradeName(),
-				seatInfo.getPrice(),
-				createSeatDetail(seatInfo)
+				seat.getGradeName(),
+				seat.getPrice(),
+				createSeatDetail(seat)
 			)
 		).toList();
 	}
 
-	private Long calculateTotalAmount(List<TicketingResponse.SeatInfo> seatInfos) {
-		return seatInfos.stream()
-			.map(TicketingResponse.SeatInfo::getPrice)
+	private Long calculateTotalAmount(TicketingResponse.SeatInfo seatInfo) {
+		return seatInfo.getSeats().stream()
+			.map(TicketingResponse.Seat::getPrice)
 			.reduce(0L, Long::sum);
 	}
 
-	private String createGradeSummary(List<TicketingResponse.SeatInfo> seatInfos) {
-		return seatInfos.stream()
+	private String createGradeSummary(TicketingResponse.SeatInfo seatInfo) {
+		return seatInfo.getSeats().stream()
 			.collect(Collectors.groupingBy(
-				TicketingResponse.SeatInfo::getGradeName,
+				TicketingResponse.Seat::getGradeName,
 				LinkedHashMap::new,
 				Collectors.counting()
 			))
@@ -84,12 +86,21 @@ public class BookingService {
 			.collect(Collectors.joining(LINE_BREAK));
 	}
 
-	private String createSeatDetail(TicketingResponse.SeatInfo seatInfo) {
+	private ShowInfo createShowInfo(TicketingResponse.SeatInfo seatInfo) {
+		return ShowInfo.builder()
+			.showId(seatInfo.getShowId())
+			.title(seatInfo.getShowTitle())
+			.venueName(seatInfo.getVenueName())
+			.startAt(seatInfo.getStartAt())
+			.build();
+	}
+
+	private String createSeatDetail(TicketingResponse.Seat seat) {
 		return SEAT_DETAIL_FORMAT.formatted(
-			seatInfo.getFloor(),
-			seatInfo.getSectionName(),
-			seatInfo.getSeatRow(),
-			seatInfo.getSeatNumber()
+			seat.getFloor(),
+			seat.getSectionName(),
+			seat.getSeatRow(),
+			seat.getSeatNumber()
 		);
 	}
 

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/ticketing/domain/entity/ShowScheduled.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/ticketing/domain/entity/ShowScheduled.java
@@ -18,6 +18,8 @@ import lombok.NoArgsConstructor;
 @Table(name = "show_scheduled")
 public class ShowScheduled extends BaseEntity {
 
+	@Column(nullable = false)
+	Long showId;
 
 	@Column(nullable = false)
 	private String title;
@@ -29,8 +31,9 @@ public class ShowScheduled extends BaseEntity {
 	LocalDateTime startAt;
 
 	@Builder
-	public ShowScheduled(String title, String venueName, LocalDateTime startAt) {
+	public ShowScheduled(Long showId, String title, String venueName, LocalDateTime startAt) {
 
+		this.showId = showId;
 		this.title = title;
 		this.venueName = venueName;
 		this.startAt = startAt;

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/ticketing/domain/entity/ShowScheduled.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/ticketing/domain/entity/ShowScheduled.java
@@ -28,14 +28,18 @@ public class ShowScheduled extends BaseEntity {
 	private String venueName;
 
 	@Column(nullable = false)
-	LocalDateTime startAt;
+	private LocalDateTime startAt;
+
+	@Column(nullable = false)
+	private String posterImg;
 
 	@Builder
-	public ShowScheduled(Long showId, String title, String venueName, LocalDateTime startAt) {
+	public ShowScheduled(Long showId, String title, String venueName, LocalDateTime startAt, String posterImg) {
 
 		this.showId = showId;
 		this.title = title;
 		this.venueName = venueName;
 		this.startAt = startAt;
+		this.posterImg = posterImg;
 	}
 }

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/ticketing/repository/ScheduledSeatRepository.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/ticketing/repository/ScheduledSeatRepository.java
@@ -4,31 +4,50 @@ import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.truve.platform.ticketing.service.booking.external.client.TicketingResponse;
 import org.truve.platform.ticketing.service.ticketing.domain.entity.ScheduledSeat;
 import org.truve.platform.ticketing.service.ticketing.dto.SeatSectionsDto;
-
-import org.springframework.data.repository.query.Param;
 
 public interface ScheduledSeatRepository extends JpaRepository<ScheduledSeat, Long> {
 
 	// TODO: N+1, 성능 개선 등 확인 필요
 	@Query("""
-	select SeatSectionsDto(
-			sc.id,
- 			sc.name,
- 			sc.gradeName,
- 			sc.price,
- 			s.id,
- 			s.seatRow,
- 			s.seatNumber,
- 			ss.status
-	)
-	from ScheduledSeat ss
-	join ss.seat s
-	join s.seatSection sc
-	where ss.showScheduleId = :showScheduleId
-	order by sc.id asc, s.seatRow asc, s.seatNumber asc
-""")
+			select SeatSectionsDto(
+					sc.id,
+		 			sc.name,
+		 			sc.gradeName,
+		 			sc.price,
+		 			s.id,
+		 			s.seatRow,
+		 			s.seatNumber,
+		 			ss.status
+			)
+			from ScheduledSeat ss
+			join ss.seat s
+			join s.seatSection sc
+			where ss.showScheduleId = :showScheduleId
+			order by sc.id asc, s.seatRow asc, s.seatNumber asc
+		""")
 	List<SeatSectionsDto> findSeatSectionByScheduledSeatId(@Param("showScheduleId") Long showScheduleId);
 
+	@Query("""
+		SELECT 
+			shs.showId AS showId,
+			shs.title AS showTitle,
+			shs.venueName AS venueName,
+			shs.startAt AS startAt,
+			sc.name AS sectionName,
+			sc.floor AS floor,
+			sc.gradeName AS gradeName,
+			s.seatRow AS seatRow,
+			s.seatNumber AS seatNumber,
+			sc.price AS price
+		FROM ScheduledSeat ss 
+		JOIN ss.seat s 
+		JOIN s.seatSection sc
+		JOIN ShowScheduled shs ON ss.showScheduleId = shs.id 
+		WHERE s.id IN :ids
+		""")
+	List<TicketingResponse.FlatSeatInfo> findFlatInfoById(List<Long> ids);
 }

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/ticketing/repository/ScheduledSeatRepository.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/ticketing/repository/ScheduledSeatRepository.java
@@ -37,6 +37,7 @@ public interface ScheduledSeatRepository extends JpaRepository<ScheduledSeat, Lo
 			shs.title AS showTitle,
 			shs.venueName AS venueName,
 			shs.startAt AS startAt,
+			shs.posterImg AS posterImg,
 			sc.name AS sectionName,
 			sc.floor AS floor,
 			sc.gradeName AS gradeName,

--- a/ticketing/src/test/java/org/truve/platform/ticketing/service/booking/service/BookingServiceTest.java
+++ b/ticketing/src/test/java/org/truve/platform/ticketing/service/booking/service/BookingServiceTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 
@@ -44,17 +45,23 @@ class BookingServiceTest {
 		List<Long> seatIds = List.of(10L, 11L, 12L);
 		BookingRequest.Create request = new BookingRequest.Create(seatIds);
 
-		TicketingResponse.SeatInfo seat1 = new TicketingResponse.SeatInfo("A", 1L, "VIP", "A", 13L, 10000L);
-		TicketingResponse.SeatInfo seat2 = new TicketingResponse.SeatInfo("B", 2L, "VIP", "B", 14L, 20000L);
-		TicketingResponse.SeatInfo seat3 = new TicketingResponse.SeatInfo("C", 3L, "S", "C", 15L, 30000L);
-		List<TicketingResponse.SeatInfo> seatInfos = List.of(seat1, seat2, seat3);
+		TicketingResponse.Seat seat1 = new TicketingResponse.Seat("Section1", 1L, "VIP", "A", 10L, 10000L);
+		TicketingResponse.Seat seat2 = new TicketingResponse.Seat("Section2", 2L, "S", "B", 20L, 20000L);
+		TicketingResponse.Seat seat3 = new TicketingResponse.Seat("Section3", 3L, "VIP", "C", 30L, 30000L);
+		List<TicketingResponse.Seat> seats = List.of(seat1, seat2, seat3);
+		TicketingResponse.SeatInfo seatInfo = new TicketingResponse.SeatInfo(
+			1L,
+			"title",
+			"venue",
+			LocalDateTime.now(),
+			seats);
 
 		String reservationNumber = "R20260309ABCDEF";
 		String ticketNumber1 = "T-1234567890123";
 		String ticketNumber2 = "T-9876543210987";
 		String ticketNumber3 = "T-1111111111111";
 
-		given(ticketingClient.getSeatInfos(seatIds)).willReturn(seatInfos);
+		given(ticketingClient.getSeatInfo(seatIds)).willReturn(seatInfo);
 		given(numberGenerator.generateReservationNumber()).willReturn(reservationNumber);
 		given(numberGenerator.generateTicketNumber()).willReturn(ticketNumber1, ticketNumber2, ticketNumber3);
 
@@ -77,7 +84,7 @@ class BookingServiceTest {
 				assertThat(savedReservation.getTickets().get(1).getPriceSnapshot()).isEqualTo(20000L);
 				assertThat(savedReservation.getTickets().getLast().getStatus()).isEqualTo(TicketStatus.ISSUED);
 				assertThat(savedReservation.getTickets().get(1).getUsedAt()).isNull();
-				assertThat(savedReservation.getTickets().getFirst().getSeatDetail()).isEqualTo("1층 A구역 A열 13번");
+				assertThat(savedReservation.getTickets().getFirst().getSeatDetail()).isEqualTo("1층 Section1구역 A열 10번");
 			}
 		);
 	}

--- a/ticketing/src/test/java/org/truve/platform/ticketing/service/booking/service/BookingServiceTest.java
+++ b/ticketing/src/test/java/org/truve/platform/ticketing/service/booking/service/BookingServiceTest.java
@@ -54,6 +54,7 @@ class BookingServiceTest {
 			"title",
 			"venue",
 			LocalDateTime.now(),
+			"poster",
 			seats);
 
 		String reservationNumber = "R20260309ABCDEF";


### PR DESCRIPTION
## 변경 사항

---

### Ticket 좌석 등급 필드 추가

Ticket에 좌석 등급을 저장하는 필드를 추가했습니다.

### Reservation ShowInfo 저장

Reservation를 생성할 때, ShowInfo(공연 ID, 공연 이름, 공연장 이름, 시작 시간)을 저장하도록 변경했습니다.

- Ticketing.ShowScheduled: Show ID 필드를 추가했습니다.
- Ticketing.ScheduledSeat: Seat ID로 Seat, SeatSection, ShowScheduled을 조회하는 기능을 추가했습니다.
- TicketingResponse.SeatInfo: 공연 정보를 포함하도록 변경했습니다.
- BookingService: 위 변경사항을 반영해 ShowInfo를 저장하도록 변경했습니다.

- [X] 전체 테스트 코드 성공 여부

## 관련 이슈

---
- Notion Ticket: #

## 참고사항 (선택)

<img width="1256" height="504" alt="image" src="https://github.com/user-attachments/assets/3007c461-916f-45c5-9601-261a122cbee2" />

예매 상세 페이지 입장 가능 시간 계산하는 것 때문에 결국 공연 정보가 필요하게 됐네요...
Musical 서버랑 통신해서 가져올까 하다가 Seat 정보 가져오는 김에 Ticketing 서버에서 가져와도 괜찮을 거 같아서 변경했습니다.

현재 위 사진에서 공연 종료 시간을 못 가져오고 있는데 이건 좀 더 고민해 보겠습니다....... (DB에 종료 시간이 저장되지 않아서 Show.runTimeMin까지 가져와서 직접 계산해야 할 거 같은데 너무 복잡해서......................)

Ticketing Server / Ticketing Service / Entity 및 Repository 변경사항이 있다는 점 참고 부탁드립니다!


---