### PR TITLE
chore: docker-compose Kafka 관련 환경변수 추가

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,6 +71,7 @@ services:
       - USER_REDIS_PORT=6379
       - TICKETING_SERVER_URI=http://ticketing:8084
       - MUSICAL_SERVER_URI=http://musical:8085
+      - KAFKA_SERVERS=kafka:9092
     networks:
       - truve-network
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -207,6 +207,7 @@ services:
       - AWS_ACCESS_KEY=test
       - AWS_SECRET_KEY=test
       - AWS_S3_ENDPOINT=http://localstack:4566
+      - KAFKA_SERVERS=kafka:9092
     depends_on:
       db:
         condition: service_healthy

--- a/init-s3.sh
+++ b/init-s3.sh
@@ -6,7 +6,9 @@ awslocal s3api put-public-access-block \
     --public-access-block-configuration "BlockPublicAcls=false,IgnorePublicAcls=false,BlockPublicPolicy=false,RestrictPublicBuckets=false"
 
 cd /tmp
-for i in {1..5}; do
-  echo "This is fake image $i" > "test_$i.png"
-  awslocal s3 cp "test_$i.png" s3://truve-media/ --acl public-read
-done
+awslocal s3 cp "poster_temp.png" s3://truve-media/ --acl public-read
+awslocal s3 cp "notice_temp_1.png" s3://truve-media/ --acl public-read
+awslocal s3 cp "notice_temp_2.png" s3://truve-media/ --acl public-read
+awslocal s3 cp "detail_temp_1.png" s3://truve-media/ --acl public-read
+awslocal s3 cp "detail_temp_2.png" s3://truve-media/ --acl public-read
+awslocal s3 cp "profile_temp.png" s3://truve-media/ --acl public-read


### PR DESCRIPTION
## 변경 사항

---
### Docker-Compose Kafka 관련 환경변수 추가

Kafka 서버 환경변수가 없던 서비스에 추가했습니다!
서버내의 배포용 Docker-Compose에도 추가하는 작업 완료했습니다.

서버 Payment랑 Musical에 카프카 환경변수가 없어서 무한 에러로그 지옥에 갇혀있었을 거 같은데 혹시 이거 때문에 서버가 아팠던 건가 싶네요..

### S3 임시 이미지 이름 변경

test_1~5.png로 생성되던 임시 png 파일 이름을 사용처에 따라 명확하게 변경했습니다.

- [ ] 전체 테스트 코드 성공 여부

## 관련 이슈

---
- Notion Ticket: #

## 참고사항 (선택)

---