### PR TITLE
feat(reservation): 예약 결제 승인시 결제 방법 및 가상계좌 정보 저장

### DIFF
--- a/payment/src/main/java/com/truve/platform/payment/service/event/PaymentUpdated.java
+++ b/payment/src/main/java/com/truve/platform/payment/service/event/PaymentUpdated.java
@@ -2,8 +2,10 @@ package com.truve.platform.payment.service.event;
 
 import java.time.LocalDateTime;
 
+import com.truve.platform.payment.service.domain.constant.PaymentMethod;
 import com.truve.platform.payment.service.domain.constant.PaymentStatus;
 import com.truve.platform.payment.service.domain.entity.Payment;
+import com.truve.platform.payment.service.domain.entity.VirtualAccount;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -17,12 +19,16 @@ public class PaymentUpdated {
 	public static class Confirmed {
 		private String orderId;
 		private LocalDateTime approvedAt;
+		private PaymentMethod method;
+		private VirtualAccount virtualAccount;
 		private PaymentStatus status;
 
 		public static Confirmed of(Payment payment) {
 			return new Confirmed(
 				payment.getOrderId(),
 				payment.getApprovedAt(),
+				payment.getMethod(),
+				payment.getVirtualAccount(),
 				payment.getStatus()
 			);
 		}

--- a/payment/src/main/java/com/truve/platform/payment/service/event/PaymentUpdatedListener.java
+++ b/payment/src/main/java/com/truve/platform/payment/service/event/PaymentUpdatedListener.java
@@ -4,7 +4,6 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 
-import com.truve.platform.payment.service.domain.constant.PaymentStatus;
 import com.truve.platform.payment.service.external.kafka.BookingEventCommand;
 import com.truve.platform.payment.service.external.kafka.BookingPublisher;
 
@@ -22,9 +21,15 @@ public class PaymentUpdatedListener {
 			new BookingEventCommand.Confirmed(
 				event.getOrderId(),
 				event.getApprovedAt(),
-				event.getStatus() == PaymentStatus.WAITING_FOR_DEPOSIT
-			)
-		);
+				event.getMethod().getDisplayName(),
+				event.getVirtualAccount() == null ? null
+					: new BookingEventCommand.Confirmed.VirtualAccount(
+					event.getVirtualAccount().getAccountNumber(),
+					event.getVirtualAccount().getBank().getBankName(),
+					event.getVirtualAccount().getCustomerName(),
+					event.getVirtualAccount().getDueDate()
+				)
+			));
 	}
 
 	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)

--- a/payment/src/main/java/com/truve/platform/payment/service/external/kafka/BookingEventCommand.java
+++ b/payment/src/main/java/com/truve/platform/payment/service/external/kafka/BookingEventCommand.java
@@ -4,7 +4,6 @@ import java.time.LocalDateTime;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -26,12 +25,23 @@ public class BookingEventCommand {
 		private String reservationNumber;
 		@JsonFormat(shape = JsonFormat.Shape.ARRAY)
 		private LocalDateTime paidAt;
-		@JsonProperty("depositPending")
-		private boolean isDepositPending;
+		private String method;
+		private VirtualAccount virtualAccount;
 
 		@Override
 		public String getEventType() {
 			return "CONFIRMED";
+		}
+
+		@Getter
+		@AllArgsConstructor
+		@NoArgsConstructor
+		public static class VirtualAccount {
+			private String accountNumber;
+			private String bank;
+			private String customerName;
+			@JsonFormat(shape = JsonFormat.Shape.ARRAY)
+			private LocalDateTime dueDate;
 		}
 	}
 

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/domain/entity/Reservation.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/domain/entity/Reservation.java
@@ -87,9 +87,20 @@ public class Reservation extends BaseEntity {
 		this.status = ReservationStatus.PENDING_PAYMENT;
 	}
 
-	public void confirm(LocalDateTime paidAt, boolean isDepositPending) {
+	public void confirm(LocalDateTime paidAt, String paymentMethod, VirtualAccount virtualAccount) {
 		this.paidAt = paidAt;
-		this.status = isDepositPending ? ReservationStatus.PENDING_DEPOSIT : ReservationStatus.CONFIRMED;
+		this.paymentMethod = paymentMethod;
+
+		if (isVirtualAccountPayment(virtualAccount)) {
+			this.virtualAccount = virtualAccount;
+			this.status = ReservationStatus.PENDING_DEPOSIT;
+		} else {
+			this.status = ReservationStatus.CONFIRMED;
+		}
+	}
+
+	private boolean isVirtualAccountPayment(VirtualAccount virtualAccount) {
+		return virtualAccount != null;
 	}
 
 	public void depositReceive(LocalDateTime paidAt) {

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/domain/entity/Reservation.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/domain/entity/Reservation.java
@@ -48,6 +48,12 @@ public class Reservation extends BaseEntity {
 	private LocalDateTime paidAt;
 
 	@Embedded
+	private VirtualAccount virtualAccount;
+
+	@Column
+	private String paymentMethod;
+
+	@Embedded
 	private Applicant applicant;
 
 	@OneToMany(mappedBy = "reservation", cascade = CascadeType.ALL)

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/domain/entity/VirtualAccount.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/domain/entity/VirtualAccount.java
@@ -2,6 +2,8 @@ package org.truve.platform.ticketing.service.booking.domain.entity;
 
 import java.time.LocalDateTime;
 
+import org.truve.platform.ticketing.service.booking.external.kafka.BookingEventCommand;
+
 import jakarta.persistence.Embeddable;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -23,5 +25,15 @@ public class VirtualAccount {
 		this.bank = bank;
 		this.customerName = customerName;
 		this.dueDate = dueDate;
+	}
+
+	public static VirtualAccount from(BookingEventCommand.Confirmed.VirtualAccount virtualAccount) {
+		return virtualAccount == null ? null
+			: VirtualAccount.builder()
+			.accountNumber(virtualAccount.getAccountNumber())
+			.bank(virtualAccount.getBank())
+			.customerName(virtualAccount.getCustomerName())
+			.dueDate(LocalDateTime.now())
+			.build();
 	}
 }

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/domain/entity/VirtualAccount.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/domain/entity/VirtualAccount.java
@@ -1,0 +1,27 @@
+package org.truve.platform.ticketing.service.booking.domain.entity;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class VirtualAccount {
+	private String accountNumber;
+	private String bank;
+	private String customerName;
+	private LocalDateTime dueDate;
+
+	@Builder
+	public VirtualAccount(String accountNumber, String bank, String customerName, LocalDateTime dueDate) {
+		this.accountNumber = accountNumber;
+		this.bank = bank;
+		this.customerName = customerName;
+		this.dueDate = dueDate;
+	}
+}

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/external/kafka/BookingEventCommand.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/external/kafka/BookingEventCommand.java
@@ -4,7 +4,6 @@ import java.time.LocalDateTime;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -26,12 +25,23 @@ public class BookingEventCommand {
 		private String reservationNumber;
 		@JsonFormat(shape = JsonFormat.Shape.ARRAY)
 		private LocalDateTime paidAt;
-		@JsonProperty("depositPending")
-		private boolean isDepositPending;
+		private String method;
+		private VirtualAccount virtualAccount;
 
 		@Override
 		public String getEventType() {
 			return "CONFIRMED";
+		}
+
+		@Getter
+		@AllArgsConstructor
+		@NoArgsConstructor
+		public static class VirtualAccount {
+			private String accountNumber;
+			private String bank;
+			private String customerName;
+			@JsonFormat(shape = JsonFormat.Shape.ARRAY)
+			private LocalDateTime dueDate;
 		}
 	}
 

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/service/BookingService.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/service/BookingService.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.truve.platform.ticketing.service.booking.domain.entity.Reservation;
 import org.truve.platform.ticketing.service.booking.domain.entity.Ticket;
+import org.truve.platform.ticketing.service.booking.domain.entity.VirtualAccount;
 import org.truve.platform.ticketing.service.booking.dto.BookingRequest;
 import org.truve.platform.ticketing.service.booking.dto.BookingResponse;
 import org.truve.platform.ticketing.service.booking.external.client.TicketingClient;
@@ -104,7 +105,7 @@ public class BookingService {
 	@Transactional
 	public void confirm(BookingEventCommand.Confirmed event) {
 		Reservation reservation = reservationRepository.findByNumber(event.getReservationNumber());
-		reservation.confirm(event.getPaidAt(), event.isDepositPending());
+		reservation.confirm(event.getPaidAt(), event.getMethod(), VirtualAccount.from(event.getVirtualAccount()));
 	}
 
 	@Transactional

--- a/ticketing/src/main/resources/application.yml
+++ b/ticketing/src/main/resources/application.yml
@@ -10,6 +10,11 @@ spring:
     password: ${TICKETING_MYSQL_PASSWORD:1234}
     driver-class-name: com.mysql.cj.jdbc.Driver
 
+  jpa:
+    hibernate:
+      ddl-auto: validate
+    show-sql: false
+
   data:
     redis:
       host: ${USER_REDIS_HOST:localhost}


### PR DESCRIPTION
## 변경 사항

---
### Reservation 결제 방법 및 가상계좌 정보 필드 추가

String paymentMethod와 가상계좌 은행, 계좌번호, 입금자명, 기한을 저장하는 필드를 추가했습니다.

### Payment 결제 승인시 결제 방법 및 가상계좌 정보 전파 

기존 결제 서버에서 승인 처리 후 응답 정보에 결제 방법 및 가상계좌 정보를 추가로 전파하도록 변경했습니다.
예매 서버에서 해당 이벤트를 받아 처리할 때 결제 방법 및 가상계좌 정보를 저장하도록 구현했습니다.

### Ticketing application.yml JPA ddl-auto 설정 추가

누락되어 있던 걸 발견해서 추가했습니다.

- [X] 전체 테스트 코드 성공 여부

## 관련 이슈

---
- Notion Ticket: #

## 참고사항 (선택)

---
예매 상세의 결제 정보를 Booking 서버 내에서 해결할 수 있도록 Reservation에서 최소한의 정보를 들고 있는 방향으로 구현했습니다....