### PR TITLE
fix: API Gateway CORS 허용 도메인에 truve.site 추가

### DIFF
--- a/api-gateway/src/main/java/com/truve/platform/apigateway/config/CorsConfig.java
+++ b/api-gateway/src/main/java/com/truve/platform/apigateway/config/CorsConfig.java
@@ -15,7 +15,8 @@ public class CorsConfig {
 		"http://localhost:[*]",
 		"http://127.0.0.1:[*]",
 		"https://front-nu-tawny.vercel.app",
-		"https://front-rosy-two.vercel.app"
+		"https://front-rosy-two.vercel.app",
+		"https://www.truve.site"
 	);
 	private static final List<String> ALLOWED_HEADERS = List.of("*");
 	private static final List<String> ALLOWED_METHODS = List.of("*");


### PR DESCRIPTION
## 변경 사항

---
`ALLOWED_ORIGIN_PATTERNS`에 https://www.truve.site 추가

- [ ] 전체 테스트 코드 성공 여부

## 관련 이슈

---
- Notion Ticket: #

## 참고사항 (선택)

---