### PR TITLE
Refactor(musical): 캐스팅 일정 표시 라벨 및 상세 date 필드 추가

### DIFF
--- a/musical/src/main/java/com/truve/platform/musical/show/dto/ShowCastingResponse.java
+++ b/musical/src/main/java/com/truve/platform/musical/show/dto/ShowCastingResponse.java
@@ -71,6 +71,8 @@ public class ShowCastingResponse {
 	public static class Row {
 		private Long scheduleId;
 		private LocalDateTime showTime;
+		private String showDateLabel;
+		private String showTimeLabel;
 		private Map<String, CastArtist> casts;
 	}
 

--- a/musical/src/main/java/com/truve/platform/musical/show/dto/ShowResponse.java
+++ b/musical/src/main/java/com/truve/platform/musical/show/dto/ShowResponse.java
@@ -21,6 +21,7 @@ public class ShowResponse {
 		private String posterUrl;
 		private List<String> noticeImgs;
 		private List<String> detailImgs;
+		private String date;
 		private LocalDateTime startTime;
 		private LocalDateTime endTime;
 		private Venue venue;

--- a/musical/src/main/java/com/truve/platform/musical/show/service/ShowCastingService.java
+++ b/musical/src/main/java/com/truve/platform/musical/show/service/ShowCastingService.java
@@ -3,9 +3,11 @@ package com.truve.platform.musical.show.service;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -30,6 +32,10 @@ import lombok.RequiredArgsConstructor;
 @Service
 @RequiredArgsConstructor
 public class ShowCastingService {
+	private static final DateTimeFormatter SHOW_DATE_LABEL_FORMATTER =
+		DateTimeFormatter.ofPattern("MM/dd(E)", Locale.KOREAN);
+	private static final DateTimeFormatter SHOW_TIME_LABEL_FORMATTER =
+		DateTimeFormatter.ofPattern("a h:mm", Locale.KOREAN);
 
 	private final ShowRepository showRepository;
 	private final ShowScheduleRepository showScheduleRepository;
@@ -85,15 +91,24 @@ public class ShowCastingService {
 			.map(schedule -> ShowCastingResponse.Row.builder()
 				.scheduleId(schedule.getId())
 				.showTime(schedule.getShowTime())
+				.showDateLabel(toShowDateLabel(schedule.getShowTime()))
+				.showTimeLabel(toShowTimeLabel(schedule.getShowTime()))
 				.casts(castsByScheduleId.getOrDefault(schedule.getId(), Map.of()))
 				.build())
 			.toList();
 
+		LocalDate rangeFrom = from != null
+			? from
+			: (show.getStartTime() != null ? show.getStartTime().toLocalDate() : null);
+		LocalDate rangeTo = to != null
+			? to
+			: (show.getEndTime() != null ? show.getEndTime().toLocalDate() : null);
+
 		return ShowCastingResponse.Detail.builder()
 			.showId(show.getId())
 			.range(ShowCastingResponse.Range.builder()
-				.from(show.getStartTime() != null ? show.getStartTime().toLocalDate() : null)
-				.to(show.getEndTime() != null ? show.getEndTime().toLocalDate() : null)
+				.from(rangeFrom)
+				.to(rangeTo)
 				.build())
 			.filters(ShowCastingResponse.Filters.builder()
 				.artists(filterArtists)
@@ -160,5 +175,19 @@ public class ShowCastingService {
 			result.put(scheduleId, casts);
 		});
 		return result;
+	}
+
+	private String toShowDateLabel(LocalDateTime showTime) {
+		if (showTime == null) {
+			return null;
+		}
+		return showTime.format(SHOW_DATE_LABEL_FORMATTER);
+	}
+
+	private String toShowTimeLabel(LocalDateTime showTime) {
+		if (showTime == null) {
+			return null;
+		}
+		return showTime.toLocalTime().format(SHOW_TIME_LABEL_FORMATTER);
 	}
 }

--- a/musical/src/main/java/com/truve/platform/musical/show/service/ShowDetailService.java
+++ b/musical/src/main/java/com/truve/platform/musical/show/service/ShowDetailService.java
@@ -1,5 +1,7 @@
 package com.truve.platform.musical.show.service;
 
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
@@ -29,6 +31,8 @@ import lombok.RequiredArgsConstructor;
 @Service
 @RequiredArgsConstructor
 public class ShowDetailService {
+	private static final DateTimeFormatter DATE_LABEL_FORMATTER = DateTimeFormatter.ofPattern("yyyy.MM.dd");
+	private static final String DEFAULT_DATE = "기간 미정";
 
 	private final ShowRepository showRepository;
 	private final ShowCastingRepository showCastingRepository;
@@ -71,6 +75,7 @@ public class ShowDetailService {
 			.posterUrl(toImageUrl(show.getPosterImg()))
 			.noticeImgs(toImageUrls(show.getNoticeImg()))
 			.detailImgs(toImageUrls(show.getDetailImg()))
+			.date(toDateRange(show.getStartTime(), show.getEndTime()))
 			.startTime(show.getStartTime())
 			.endTime(show.getEndTime())
 			.venue(toVenueResponse(show))
@@ -158,5 +163,12 @@ public class ShowDetailService {
 			return casting.getProfileImg();
 		}
 		return casting.getArtist().getProfileImg();
+	}
+
+	private String toDateRange(LocalDateTime startTime, LocalDateTime endTime) {
+		if (startTime == null || endTime == null) {
+			return DEFAULT_DATE;
+		}
+		return startTime.format(DATE_LABEL_FORMATTER) + " ~ " + endTime.format(DATE_LABEL_FORMATTER);
 	}
 }

--- a/musical/src/test/java/com/truve/platform/show/service/service/ShowServiceTest.java
+++ b/musical/src/test/java/com/truve/platform/show/service/service/ShowServiceTest.java
@@ -156,6 +156,7 @@ class ShowServiceTest {
 		assertEquals("https://img/notice.jpg", result.getNoticeImgs().get(0));
 		assertEquals(2, result.getDetailImgs().size());
 		assertEquals("https://img/content1.jpg", result.getDetailImgs().get(0));
+		assertEquals("2026.03.01 ~ 2026.04.01", result.getDate());
 		assertEquals(2, result.getSchedules().size());
 		assertEquals("OPEN", result.getSchedules().get(0).getStatus());
 		assertEquals("CANCELLED", result.getSchedules().get(1).getStatus());
@@ -183,8 +184,6 @@ class ShowServiceTest {
 		Long showId = 1L;
 		Show show = org.mockito.Mockito.mock(Show.class);
 		when(show.getId()).thenReturn(showId);
-		when(show.getStartTime()).thenReturn(LocalDateTime.of(2025, 12, 17, 0, 0));
-		when(show.getEndTime()).thenReturn(LocalDateTime.of(2026, 3, 29, 0, 0));
 
 		ShowSchedule schedule1 = org.mockito.Mockito.mock(ShowSchedule.class);
 		when(schedule1.getId()).thenReturn(101L);
@@ -245,11 +244,47 @@ class ShowServiceTest {
 		assertEquals(1, result.getRoles().get(0).getOrder());
 		assertEquals(1, result.getRows().size());
 		assertEquals(101L, result.getRows().get(0).getScheduleId());
+		assertEquals("01/02(금)", result.getRows().get(0).getShowDateLabel());
+		assertEquals("오후 7:00", result.getRows().get(0).getShowTimeLabel());
 		assertEquals("김호영", result.getRows().get(0).getCasts().get("찰리").getArtistName());
 		assertEquals("강홍석", result.getRows().get(0).getCasts().get("롤라").getArtistName());
 		assertEquals(0, result.getPage().getCurrentPage());
 		assertEquals(50, result.getPage().getSize());
 		assertEquals(1, result.getPage().getTotalElements());
 		assertEquals(1, result.getPage().getTotalPages());
+	}
+
+	@Test
+	@DisplayName("캐스팅 일정 조회 range는 요청 from/to를 우선 반환한다.")
+	void 캐스팅_일정_조회_range는_요청값_우선() {
+		Long showId = 1L;
+		Show show = org.mockito.Mockito.mock(Show.class);
+		when(show.getId()).thenReturn(showId);
+
+		LocalDate requestFrom = LocalDate.of(2026, 3, 10);
+		LocalDate requestTo = LocalDate.of(2026, 3, 12);
+
+		when(showRepository.findByIdOrThrow(showId)).thenReturn(show);
+		when(showScheduleRepository.findCastingSchedules(
+			org.mockito.ArgumentMatchers.eq(showId),
+			org.mockito.ArgumentMatchers.any(),
+			org.mockito.ArgumentMatchers.any(),
+			org.mockito.ArgumentMatchers.eq(true),
+			org.mockito.ArgumentMatchers.anyList(),
+			org.mockito.ArgumentMatchers.any(PageRequest.class)
+		)).thenReturn(new PageImpl<>(List.of(), PageRequest.of(0, 50), 0));
+		when(showCastingRepository.findAllByShowId(showId)).thenReturn(List.of());
+
+		ShowCastingResponse.Detail result = showCastingService.getCastingSchedules(
+			showId,
+			requestFrom,
+			requestTo,
+			List.of(),
+			0,
+			50
+		);
+
+		assertEquals(requestFrom, result.getRange().getFrom());
+		assertEquals(requestTo, result.getRange().getTo());
 	}
 }


### PR DESCRIPTION
 ## 변경 사항

  - 캐스팅 일정 조회 응답에 표시용 필드 showDateLabel, showTimeLabel 추가
  - 캐스팅 일정 조회 range를 요청 from/to 우선으로 반환하도록 수정
  - 공연 상세 조회 응답에 date 문자열 필드 추가
  
  - [x] 전체 테스트 코드 성공 여부

  ## 관련 이슈

  - Notion Ticket: # ( )

  ## 참고사항 (선택)