### PR TITLE
docs: API Gateway api-docs 라우트 추가

### DIFF
--- a/api-gateway/src/main/resources/application.yml
+++ b/api-gateway/src/main/resources/application.yml
@@ -32,6 +32,33 @@ spring:
       server:
         webflux:
           routes:
+            # api-docs (Swagger)
+            - id: auth-docs
+              uri: ${AUTH_SERVER_URI:http://localhost:8081}
+              predicates:
+                - Path=/api/auth/v3/api-docs
+            - id: payment-docs
+              uri: ${PAYMENT_SERVER_URI:http://localhost:8082}
+              predicates:
+                - Path=/api/payments/v3/api-docs
+            - id: queue-docs
+              uri: ${QUEUE_SERVER_URI:http://localhost:8083}
+              predicates:
+                - Path=/api/queue/v3/api-docs
+            - id: ticketing-docs
+              uri: ${TICKETING_SERVER_URI:http://localhost:8084}
+              predicates:
+                - Path=/api/ticketing/v3/api-docs/ticketing
+            - id: booking-docs
+              uri: ${TICKETING_SERVER_URI:http://localhost:8084}
+              predicates:
+                - Path=/api/ticketing/v3/api-docs/booking
+            - id: musical-docs
+              uri: ${MUSICAL_SERVER_URI:http://localhost:8085}
+              predicates:
+                - Path=/api/musical/v3/api-docs
+
+            # service
             - id: auth-jwt
               uri: ${AUTH_SERVER_URI:http://localhost:8081}
               predicates:
@@ -42,7 +69,7 @@ spring:
               uri: ${AUTH_SERVER_URI:http://localhost:8081}
               predicates:
                 - Path=/api/auth/**
-            - id: auth
+            - id: auth-test
               uri: ${AUTH_SERVER_URI:http://localhost:8081}
               predicates:
                 - Path=/test/**


### PR DESCRIPTION
## 변경 사항

---
<img width="485" height="152" alt="image" src="https://github.com/user-attachments/assets/e7d18ead-d4f2-4ec3-8858-4abb86cb9f0f" />

`JwtAuthenticationFilter`가 적용된 서비스들의 경우, Swagger api-docs 경로도 필터를 통과해야 해서 401 Unauthorized 에러가 발생하는 문제가 있었습니다.
서비스별 api-docs 경로를 필터가 없는 별도의 라우트로 분리했습니다!

- [ ] 전체 테스트 코드 성공 여부

## 관련 이슈

---
- Notion Ticket: #

## 참고사항 (선택)

---