### PR TITLE
Refactor(musical): 상세/캐스팅 응답 이미지 필드 구조 정리

### DIFF
--- a/musical/src/main/java/com/truve/platform/musical/seat/domain/entity/Venue.java
+++ b/musical/src/main/java/com/truve/platform/musical/seat/domain/entity/Venue.java
@@ -15,6 +15,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "venue")
+@AttributeOverride(name = "id", column = @Column(name = "venue_id"))
 public class Venue extends BaseEntity {
 
 	@Column(nullable = false, length = 255)

--- a/musical/src/main/java/com/truve/platform/musical/show/domain/converter/StringListConverter.java
+++ b/musical/src/main/java/com/truve/platform/musical/show/domain/converter/StringListConverter.java
@@ -1,0 +1,43 @@
+package com.truve.platform.musical.show.domain.converter;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.util.StringUtils;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+@Converter
+public class StringListConverter implements AttributeConverter<List<String>, String> {
+
+	@Override
+	public String convertToDatabaseColumn(List<String> attribute) {
+		if (attribute == null || attribute.isEmpty()) {
+			return null;
+		}
+
+		List<String> sanitized = attribute.stream()
+			.map(value -> value == null ? "" : value.trim())
+			.filter(StringUtils::hasText)
+			.toList();
+		if (sanitized.isEmpty()) {
+			return null;
+		}
+		return String.join(",", sanitized);
+	}
+
+	@Override
+	public List<String> convertToEntityAttribute(String dbData) {
+		if (!StringUtils.hasText(dbData)) {
+			return Collections.emptyList();
+		}
+
+		return Arrays.stream(dbData.split(","))
+			.map(String::trim)
+			.filter(StringUtils::hasText)
+			.collect(Collectors.toList());
+	}
+}

--- a/musical/src/main/java/com/truve/platform/musical/show/domain/entity/Show.java
+++ b/musical/src/main/java/com/truve/platform/musical/show/domain/entity/Show.java
@@ -1,10 +1,13 @@
 package com.truve.platform.musical.show.domain.entity;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 import com.truve.platform.common.support.BaseEntity;
+import com.truve.platform.musical.show.domain.converter.StringListConverter;
 
 import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
@@ -35,8 +38,13 @@ public class Show extends BaseEntity {
 	@Column(nullable = false, length = 500)
 	private String posterImg;
 
-	@Column(length = 500)
-	private String noticeImg;
+	@Convert(converter = StringListConverter.class)
+	@Column(name = "notice_img", length = 2000)
+	private List<String> noticeImg;
+
+	@Convert(converter = StringListConverter.class)
+	@Column(name = "detail_img", length = 2000)
+	private List<String> detailImg;
 
 	@Column(name = "start_time")
 	private LocalDateTime startTime;
@@ -52,7 +60,8 @@ public class Show extends BaseEntity {
 		Integer runtimeMin,
 		Integer ageLimit,
 		String posterImg,
-		String noticeImg,
+		List<String> noticeImg,
+		List<String> detailImg,
 		LocalDateTime startTime,
 		LocalDateTime endTime
 	) {
@@ -63,6 +72,7 @@ public class Show extends BaseEntity {
 		this.ageLimit = ageLimit;
 		this.posterImg = posterImg;
 		this.noticeImg = noticeImg;
+		this.detailImg = detailImg;
 		this.startTime = startTime;
 		this.endTime = endTime;
 	}

--- a/musical/src/main/java/com/truve/platform/musical/show/domain/entity/ShowCasting.java
+++ b/musical/src/main/java/com/truve/platform/musical/show/domain/entity/ShowCasting.java
@@ -33,11 +33,15 @@ public class ShowCasting extends BaseEntity {
 	@Column(name = "`order`")
 	private Integer castingOrder;
 
+	@Column(name = "profile_img", length = 500)
+	private String profileImg;
+
 	@Builder
-	private ShowCasting(Show show, Artist artist, String roleName, Integer castingOrder) {
+	private ShowCasting(Show show, Artist artist, String roleName, Integer castingOrder, String profileImg) {
 		this.show = show;
 		this.artist = artist;
 		this.roleName = roleName;
 		this.castingOrder = castingOrder;
+		this.profileImg = profileImg;
 	}
 }

--- a/musical/src/main/java/com/truve/platform/musical/show/dto/ShowCastingResponse.java
+++ b/musical/src/main/java/com/truve/platform/musical/show/dto/ShowCastingResponse.java
@@ -45,7 +45,6 @@ public class ShowCastingResponse {
 	public static class FilterArtist {
 		private Long artistId;
 		private String artistName;
-		private String profileImageUrl;
 	}
 
 	@Getter
@@ -82,5 +81,6 @@ public class ShowCastingResponse {
 	public static class CastArtist {
 		private Long artistId;
 		private String artistName;
+		private String profileImageUrl;
 	}
 }

--- a/musical/src/main/java/com/truve/platform/musical/show/dto/ShowCastingResponse.java
+++ b/musical/src/main/java/com/truve/platform/musical/show/dto/ShowCastingResponse.java
@@ -81,5 +81,6 @@ public class ShowCastingResponse {
 	public static class CastArtist {
 		private Long artistId;
 		private String artistName;
+		private String profileImageUrl;
 	}
 }

--- a/musical/src/main/java/com/truve/platform/musical/show/dto/ShowCastingResponse.java
+++ b/musical/src/main/java/com/truve/platform/musical/show/dto/ShowCastingResponse.java
@@ -45,6 +45,7 @@ public class ShowCastingResponse {
 	public static class FilterArtist {
 		private Long artistId;
 		private String artistName;
+		private String profileImageUrl;
 	}
 
 	@Getter
@@ -81,6 +82,5 @@ public class ShowCastingResponse {
 	public static class CastArtist {
 		private Long artistId;
 		private String artistName;
-		private String profileImageUrl;
 	}
 }

--- a/musical/src/main/java/com/truve/platform/musical/show/dto/ShowCastingResponse.java
+++ b/musical/src/main/java/com/truve/platform/musical/show/dto/ShowCastingResponse.java
@@ -81,6 +81,5 @@ public class ShowCastingResponse {
 	public static class CastArtist {
 		private Long artistId;
 		private String artistName;
-		private String profileImageUrl;
 	}
 }

--- a/musical/src/main/java/com/truve/platform/musical/show/dto/ShowResponse.java
+++ b/musical/src/main/java/com/truve/platform/musical/show/dto/ShowResponse.java
@@ -19,7 +19,8 @@ public class ShowResponse {
 		private Integer runtimeMin;
 		private Integer ageLimit;
 		private String posterUrl;
-		private String noticeUrl;
+		private List<String> noticeImgs;
+		private List<String> detailImgs;
 		private LocalDateTime startTime;
 		private LocalDateTime endTime;
 		private Venue venue;
@@ -79,4 +80,3 @@ public class ShowResponse {
 		private Long price;
 	}
 }
-

--- a/musical/src/main/java/com/truve/platform/musical/show/service/ShowCastingService.java
+++ b/musical/src/main/java/com/truve/platform/musical/show/service/ShowCastingService.java
@@ -14,9 +14,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.util.StringUtils;
 
-import com.truve.platform.musical.s3.S3Service;
 import com.truve.platform.musical.show.domain.entity.Show;
 import com.truve.platform.musical.show.domain.entity.ShowCasting;
 import com.truve.platform.musical.show.domain.entity.ShowSchedule;
@@ -37,7 +35,6 @@ public class ShowCastingService {
 	private final ShowScheduleRepository showScheduleRepository;
 	private final ShowCastingRepository showCastingRepository;
 	private final ShowScheduleCastingRepository showScheduleCastingRepository;
-	private final S3Service s3Service;
 
 	@Transactional(readOnly = true)
 	public ShowCastingResponse.Detail getCastingSchedules(
@@ -156,7 +153,6 @@ public class ShowCastingService {
 					(ShowScheduleCasting sc) -> ShowCastingResponse.CastArtist.builder()
 						.artistId(sc.getShowCasting().getArtist().getId())
 						.artistName(sc.getShowCasting().getArtist().getName())
-						.profileImageUrl(toImageUrl(sc.getShowCasting().getProfileImg()))
 						.build(),
 					(existing, replacement) -> existing,
 					LinkedHashMap::new
@@ -164,12 +160,5 @@ public class ShowCastingService {
 			result.put(scheduleId, casts);
 		});
 		return result;
-	}
-
-	private String toImageUrl(String fileName) {
-		if (!StringUtils.hasText(fileName)) {
-			return null;
-		}
-		return s3Service.getImageUrl(fileName);
 	}
 }

--- a/musical/src/main/java/com/truve/platform/musical/show/service/ShowCastingService.java
+++ b/musical/src/main/java/com/truve/platform/musical/show/service/ShowCastingService.java
@@ -135,7 +135,6 @@ public class ShowCastingService {
 			ShowCastingResponse.FilterArtist.builder()
 				.artistId(casting.getArtist().getId())
 				.artistName(casting.getArtist().getName())
-				.profileImageUrl(toImageUrl(casting.getArtist().getProfileImg()))
 				.build()
 		));
 		return byArtistId.values().stream().toList();
@@ -145,7 +144,6 @@ public class ShowCastingService {
 		List<ShowScheduleCasting> scheduleCastings = showScheduleCastingRepository.findAllByScheduleIds(scheduleIds);
 		Map<Long, List<ShowScheduleCasting>> grouped = scheduleCastings.stream()
 			.collect(Collectors.groupingBy(sc -> sc.getShowSchedule().getId()));
-
 		Map<Long, Map<String, ShowCastingResponse.CastArtist>> result = new LinkedHashMap<>();
 		grouped.forEach((Long scheduleId, List<ShowScheduleCasting> castings) -> {
 			Map<String, ShowCastingResponse.CastArtist> casts = castings.stream()
@@ -158,6 +156,7 @@ public class ShowCastingService {
 					(ShowScheduleCasting sc) -> ShowCastingResponse.CastArtist.builder()
 						.artistId(sc.getShowCasting().getArtist().getId())
 						.artistName(sc.getShowCasting().getArtist().getName())
+						.profileImageUrl(toImageUrl(sc.getShowCasting().getProfileImg()))
 						.build(),
 					(existing, replacement) -> existing,
 					LinkedHashMap::new

--- a/musical/src/main/java/com/truve/platform/musical/show/service/ShowCastingService.java
+++ b/musical/src/main/java/com/truve/platform/musical/show/service/ShowCastingService.java
@@ -14,7 +14,9 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
 
+import com.truve.platform.musical.s3.S3Service;
 import com.truve.platform.musical.show.domain.entity.Show;
 import com.truve.platform.musical.show.domain.entity.ShowCasting;
 import com.truve.platform.musical.show.domain.entity.ShowSchedule;
@@ -35,6 +37,7 @@ public class ShowCastingService {
 	private final ShowScheduleRepository showScheduleRepository;
 	private final ShowCastingRepository showCastingRepository;
 	private final ShowScheduleCastingRepository showScheduleCastingRepository;
+	private final S3Service s3Service;
 
 	@Transactional(readOnly = true)
 	public ShowCastingResponse.Detail getCastingSchedules(
@@ -154,6 +157,7 @@ public class ShowCastingService {
 					(ShowScheduleCasting sc) -> ShowCastingResponse.CastArtist.builder()
 						.artistId(sc.getShowCasting().getArtist().getId())
 						.artistName(sc.getShowCasting().getArtist().getName())
+						.profileImageUrl(toImageUrl(sc.getShowCasting().getArtist().getProfileImg()))
 						.build(),
 					(existing, replacement) -> existing,
 					LinkedHashMap::new
@@ -161,5 +165,12 @@ public class ShowCastingService {
 			result.put(scheduleId, casts);
 		});
 		return result;
+	}
+
+	private String toImageUrl(String fileName) {
+		if (!StringUtils.hasText(fileName)) {
+			return null;
+		}
+		return s3Service.getImageUrl(fileName);
 	}
 }

--- a/musical/src/main/java/com/truve/platform/musical/show/service/ShowCastingService.java
+++ b/musical/src/main/java/com/truve/platform/musical/show/service/ShowCastingService.java
@@ -135,6 +135,7 @@ public class ShowCastingService {
 			ShowCastingResponse.FilterArtist.builder()
 				.artistId(casting.getArtist().getId())
 				.artistName(casting.getArtist().getName())
+				.profileImageUrl(toImageUrl(casting.getArtist().getProfileImg()))
 				.build()
 		));
 		return byArtistId.values().stream().toList();
@@ -157,7 +158,6 @@ public class ShowCastingService {
 					(ShowScheduleCasting sc) -> ShowCastingResponse.CastArtist.builder()
 						.artistId(sc.getShowCasting().getArtist().getId())
 						.artistName(sc.getShowCasting().getArtist().getName())
-						.profileImageUrl(toImageUrl(sc.getShowCasting().getArtist().getProfileImg()))
 						.build(),
 					(existing, replacement) -> existing,
 					LinkedHashMap::new

--- a/musical/src/main/java/com/truve/platform/musical/show/service/ShowDetailService.java
+++ b/musical/src/main/java/com/truve/platform/musical/show/service/ShowDetailService.java
@@ -119,7 +119,7 @@ public class ShowDetailService {
 			.showCastId(casting.getId())
 			.artistId(casting.getArtist().getId())
 			.artistName(casting.getArtist().getName())
-			.profileImageUrl(toImageUrl(casting.getArtist().getProfileImg()))
+			.profileImageUrl(toImageUrl(casting.getProfileImg()))
 			.roleName(casting.getRoleName())
 			.order(casting.getCastingOrder())
 			.isLiked(isLiked)

--- a/musical/src/main/java/com/truve/platform/musical/show/service/ShowDetailService.java
+++ b/musical/src/main/java/com/truve/platform/musical/show/service/ShowDetailService.java
@@ -1,6 +1,8 @@
 package com.truve.platform.musical.show.service;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
 
@@ -67,7 +69,8 @@ public class ShowDetailService {
 			.runtimeMin(show.getRuntimeMin())
 			.ageLimit(show.getAgeLimit())
 			.posterUrl(toImageUrl(show.getPosterImg()))
-			.noticeUrl(toImageUrl(show.getNoticeImg()))
+			.noticeImgs(toImageUrls(show.getNoticeImg()))
+			.detailImgs(toImageUrls(show.getDetailImg()))
 			.startTime(show.getStartTime())
 			.endTime(show.getEndTime())
 			.venue(toVenueResponse(show))
@@ -128,6 +131,17 @@ public class ShowDetailService {
 			return null;
 		}
 		return s3Service.getImageUrl(fileName);
+	}
+
+	private List<String> toImageUrls(List<String> fileNames) {
+		if (fileNames == null || fileNames.isEmpty()) {
+			return Collections.emptyList();
+		}
+
+		return fileNames.stream()
+			.map(this::toImageUrl)
+			.filter(Objects::nonNull)
+			.toList();
 	}
 
 	private ShowResponse.SeatGrade toSeatGradeResponse(ShowSectionGrade seatGrade) {

--- a/musical/src/main/java/com/truve/platform/musical/show/service/ShowDetailService.java
+++ b/musical/src/main/java/com/truve/platform/musical/show/service/ShowDetailService.java
@@ -119,7 +119,7 @@ public class ShowDetailService {
 			.showCastId(casting.getId())
 			.artistId(casting.getArtist().getId())
 			.artistName(casting.getArtist().getName())
-			.profileImageUrl(toImageUrl(casting.getProfileImg()))
+			.profileImageUrl(toImageUrl(chooseProfileImgKey(casting)))
 			.roleName(casting.getRoleName())
 			.order(casting.getCastingOrder())
 			.isLiked(isLiked)
@@ -151,5 +151,12 @@ public class ShowDetailService {
 			.colorCode(seatGrade.getColorCode())
 			.price(seatGrade.getPrice())
 			.build();
+	}
+
+	private String chooseProfileImgKey(ShowCasting casting) {
+		if (StringUtils.hasText(casting.getProfileImg())) {
+			return casting.getProfileImg();
+		}
+		return casting.getArtist().getProfileImg();
 	}
 }

--- a/musical/src/test/java/com/truve/platform/musical/show/controller/ShowControllerTest.java
+++ b/musical/src/test/java/com/truve/platform/musical/show/controller/ShowControllerTest.java
@@ -186,7 +186,6 @@ class ShowControllerTest {
 					ShowCastingResponse.FilterArtist.builder()
 						.artistId(1L)
 						.artistName("김호영")
-						.profileImageUrl("https://img.example/artist-charlie.jpg")
 						.build()
 				))
 				.build())
@@ -208,10 +207,12 @@ class ShowControllerTest {
 						"찰리", ShowCastingResponse.CastArtist.builder()
 							.artistId(1L)
 							.artistName("김호영")
+							.profileImageUrl("https://img.example/show-casting-charlie.jpg")
 							.build(),
 						"롤라", ShowCastingResponse.CastArtist.builder()
 							.artistId(10L)
 							.artistName("강홍석")
+							.profileImageUrl("https://img.example/show-casting-lola.jpg")
 							.build()
 					))
 					.build()
@@ -237,10 +238,10 @@ class ShowControllerTest {
 			.andExpect(jsonPath("$.code").value("ok"))
 			.andExpect(jsonPath("$.data.showId").value(1))
 			.andExpect(jsonPath("$.data.range.from").value("2025-12-17"))
-			.andExpect(jsonPath("$.data.filters.artists[0].profileImageUrl").value("https://img.example/artist-charlie.jpg"))
 			.andExpect(jsonPath("$.data.roles[0].roleName").value("찰리"))
 			.andExpect(jsonPath("$.data.page.currentPage").value(0))
 			.andExpect(jsonPath("$.data.rows[0].scheduleId").value(101))
-			.andExpect(jsonPath("$.data.rows[0].casts.찰리.artistName").value("김호영"));
+			.andExpect(jsonPath("$.data.rows[0].casts.찰리.artistName").value("김호영"))
+			.andExpect(jsonPath("$.data.rows[0].casts.찰리.profileImageUrl").value("https://img.example/show-casting-charlie.jpg"));
 	}
 }

--- a/musical/src/test/java/com/truve/platform/musical/show/controller/ShowControllerTest.java
+++ b/musical/src/test/java/com/truve/platform/musical/show/controller/ShowControllerTest.java
@@ -183,7 +183,11 @@ class ShowControllerTest {
 				.build())
 			.filters(ShowCastingResponse.Filters.builder()
 				.artists(List.of(
-					ShowCastingResponse.FilterArtist.builder().artistId(1L).artistName("김호영").build()
+					ShowCastingResponse.FilterArtist.builder()
+						.artistId(1L)
+						.artistName("김호영")
+						.profileImageUrl("https://img.example/artist-charlie.jpg")
+						.build()
 				))
 				.build())
 			.roles(List.of(
@@ -204,12 +208,10 @@ class ShowControllerTest {
 						"찰리", ShowCastingResponse.CastArtist.builder()
 							.artistId(1L)
 							.artistName("김호영")
-							.profileImageUrl("https://img.example/artist-charlie.jpg")
 							.build(),
 						"롤라", ShowCastingResponse.CastArtist.builder()
 							.artistId(10L)
 							.artistName("강홍석")
-							.profileImageUrl("https://img.example/artist-lola.jpg")
 							.build()
 					))
 					.build()
@@ -235,10 +237,10 @@ class ShowControllerTest {
 			.andExpect(jsonPath("$.code").value("ok"))
 			.andExpect(jsonPath("$.data.showId").value(1))
 			.andExpect(jsonPath("$.data.range.from").value("2025-12-17"))
+			.andExpect(jsonPath("$.data.filters.artists[0].profileImageUrl").value("https://img.example/artist-charlie.jpg"))
 			.andExpect(jsonPath("$.data.roles[0].roleName").value("찰리"))
 			.andExpect(jsonPath("$.data.page.currentPage").value(0))
 			.andExpect(jsonPath("$.data.rows[0].scheduleId").value(101))
-			.andExpect(jsonPath("$.data.rows[0].casts.찰리.artistName").value("김호영"))
-			.andExpect(jsonPath("$.data.rows[0].casts.찰리.profileImageUrl").value("https://img.example/artist-charlie.jpg"));
+			.andExpect(jsonPath("$.data.rows[0].casts.찰리.artistName").value("김호영"));
 	}
 }

--- a/musical/src/test/java/com/truve/platform/musical/show/controller/ShowControllerTest.java
+++ b/musical/src/test/java/com/truve/platform/musical/show/controller/ShowControllerTest.java
@@ -1,6 +1,5 @@
 package com.truve.platform.musical.show.controller;
 
-import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.BDDMockito.given;
@@ -58,7 +57,8 @@ class ShowControllerTest {
 			.runtimeMin(120)
 			.ageLimit(8)
 			.posterUrl("https://img/1.jpg")
-			.noticeUrl("https://img/notice.jpg")
+			.noticeImgs(List.of("https://img/notice.jpg"))
+			.detailImgs(List.of("https://img/detail-1.jpg", "https://img/detail-2.jpg"))
 			.startTime(LocalDateTime.of(2026, 3, 1, 0, 0))
 			.endTime(LocalDateTime.of(2026, 4, 1, 0, 0))
 			.venue(
@@ -112,7 +112,8 @@ class ShowControllerTest {
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.code").value("ok"))
 			.andExpect(jsonPath("$.data.showId").value(1))
-			.andExpect(jsonPath("$.data.noticeUrl").value("https://img/notice.jpg"))
+			.andExpect(jsonPath("$.data.noticeImgs[0]").value("https://img/notice.jpg"))
+			.andExpect(jsonPath("$.data.detailImgs[0]").value("https://img/detail-1.jpg"))
 			.andExpect(jsonPath("$.data.schedules[1].status").value(ShowScheduleStatus.CLOSED.name()))
 			.andExpect(jsonPath("$.data.schedules[2].status").value(ShowScheduleStatus.CANCELLED.name()))
 			.andExpect(jsonPath("$.data.castings[0].artistName").value("배우A"))
@@ -121,7 +122,7 @@ class ShowControllerTest {
 	}
 
 	@Test
-	@DisplayName("noticeUrl이 없고 회차/좌석 정보가 없어도 200과 빈 목록을 응답한다.")
+	@DisplayName("noticeImgs/detailImgs가 비어도 회차/좌석 정보와 함께 200을 응답한다.")
 	void 공연_상세_조회_공지없음_빈목록_성공() throws Exception {
 		ShowResponse.Detail response = ShowResponse.Detail.builder()
 			.showId(10L)
@@ -130,7 +131,8 @@ class ShowControllerTest {
 			.runtimeMin(100)
 			.ageLimit(12)
 			.posterUrl("https://img/2.jpg")
-			.noticeUrl(null)
+			.noticeImgs(List.of())
+			.detailImgs(List.of())
 			.startTime(LocalDateTime.of(2026, 5, 1, 0, 0))
 			.endTime(LocalDateTime.of(2026, 5, 31, 0, 0))
 			.venue(ShowResponse.Venue.builder()
@@ -147,7 +149,10 @@ class ShowControllerTest {
 
 		mockMvc.perform(get("/api/shows/{showId}", 10L))
 			.andExpect(status().isOk())
-			.andExpect(jsonPath("$.data.noticeUrl").value(nullValue()))
+			.andExpect(jsonPath("$.data.noticeImgs").isArray())
+			.andExpect(jsonPath("$.data.noticeImgs").isEmpty())
+			.andExpect(jsonPath("$.data.detailImgs").isArray())
+			.andExpect(jsonPath("$.data.detailImgs").isEmpty())
 			.andExpect(jsonPath("$.data.schedules").isArray())
 			.andExpect(jsonPath("$.data.schedules").isEmpty())
 			.andExpect(jsonPath("$.data.seatGrades").isArray())
@@ -196,8 +201,16 @@ class ShowControllerTest {
 					.scheduleId(101L)
 					.showTime(LocalDateTime.of(2026, 1, 2, 19, 0))
 					.casts(Map.of(
-						"찰리", ShowCastingResponse.CastArtist.builder().artistId(1L).artistName("김호영").build(),
-						"롤라", ShowCastingResponse.CastArtist.builder().artistId(10L).artistName("강홍석").build()
+						"찰리", ShowCastingResponse.CastArtist.builder()
+							.artistId(1L)
+							.artistName("김호영")
+							.profileImageUrl("https://img.example/artist-charlie.jpg")
+							.build(),
+						"롤라", ShowCastingResponse.CastArtist.builder()
+							.artistId(10L)
+							.artistName("강홍석")
+							.profileImageUrl("https://img.example/artist-lola.jpg")
+							.build()
 					))
 					.build()
 			))
@@ -225,6 +238,7 @@ class ShowControllerTest {
 			.andExpect(jsonPath("$.data.roles[0].roleName").value("찰리"))
 			.andExpect(jsonPath("$.data.page.currentPage").value(0))
 			.andExpect(jsonPath("$.data.rows[0].scheduleId").value(101))
-			.andExpect(jsonPath("$.data.rows[0].casts.찰리.artistName").value("김호영"));
+			.andExpect(jsonPath("$.data.rows[0].casts.찰리.artistName").value("김호영"))
+			.andExpect(jsonPath("$.data.rows[0].casts.찰리.profileImageUrl").value("https://img.example/artist-charlie.jpg"));
 	}
 }

--- a/musical/src/test/java/com/truve/platform/musical/show/controller/ShowControllerTest.java
+++ b/musical/src/test/java/com/truve/platform/musical/show/controller/ShowControllerTest.java
@@ -203,18 +203,16 @@ class ShowControllerTest {
 				ShowCastingResponse.Row.builder()
 					.scheduleId(101L)
 					.showTime(LocalDateTime.of(2026, 1, 2, 19, 0))
-					.casts(Map.of(
-						"찰리", ShowCastingResponse.CastArtist.builder()
-							.artistId(1L)
-							.artistName("김호영")
-							.profileImageUrl("https://img.example/show-casting-charlie.jpg")
-							.build(),
-						"롤라", ShowCastingResponse.CastArtist.builder()
-							.artistId(10L)
-							.artistName("강홍석")
-							.profileImageUrl("https://img.example/show-casting-lola.jpg")
-							.build()
-					))
+						.casts(Map.of(
+							"찰리", ShowCastingResponse.CastArtist.builder()
+								.artistId(1L)
+								.artistName("김호영")
+								.build(),
+							"롤라", ShowCastingResponse.CastArtist.builder()
+								.artistId(10L)
+								.artistName("강홍석")
+								.build()
+						))
 					.build()
 			))
 			.build();
@@ -239,9 +237,9 @@ class ShowControllerTest {
 			.andExpect(jsonPath("$.data.showId").value(1))
 			.andExpect(jsonPath("$.data.range.from").value("2025-12-17"))
 			.andExpect(jsonPath("$.data.roles[0].roleName").value("찰리"))
-			.andExpect(jsonPath("$.data.page.currentPage").value(0))
-			.andExpect(jsonPath("$.data.rows[0].scheduleId").value(101))
-			.andExpect(jsonPath("$.data.rows[0].casts.찰리.artistName").value("김호영"))
-			.andExpect(jsonPath("$.data.rows[0].casts.찰리.profileImageUrl").value("https://img.example/show-casting-charlie.jpg"));
+				.andExpect(jsonPath("$.data.page.currentPage").value(0))
+				.andExpect(jsonPath("$.data.rows[0].scheduleId").value(101))
+				.andExpect(jsonPath("$.data.rows[0].casts.찰리.artistName").value("김호영"))
+				.andExpect(jsonPath("$.data.rows[0].casts.찰리.profileImageUrl").doesNotExist());
 	}
 }

--- a/musical/src/test/java/com/truve/platform/show/service/service/ShowServiceTest.java
+++ b/musical/src/test/java/com/truve/platform/show/service/service/ShowServiceTest.java
@@ -109,16 +109,10 @@ class ShowServiceTest {
 		Artist artistC = org.mockito.Mockito.mock(Artist.class);
 		when(artistA.getId()).thenReturn(101L);
 		when(artistA.getName()).thenReturn("배우A");
-		when(artistA.getProfileImg()).thenReturn("artistA.jpg");
-		when(s3Service.getImageUrl("artistA.jpg")).thenReturn("https://img.example/artistA.jpg");
 		when(artistB.getId()).thenReturn(102L);
 		when(artistB.getName()).thenReturn("배우B");
-		when(artistB.getProfileImg()).thenReturn("artistB.jpg");
-		when(s3Service.getImageUrl("artistB.jpg")).thenReturn("https://img.example/artistB.jpg");
 		when(artistC.getId()).thenReturn(103L);
 		when(artistC.getName()).thenReturn("배우C");
-		when(artistC.getProfileImg()).thenReturn("artistC.jpg");
-		when(s3Service.getImageUrl("artistC.jpg")).thenReturn("https://img.example/artistC.jpg");
 
 		ShowCasting castOrder1 = org.mockito.Mockito.mock(ShowCasting.class);
 		ShowCasting castOrder2 = org.mockito.Mockito.mock(ShowCasting.class);
@@ -127,14 +121,18 @@ class ShowServiceTest {
 		when(castOrder1.getArtist()).thenReturn(artistA);
 		when(castOrder1.getRoleName()).thenReturn("주연");
 		when(castOrder1.getCastingOrder()).thenReturn(1);
+		when(castOrder1.getProfileImg()).thenReturn("show-casting-artistA.jpg");
+		when(s3Service.getImageUrl("show-casting-artistA.jpg")).thenReturn("https://img.example/show-casting-artistA.jpg");
 		when(castOrder2.getId()).thenReturn(5002L);
 		when(castOrder2.getArtist()).thenReturn(artistB);
 		when(castOrder2.getRoleName()).thenReturn("조연");
 		when(castOrder2.getCastingOrder()).thenReturn(2);
+		when(castOrder2.getProfileImg()).thenReturn(null);
 		when(castOrderNull.getId()).thenReturn(5003L);
 		when(castOrderNull.getArtist()).thenReturn(artistC);
 		when(castOrderNull.getRoleName()).thenReturn("특별출연");
 		when(castOrderNull.getCastingOrder()).thenReturn(null);
+		when(castOrderNull.getProfileImg()).thenReturn(null);
 
 		ShowSectionGrade seat = org.mockito.Mockito.mock(ShowSectionGrade.class);
 		when(seat.getId()).thenReturn(7001L);
@@ -163,11 +161,13 @@ class ShowServiceTest {
 		List<ShowResponse.Casting> castings = result.getCastings();
 		assertEquals(3, castings.size());
 		assertEquals("배우A", castings.get(0).getArtistName());
-		assertEquals("https://img.example/artistA.jpg", castings.get(0).getProfileImageUrl());
+		assertEquals("https://img.example/show-casting-artistA.jpg", castings.get(0).getProfileImageUrl());
 		assertEquals(1, castings.get(0).getOrder());
 		assertEquals("배우B", castings.get(1).getArtistName());
+		assertNull(castings.get(1).getProfileImageUrl());
 		assertEquals(2, castings.get(1).getOrder());
 		assertEquals("배우C", castings.get(2).getArtistName());
+		assertNull(castings.get(2).getProfileImageUrl());
 		assertNull(castings.get(2).getOrder());
 
 		assertTrue(castings.get(0).getIsLiked());
@@ -191,24 +191,24 @@ class ShowServiceTest {
 		Artist artistCharlie = org.mockito.Mockito.mock(Artist.class);
 		when(artistCharlie.getId()).thenReturn(1L);
 		when(artistCharlie.getName()).thenReturn("김호영");
-		when(artistCharlie.getProfileImg()).thenReturn("artist-charlie.png");
-		when(s3Service.getImageUrl("artist-charlie.png")).thenReturn("https://img.example/artist-charlie.png");
 
 		Artist artistLola = org.mockito.Mockito.mock(Artist.class);
 		when(artistLola.getId()).thenReturn(10L);
 		when(artistLola.getName()).thenReturn("강홍석");
-		when(artistLola.getProfileImg()).thenReturn("artist-lola.png");
-		when(s3Service.getImageUrl("artist-lola.png")).thenReturn("https://img.example/artist-lola.png");
 
 		ShowCasting charlieCasting = org.mockito.Mockito.mock(ShowCasting.class);
 		when(charlieCasting.getRoleName()).thenReturn("찰리");
 		when(charlieCasting.getCastingOrder()).thenReturn(1);
 		when(charlieCasting.getArtist()).thenReturn(artistCharlie);
+		when(charlieCasting.getProfileImg()).thenReturn("show-casting-charlie.png");
+		when(s3Service.getImageUrl("show-casting-charlie.png"))
+			.thenReturn("https://img.example/show-casting-charlie.png");
 
 		ShowCasting lolaCasting = org.mockito.Mockito.mock(ShowCasting.class);
 		when(lolaCasting.getRoleName()).thenReturn("롤라");
 		when(lolaCasting.getCastingOrder()).thenReturn(2);
 		when(lolaCasting.getArtist()).thenReturn(artistLola);
+		when(lolaCasting.getProfileImg()).thenReturn(null);
 
 		ShowScheduleCasting sc1 = org.mockito.Mockito.mock(ShowScheduleCasting.class);
 		when(sc1.getShowSchedule()).thenReturn(schedule1);
@@ -245,11 +245,15 @@ class ShowServiceTest {
 		assertEquals(2, result.getRoles().size());
 		assertEquals("찰리", result.getRoles().get(0).getRoleName());
 		assertEquals(1, result.getRoles().get(0).getOrder());
-		assertEquals("https://img.example/artist-charlie.png", result.getFilters().getArtists().get(0).getProfileImageUrl());
 		assertEquals(1, result.getRows().size());
 		assertEquals(101L, result.getRows().get(0).getScheduleId());
 		assertEquals("김호영", result.getRows().get(0).getCasts().get("찰리").getArtistName());
+		assertEquals(
+			"https://img.example/show-casting-charlie.png",
+			result.getRows().get(0).getCasts().get("찰리").getProfileImageUrl()
+		);
 		assertEquals("강홍석", result.getRows().get(0).getCasts().get("롤라").getArtistName());
+		assertNull(result.getRows().get(0).getCasts().get("롤라").getProfileImageUrl());
 		assertEquals(0, result.getPage().getCurrentPage());
 		assertEquals(50, result.getPage().getSize());
 		assertEquals(1, result.getPage().getTotalElements());

--- a/musical/src/test/java/com/truve/platform/show/service/service/ShowServiceTest.java
+++ b/musical/src/test/java/com/truve/platform/show/service/service/ShowServiceTest.java
@@ -111,6 +111,8 @@ class ShowServiceTest {
 		when(artistA.getName()).thenReturn("배우A");
 		when(artistB.getId()).thenReturn(102L);
 		when(artistB.getName()).thenReturn("배우B");
+		when(artistB.getProfileImg()).thenReturn("artistB.jpg");
+		when(s3Service.getImageUrl("artistB.jpg")).thenReturn("https://img.example/artistB.jpg");
 		when(artistC.getId()).thenReturn(103L);
 		when(artistC.getName()).thenReturn("배우C");
 
@@ -164,7 +166,7 @@ class ShowServiceTest {
 		assertEquals("https://img.example/show-casting-artistA.jpg", castings.get(0).getProfileImageUrl());
 		assertEquals(1, castings.get(0).getOrder());
 		assertEquals("배우B", castings.get(1).getArtistName());
-		assertNull(castings.get(1).getProfileImageUrl());
+		assertEquals("https://img.example/artistB.jpg", castings.get(1).getProfileImageUrl());
 		assertEquals(2, castings.get(1).getOrder());
 		assertEquals("배우C", castings.get(2).getArtistName());
 		assertNull(castings.get(2).getProfileImageUrl());

--- a/musical/src/test/java/com/truve/platform/show/service/service/ShowServiceTest.java
+++ b/musical/src/test/java/com/truve/platform/show/service/service/ShowServiceTest.java
@@ -191,14 +191,14 @@ class ShowServiceTest {
 		Artist artistCharlie = org.mockito.Mockito.mock(Artist.class);
 		when(artistCharlie.getId()).thenReturn(1L);
 		when(artistCharlie.getName()).thenReturn("김호영");
-		when(artistCharlie.getProfileImg()).thenReturn("artist-charlie.jpg");
-		when(s3Service.getImageUrl("artist-charlie.jpg")).thenReturn("https://img.example/artist-charlie.jpg");
+		when(artistCharlie.getProfileImg()).thenReturn("artist-charlie.png");
+		when(s3Service.getImageUrl("artist-charlie.png")).thenReturn("https://img.example/artist-charlie.png");
 
 		Artist artistLola = org.mockito.Mockito.mock(Artist.class);
 		when(artistLola.getId()).thenReturn(10L);
 		when(artistLola.getName()).thenReturn("강홍석");
-		when(artistLola.getProfileImg()).thenReturn("artist-lola.jpg");
-		when(s3Service.getImageUrl("artist-lola.jpg")).thenReturn("https://img.example/artist-lola.jpg");
+		when(artistLola.getProfileImg()).thenReturn("artist-lola.png");
+		when(s3Service.getImageUrl("artist-lola.png")).thenReturn("https://img.example/artist-lola.png");
 
 		ShowCasting charlieCasting = org.mockito.Mockito.mock(ShowCasting.class);
 		when(charlieCasting.getRoleName()).thenReturn("찰리");
@@ -245,12 +245,11 @@ class ShowServiceTest {
 		assertEquals(2, result.getRoles().size());
 		assertEquals("찰리", result.getRoles().get(0).getRoleName());
 		assertEquals(1, result.getRoles().get(0).getOrder());
+		assertEquals("https://img.example/artist-charlie.png", result.getFilters().getArtists().get(0).getProfileImageUrl());
 		assertEquals(1, result.getRows().size());
 		assertEquals(101L, result.getRows().get(0).getScheduleId());
 		assertEquals("김호영", result.getRows().get(0).getCasts().get("찰리").getArtistName());
-		assertEquals("https://img.example/artist-charlie.jpg", result.getRows().get(0).getCasts().get("찰리").getProfileImageUrl());
 		assertEquals("강홍석", result.getRows().get(0).getCasts().get("롤라").getArtistName());
-		assertEquals("https://img.example/artist-lola.jpg", result.getRows().get(0).getCasts().get("롤라").getProfileImageUrl());
 		assertEquals(0, result.getPage().getCurrentPage());
 		assertEquals(50, result.getPage().getSize());
 		assertEquals(1, result.getPage().getTotalElements());

--- a/musical/src/test/java/com/truve/platform/show/service/service/ShowServiceTest.java
+++ b/musical/src/test/java/com/truve/platform/show/service/service/ShowServiceTest.java
@@ -200,15 +200,11 @@ class ShowServiceTest {
 		when(charlieCasting.getRoleName()).thenReturn("찰리");
 		when(charlieCasting.getCastingOrder()).thenReturn(1);
 		when(charlieCasting.getArtist()).thenReturn(artistCharlie);
-		when(charlieCasting.getProfileImg()).thenReturn("show-casting-charlie.png");
-		when(s3Service.getImageUrl("show-casting-charlie.png"))
-			.thenReturn("https://img.example/show-casting-charlie.png");
 
 		ShowCasting lolaCasting = org.mockito.Mockito.mock(ShowCasting.class);
 		when(lolaCasting.getRoleName()).thenReturn("롤라");
 		when(lolaCasting.getCastingOrder()).thenReturn(2);
 		when(lolaCasting.getArtist()).thenReturn(artistLola);
-		when(lolaCasting.getProfileImg()).thenReturn(null);
 
 		ShowScheduleCasting sc1 = org.mockito.Mockito.mock(ShowScheduleCasting.class);
 		when(sc1.getShowSchedule()).thenReturn(schedule1);
@@ -248,12 +244,7 @@ class ShowServiceTest {
 		assertEquals(1, result.getRows().size());
 		assertEquals(101L, result.getRows().get(0).getScheduleId());
 		assertEquals("김호영", result.getRows().get(0).getCasts().get("찰리").getArtistName());
-		assertEquals(
-			"https://img.example/show-casting-charlie.png",
-			result.getRows().get(0).getCasts().get("찰리").getProfileImageUrl()
-		);
 		assertEquals("강홍석", result.getRows().get(0).getCasts().get("롤라").getArtistName());
-		assertNull(result.getRows().get(0).getCasts().get("롤라").getProfileImageUrl());
 		assertEquals(0, result.getPage().getCurrentPage());
 		assertEquals(50, result.getPage().getSize());
 		assertEquals(1, result.getPage().getTotalElements());

--- a/musical/src/test/java/com/truve/platform/show/service/service/ShowServiceTest.java
+++ b/musical/src/test/java/com/truve/platform/show/service/service/ShowServiceTest.java
@@ -81,9 +81,14 @@ class ShowServiceTest {
 		when(show.getRuntimeMin()).thenReturn(120);
 		when(show.getAgeLimit()).thenReturn(8);
 		when(show.getPosterImg()).thenReturn("poster.jpg");
-		when(show.getNoticeImg()).thenReturn("notice.jpg");
+		when(show.getNoticeImg()).thenReturn(List.of("notice.jpg", "detail1.jpg", "detail2.jpg"));
+		when(show.getDetailImg()).thenReturn(List.of("content1.jpg", "content2.jpg"));
 		when(s3Service.getImageUrl("poster.jpg")).thenReturn("https://img/poster.jpg");
-		when(s3Service.getImageUrl("notice.jpg")).thenReturn(null);
+		when(s3Service.getImageUrl("notice.jpg")).thenReturn("https://img/notice.jpg");
+		when(s3Service.getImageUrl("detail1.jpg")).thenReturn("https://img/detail1.jpg");
+		when(s3Service.getImageUrl("detail2.jpg")).thenReturn("https://img/detail2.jpg");
+		when(s3Service.getImageUrl("content1.jpg")).thenReturn("https://img/content1.jpg");
+		when(s3Service.getImageUrl("content2.jpg")).thenReturn("https://img/content2.jpg");
 		when(show.getStartTime()).thenReturn(LocalDateTime.of(2026, 3, 1, 0, 0));
 		when(show.getEndTime()).thenReturn(LocalDateTime.of(2026, 4, 1, 0, 0));
 		when(show.getVenueId()).thenReturn(10L);
@@ -147,6 +152,10 @@ class ShowServiceTest {
 
 		ShowResponse.Detail result = showDetailService.getDetail(showId, userId);
 
+		assertEquals(3, result.getNoticeImgs().size());
+		assertEquals("https://img/notice.jpg", result.getNoticeImgs().get(0));
+		assertEquals(2, result.getDetailImgs().size());
+		assertEquals("https://img/content1.jpg", result.getDetailImgs().get(0));
 		assertEquals(2, result.getSchedules().size());
 		assertEquals("OPEN", result.getSchedules().get(0).getStatus());
 		assertEquals("CANCELLED", result.getSchedules().get(1).getStatus());
@@ -182,10 +191,14 @@ class ShowServiceTest {
 		Artist artistCharlie = org.mockito.Mockito.mock(Artist.class);
 		when(artistCharlie.getId()).thenReturn(1L);
 		when(artistCharlie.getName()).thenReturn("김호영");
+		when(artistCharlie.getProfileImg()).thenReturn("artist-charlie.jpg");
+		when(s3Service.getImageUrl("artist-charlie.jpg")).thenReturn("https://img.example/artist-charlie.jpg");
 
 		Artist artistLola = org.mockito.Mockito.mock(Artist.class);
 		when(artistLola.getId()).thenReturn(10L);
 		when(artistLola.getName()).thenReturn("강홍석");
+		when(artistLola.getProfileImg()).thenReturn("artist-lola.jpg");
+		when(s3Service.getImageUrl("artist-lola.jpg")).thenReturn("https://img.example/artist-lola.jpg");
 
 		ShowCasting charlieCasting = org.mockito.Mockito.mock(ShowCasting.class);
 		when(charlieCasting.getRoleName()).thenReturn("찰리");
@@ -235,7 +248,9 @@ class ShowServiceTest {
 		assertEquals(1, result.getRows().size());
 		assertEquals(101L, result.getRows().get(0).getScheduleId());
 		assertEquals("김호영", result.getRows().get(0).getCasts().get("찰리").getArtistName());
+		assertEquals("https://img.example/artist-charlie.jpg", result.getRows().get(0).getCasts().get("찰리").getProfileImageUrl());
 		assertEquals("강홍석", result.getRows().get(0).getCasts().get("롤라").getArtistName());
+		assertEquals("https://img.example/artist-lola.jpg", result.getRows().get(0).getCasts().get("롤라").getProfileImageUrl());
 		assertEquals(0, result.getPage().getCurrentPage());
 		assertEquals(50, result.getPage().getSize());
 		assertEquals(1, result.getPage().getTotalElements());


### PR DESCRIPTION
## 변경 사항

---
- 공연 상세 응답 이미지 필드 변경
      - noticeUrl (String) → noticeImgs (List<String>)
      - detailImgs (List<String>) 추가
- shows 엔티티 이미지 컬럼을 List<String>으로 매핑
      - @Convert(StringListConverter) 적용
- 캐스팅 일정 응답(ShowCastingResponse.CastArtist)에 profileImageUrl 추가

- [x] 전체 테스트 코드 성공 여부

## 관련 이슈

---
- Notion Ticket: #

## 참고사항 (선택)

---