### PR TITLE
refactor(reservation): Reservation 엔티티로 금액 계산 책임 이동

### DIFF
--- a/payment/src/main/java/com/truve/platform/payment/service/event/PaymentUpdated.java
+++ b/payment/src/main/java/com/truve/platform/payment/service/event/PaymentUpdated.java
@@ -18,6 +18,7 @@ public class PaymentUpdated {
 	@NoArgsConstructor
 	public static class Confirmed {
 		private String orderId;
+		private LocalDateTime requestedAt;
 		private LocalDateTime approvedAt;
 		private PaymentMethod method;
 		private VirtualAccount virtualAccount;
@@ -26,6 +27,7 @@ public class PaymentUpdated {
 		public static Confirmed of(Payment payment) {
 			return new Confirmed(
 				payment.getOrderId(),
+				payment.getRequestedAt(),
 				payment.getApprovedAt(),
 				payment.getMethod(),
 				payment.getVirtualAccount(),

--- a/payment/src/main/java/com/truve/platform/payment/service/event/PaymentUpdatedListener.java
+++ b/payment/src/main/java/com/truve/platform/payment/service/event/PaymentUpdatedListener.java
@@ -20,6 +20,7 @@ public class PaymentUpdatedListener {
 		bookingPublisher.publish(
 			new BookingEventCommand.Confirmed(
 				event.getOrderId(),
+				event.getRequestedAt(),
 				event.getApprovedAt(),
 				event.getMethod().getDisplayName(),
 				event.getVirtualAccount() == null ? null

--- a/payment/src/main/java/com/truve/platform/payment/service/external/kafka/BookingEventCommand.java
+++ b/payment/src/main/java/com/truve/platform/payment/service/external/kafka/BookingEventCommand.java
@@ -24,6 +24,8 @@ public class BookingEventCommand {
 	public static class Confirmed implements BookingEvent {
 		private String reservationNumber;
 		@JsonFormat(shape = JsonFormat.Shape.ARRAY)
+		private LocalDateTime bookedAt;
+		@JsonFormat(shape = JsonFormat.Shape.ARRAY)
 		private LocalDateTime paidAt;
 		private String method;
 		private VirtualAccount virtualAccount;

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/domain/entity/Reservation.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/domain/entity/Reservation.java
@@ -49,6 +49,9 @@ public class Reservation extends BaseEntity {
 	private ReservationStatus status;
 
 	@Column
+	private LocalDateTime bookedAt;
+
+	@Column
 	private LocalDateTime paidAt;
 
 	@Embedded
@@ -107,14 +110,16 @@ public class Reservation extends BaseEntity {
 		this.status = ReservationStatus.PENDING_PAYMENT;
 	}
 
-	public void confirm(LocalDateTime paidAt, String paymentMethod, VirtualAccount virtualAccount) {
-		this.paidAt = paidAt;
+	// TODO: 메서드 분리
+	public void confirm(LocalDateTime bookedAt, String paymentMethod, VirtualAccount virtualAccount) {
+		this.bookedAt = bookedAt;
 		this.paymentMethod = paymentMethod;
 
 		if (isVirtualAccountPayment(virtualAccount)) {
 			this.virtualAccount = virtualAccount;
 			this.status = ReservationStatus.PENDING_DEPOSIT;
 		} else {
+			this.paidAt = bookedAt;
 			this.status = ReservationStatus.CONFIRMED;
 		}
 	}

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/domain/entity/Reservation.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/domain/entity/Reservation.java
@@ -27,6 +27,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "reservations")
 public class Reservation extends BaseEntity {
+	private static final Long TICKET_SERVICE_FEE = 2000L;
 
 	@Column(nullable = false)
 	private UUID userId;
@@ -56,7 +57,7 @@ public class Reservation extends BaseEntity {
 	@Column
 	private String paymentMethod;
 
-  @Embedded
+	@Embedded
 	private ShowInfo showInfo;
 
 	@Embedded
@@ -66,12 +67,12 @@ public class Reservation extends BaseEntity {
 	private List<Ticket> tickets = new ArrayList<>();
 
 	@Builder
-	private Reservation(UUID userId, String number, Long totalAmount, Long serviceFee, String gradeSummary, ShowInfo showInfo) {
+	private Reservation(UUID userId, String number, String gradeSummary, ShowInfo showInfo) {
 
 		this.userId = userId;
 		this.number = number;
-		this.totalAmount = totalAmount;
-		this.serviceFee = serviceFee;
+		this.totalAmount = 0L;
+		this.serviceFee = 0L;
 		this.gradeSummary = gradeSummary;
 		this.showInfo = showInfo;
 		this.status = ReservationStatus.CREATED;
@@ -80,16 +81,12 @@ public class Reservation extends BaseEntity {
 	public static Reservation create(
 		UUID userId,
 		String number,
-		Long totalAmount,
-    Long serviceFee,
 		String gradeSummary,
 		ShowInfo showInfo
 	) {
 		return Reservation.builder()
 			.userId(userId)
 			.number(number)
-			.totalAmount(totalAmount)
-			.serviceFee(serviceFee)
 			.gradeSummary(gradeSummary)
 			.showInfo(showInfo)
 			.build();
@@ -97,6 +94,12 @@ public class Reservation extends BaseEntity {
 
 	public void addTickets(List<Ticket> tickets) {
 		this.tickets.addAll(tickets);
+		this.serviceFee = tickets.size() * TICKET_SERVICE_FEE;
+		this.totalAmount = calculateTicketAmount() + this.serviceFee;
+	}
+
+	public Long calculateTicketAmount() {
+		return tickets.stream().mapToLong(Ticket::getPriceSnapshot).sum();
 	}
 
 	public void readyForPayment(Applicant applicant) {

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/domain/entity/Reservation.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/domain/entity/Reservation.java
@@ -111,15 +111,16 @@ public class Reservation extends BaseEntity {
 	}
 
 	// TODO: 메서드 분리
-	public void confirm(LocalDateTime bookedAt, String paymentMethod, VirtualAccount virtualAccount) {
+	public void confirm(LocalDateTime bookedAt, LocalDateTime paidAt, String paymentMethod,
+		VirtualAccount virtualAccount) {
 		this.bookedAt = bookedAt;
+		this.paidAt = paidAt;
 		this.paymentMethod = paymentMethod;
 
 		if (isVirtualAccountPayment(virtualAccount)) {
 			this.virtualAccount = virtualAccount;
 			this.status = ReservationStatus.PENDING_DEPOSIT;
 		} else {
-			this.paidAt = bookedAt;
 			this.status = ReservationStatus.CONFIRMED;
 		}
 	}

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/external/kafka/BookingEventCommand.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/external/kafka/BookingEventCommand.java
@@ -24,6 +24,8 @@ public class BookingEventCommand {
 	public static class Confirmed implements BookingEvent {
 		private String reservationNumber;
 		@JsonFormat(shape = JsonFormat.Shape.ARRAY)
+		private LocalDateTime bookedAt;
+		@JsonFormat(shape = JsonFormat.Shape.ARRAY)
 		private LocalDateTime paidAt;
 		private String method;
 		private VirtualAccount virtualAccount;

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/external/kafka/PaymentEventCommand.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/external/kafka/PaymentEventCommand.java
@@ -18,7 +18,7 @@ public class PaymentEventCommand {
 		public static Create of(Reservation reservation) {
 			return Create.builder()
 				.orderId(reservation.getNumber())
-				.amount(reservation.getTotalAmount() + reservation.getServiceFee())
+				.amount(reservation.getTotalAmount())
 				.build();
 		}
 	}

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/service/BookingService.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/service/BookingService.java
@@ -1,5 +1,7 @@
 package org.truve.platform.ticketing.service.booking.service;
 
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.UUID;
@@ -111,7 +113,12 @@ public class BookingService {
 	@Transactional
 	public void confirm(BookingEventCommand.Confirmed event) {
 		Reservation reservation = reservationRepository.findByNumber(event.getReservationNumber());
-		reservation.confirm(event.getPaidAt(), event.getMethod(), VirtualAccount.from(event.getVirtualAccount()));
+		reservation.confirm(
+			event.getBookedAt(),
+			event.getPaidAt(),
+			event.getMethod(),
+			VirtualAccount.from(event.getVirtualAccount())
+		);
 	}
 
 	@Transactional

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/service/BookingService.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/service/BookingService.java
@@ -26,7 +26,6 @@ import lombok.RequiredArgsConstructor;
 @Service
 @RequiredArgsConstructor
 public class BookingService {
-	private static final Long TICKET_SERVICE_FEE = 2000L;
 	private static final String GRADE_SUMMARY_FORMAT = "%s석 %d인";
 	private static final String LINE_BREAK = "\n";
 	private static final String SEAT_DETAIL_FORMAT = "%d층 %s구역 %s열 %d번";
@@ -52,8 +51,6 @@ public class BookingService {
 		return Reservation.create(
 			userId,
 			numberGenerator.generateReservationNumber(),
-			calculateTotalAmount(seatInfo),
-			TICKET_SERVICE_FEE * seatInfo.getSeats().size(),
 			createGradeSummary(seatInfo),
 			createShowInfo(seatInfo)
 		);
@@ -69,12 +66,6 @@ public class BookingService {
 				createSeatDetail(seat)
 			)
 		).toList();
-	}
-
-	private Long calculateTotalAmount(TicketingResponse.SeatInfo seatInfo) {
-		return seatInfo.getSeats().stream()
-			.map(TicketingResponse.Seat::getPrice)
-			.reduce(0L, Long::sum);
 	}
 
 	private String createGradeSummary(TicketingResponse.SeatInfo seatInfo) {

--- a/ticketing/src/test/java/org/truve/platform/ticketing/service/booking/service/BookingServiceTest.java
+++ b/ticketing/src/test/java/org/truve/platform/ticketing/service/booking/service/BookingServiceTest.java
@@ -76,7 +76,7 @@ class BookingServiceTest {
 
 		assertAll(
 			() -> assertThat(response.getReservationNumber()).isEqualTo(reservationNumber),
-			() -> assertThat(savedReservation.getTotalAmount()).isEqualTo(60000L),
+			() -> assertThat(savedReservation.calculateTicketAmount()).isEqualTo(60000L),
 			() -> assertThat(savedReservation.getGradeSummary()).isEqualTo("VIP석 2인\nS석 1인"),
 			() -> assertThat(savedReservation.getTickets()).hasSize(3),
 			() -> assertThat(savedReservation.getServiceFee()).isEqualTo(6000L),


### PR DESCRIPTION
## 변경 사항

---
### Reservation 엔티티로 금액 계산 책임 이동

[기존] Service에서 서비스 수수료(2000*티켓 수), 총 금액을 계산해 엔티티 생성자 호출
[변경] Service에서 티켓을 추가하는 시점에 **엔티티에서 서비스 수수료, 총 금액 계산 후 저장**

DB에는 서비스 수수료와 서비스 수수료를 포함한 총 결제 금액만 저장합니다.
-> 서비스 수수료를 제외한 티켓 가격의 총합은 호출 빈도가 많지 않은 걸로 판단되어 `calculateTicketAmount` 메서드로 계산

### 예매 시간/결제 시간 분리

Payment 서버에서 결제 요청 시간을 bookedAt으로, 결제 승인 시간을 paidAt으로 매핑
무통장 입금의 경우 입금 확인 후 paidAt 저장

- [X] 전체 테스트 코드 성공 여부
- [X] 예매 생성시 서비스 수수료, 총 금액 계산 확인
- [X] 무통장 입금 승인, 입금시의 bookedAt, paidAt 확인
- [X] 무통장 입금 외 결제 수단의 bookedAt, paidAt 확인

## 관련 이슈

---
- Notion Ticket: #

## 참고사항 (선택)

---
조회 API 구현을 위해 갈 길이 너무 머네요........................