### PR TITLE
feat(user): 자체 로그인 닉네임, 약관 동의 여부 추가

### DIFF
--- a/auth-server/src/main/java/com/truve/platform/auth/service/controller/AuthController.java
+++ b/auth-server/src/main/java/com/truve/platform/auth/service/controller/AuthController.java
@@ -38,7 +38,15 @@ public class AuthController {
 	public ApiResult<Void> signUp(
 		@RequestBody  @Valid AuthRequest.SignUp request
 	) {
-		authService.signUp(request.getEmail(), request.getPassword());
+		authService.signUp(
+			request.getEmail(),
+			request.getPassword(),
+			request.isServiceTermsAgreed(),
+			request.isElectronicFinanceTermsAgreed(),
+			request.isPrivacyCollectionAgreed(),
+			request.isMarketingInfoAgreed(),
+			request.isOver14Agreed()
+		);
 
 		return ApiResult.ok();
 	}

--- a/auth-server/src/main/java/com/truve/platform/auth/service/controller/AuthController.java
+++ b/auth-server/src/main/java/com/truve/platform/auth/service/controller/AuthController.java
@@ -40,6 +40,7 @@ public class AuthController {
 	) {
 		authService.signUp(
 			request.getEmail(),
+			request.getNickname(),
 			request.getPassword(),
 			request.isServiceTermsAgreed(),
 			request.isElectronicFinanceTermsAgreed(),

--- a/auth-server/src/main/java/com/truve/platform/auth/service/domain/dto/request/AuthRequest.java
+++ b/auth-server/src/main/java/com/truve/platform/auth/service/domain/dto/request/AuthRequest.java
@@ -19,6 +19,9 @@ public class AuthRequest {
 		@NotBlank
 		private String password;
 
+		@NotBlank
+		private String nickname;
+
 		private boolean serviceTermsAgreed;
 
 		private boolean electronicFinanceTermsAgreed;

--- a/auth-server/src/main/java/com/truve/platform/auth/service/domain/dto/request/AuthRequest.java
+++ b/auth-server/src/main/java/com/truve/platform/auth/service/domain/dto/request/AuthRequest.java
@@ -18,6 +18,16 @@ public class AuthRequest {
 
 		@NotBlank
 		private String password;
+
+		private boolean serviceTermsAgreed;
+
+		private boolean electronicFinanceTermsAgreed;
+
+		private boolean privacyCollectionAgreed;
+
+		private boolean marketingInfoAgreed;
+
+		private boolean over14Agreed;
 	}
 
 	@Getter

--- a/auth-server/src/main/java/com/truve/platform/auth/service/domain/entity/User.java
+++ b/auth-server/src/main/java/com/truve/platform/auth/service/domain/entity/User.java
@@ -47,10 +47,38 @@ public class User extends BaseEntity {
 
 	private String oAuthRefreshToken;
 
+	@Column(nullable = false)
+	private boolean serviceTermsAgreed;
+
+	@Column(nullable = false)
+	private boolean electronicFinanceTermsAgreed;
+
+	@Column(nullable = false)
+	private boolean privacyCollectionAgreed;
+
+	@Column(nullable = false)
+	private boolean marketingInfoAgreed;
+
+	@Column(nullable = false)
+	private boolean over14Agreed;
+
 
 	@Builder
-	private User(UUID publicId, String email, String password, AuthProvider provider,
-		UserRole role,  String oAuthUserId, String oAuthAccessToken, String oAuthRefreshToken) {
+	private User(
+		UUID publicId,
+		String email,
+		String password,
+		AuthProvider provider,
+		UserRole role,
+		String oAuthUserId,
+		String oAuthAccessToken,
+		String oAuthRefreshToken,
+		boolean serviceTermsAgreed,
+		boolean electronicFinanceTermsAgreed,
+		boolean privacyCollectionAgreed,
+		boolean marketingInfoAgreed,
+		boolean over14Agreed
+	) {
 		this.publicId = publicId;
 		this.email = email;
 		this.password = password;
@@ -59,15 +87,33 @@ public class User extends BaseEntity {
 		this.oAuthUserId = oAuthUserId;
 		this.oAuthAccessToken = oAuthAccessToken;
 		this.oAuthRefreshToken = oAuthRefreshToken;
+		this.serviceTermsAgreed = serviceTermsAgreed;
+		this.electronicFinanceTermsAgreed = electronicFinanceTermsAgreed;
+		this.privacyCollectionAgreed = privacyCollectionAgreed;
+		this.marketingInfoAgreed = marketingInfoAgreed;
+		this.over14Agreed = over14Agreed;
 	}
 
-	public static User createLocalUser(String email, String password) {
+	public static User createLocalUser(
+		String email,
+		String password,
+		boolean serviceTermsAgreed,
+		boolean electronicFinanceTermsAgreed,
+		boolean privacyCollectionAgreed,
+		boolean marketingInfoAgreed,
+		boolean over14Agreed
+	) {
 		return User.builder()
 			.publicId(UUID.randomUUID())
 			.email(email)
 			.password(password)
 			.provider(AuthProvider.LOCAL)
 			.role(UserRole.MEMBER)
+			.serviceTermsAgreed(serviceTermsAgreed)
+			.electronicFinanceTermsAgreed(electronicFinanceTermsAgreed)
+			.privacyCollectionAgreed(privacyCollectionAgreed)
+			.marketingInfoAgreed(marketingInfoAgreed)
+			.over14Agreed(over14Agreed)
 			.build();
 	}
 
@@ -86,6 +132,11 @@ public class User extends BaseEntity {
 			.oAuthUserId(oAuthUserId)
 			.oAuthAccessToken(oAuthAccessToken)
 			.oAuthRefreshToken(oAuthRefreshToken)
+			.serviceTermsAgreed(false)
+			.electronicFinanceTermsAgreed(false)
+			.privacyCollectionAgreed(false)
+			.marketingInfoAgreed(false)
+			.over14Agreed(false)
 			.build();
 	}
 }

--- a/auth-server/src/main/java/com/truve/platform/auth/service/domain/entity/User.java
+++ b/auth-server/src/main/java/com/truve/platform/auth/service/domain/entity/User.java
@@ -30,6 +30,9 @@ public class User extends BaseEntity {
 	@Column(nullable = false, unique = true)
 	private String email;
 
+	@Column(unique = true)
+	private String nickname;
+
 	// TODO: 기획 논의 이후 비밀번호 정책 정규식 설정
 	private String password;
 
@@ -67,6 +70,7 @@ public class User extends BaseEntity {
 	private User(
 		UUID publicId,
 		String email,
+		String nickname,
 		String password,
 		AuthProvider provider,
 		UserRole role,
@@ -81,6 +85,7 @@ public class User extends BaseEntity {
 	) {
 		this.publicId = publicId;
 		this.email = email;
+		this.nickname = nickname;
 		this.password = password;
 		this.provider = provider;
 		this.role = role;
@@ -96,6 +101,7 @@ public class User extends BaseEntity {
 
 	public static User createLocalUser(
 		String email,
+		String nickname,
 		String password,
 		boolean serviceTermsAgreed,
 		boolean electronicFinanceTermsAgreed,
@@ -106,6 +112,7 @@ public class User extends BaseEntity {
 		return User.builder()
 			.publicId(UUID.randomUUID())
 			.email(email)
+			.nickname(nickname)
 			.password(password)
 			.provider(AuthProvider.LOCAL)
 			.role(UserRole.MEMBER)
@@ -127,6 +134,7 @@ public class User extends BaseEntity {
 		return User.builder()
 			.publicId(UUID.randomUUID())
 			.email(email)
+			.nickname(null)
 			.provider(provider)
 			.role(UserRole.MEMBER)
 			.oAuthUserId(oAuthUserId)

--- a/auth-server/src/main/java/com/truve/platform/auth/service/event/UserSignedUpEvent.java
+++ b/auth-server/src/main/java/com/truve/platform/auth/service/event/UserSignedUpEvent.java
@@ -27,8 +27,7 @@ public class UserSignedUpEvent {
 			EVENT_TYPE,
 			LocalDateTime.now(),
 			user.getPublicId(),
-			// TODO: 닉네임으로 변경 예정
-			user.getEmail()
+			user.getNickname()
 		);
 	}
 }

--- a/auth-server/src/main/java/com/truve/platform/auth/service/repository/UserRepository.java
+++ b/auth-server/src/main/java/com/truve/platform/auth/service/repository/UserRepository.java
@@ -17,6 +17,8 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
 	boolean existsByEmail(String email);
 
+	boolean existsByNickname(String nickname);
+
 	default User findByEmailOrThrow(String email) {
 		return findByEmail(email).orElseThrow(
 			() -> new CustomException(ErrorCode.NOT_FOUND_EMAIL)

--- a/auth-server/src/main/java/com/truve/platform/auth/service/service/AuthService.java
+++ b/auth-server/src/main/java/com/truve/platform/auth/service/service/AuthService.java
@@ -99,7 +99,15 @@ public class AuthService {
 	}
 
 	@Transactional
-	public void signUp(String email, String password) {
+	public void signUp(
+		String email,
+		String password,
+		boolean serviceTermsAgreed,
+		boolean electronicFinanceTermsAgreed,
+		boolean privacyCollectionAgreed,
+		boolean marketingInfoAgreed,
+		boolean over14Agreed
+	) {
 
 		String verifiedAt = emailVerificationRepository.isVerifiedEmail(email);
 		Preconditions.validate(!(verifiedAt == null || verifiedAt.isBlank()), ErrorCode.NOT_VERIFIED_EMAIL);
@@ -107,6 +115,10 @@ public class AuthService {
 		Preconditions.validate(
 			!userRepository.existsByEmail(email),
 			ErrorCode.ALREADY_EXISTS_EMAIL
+		);
+		Preconditions.validate(
+			serviceTermsAgreed && electronicFinanceTermsAgreed && privacyCollectionAgreed && over14Agreed,
+			ErrorCode.REQUIRED_TERMS_NOT_AGREED
 		);
 
 		String encodedPassword = passwordEncoder.encode(password);

--- a/auth-server/src/main/java/com/truve/platform/auth/service/service/AuthService.java
+++ b/auth-server/src/main/java/com/truve/platform/auth/service/service/AuthService.java
@@ -1,6 +1,7 @@
 package com.truve.platform.auth.service.service;
 
 import java.util.UUID;
+import java.util.regex.Pattern;
 
 import org.springframework.data.util.Pair;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -23,6 +24,7 @@ import lombok.RequiredArgsConstructor;
 @Service
 @RequiredArgsConstructor
 public class AuthService {
+	private static final Pattern NICKNAME_PATTERN = Pattern.compile("^[a-zA-Z0-9가-힣]{2,10}$");
 
 	private final UserRepository userRepository;
 	private final EmailVerificationRepository emailVerificationRepository;
@@ -116,6 +118,14 @@ public class AuthService {
 		Preconditions.validate(
 			!userRepository.existsByEmail(email),
 			ErrorCode.ALREADY_EXISTS_EMAIL
+		);
+		Preconditions.validate(
+			nickname != null && NICKNAME_PATTERN.matcher(nickname).matches(),
+			ErrorCode.INVALID_NICKNAME
+		);
+		Preconditions.validate(
+			!userRepository.existsByNickname(nickname),
+			ErrorCode.ALREADY_EXISTS_NICKNAME
 		);
 		Preconditions.validate(
 			serviceTermsAgreed && electronicFinanceTermsAgreed && privacyCollectionAgreed && over14Agreed,

--- a/auth-server/src/main/java/com/truve/platform/auth/service/service/AuthService.java
+++ b/auth-server/src/main/java/com/truve/platform/auth/service/service/AuthService.java
@@ -101,6 +101,7 @@ public class AuthService {
 	@Transactional
 	public void signUp(
 		String email,
+		String nickname,
 		String password,
 		boolean serviceTermsAgreed,
 		boolean electronicFinanceTermsAgreed,
@@ -125,6 +126,7 @@ public class AuthService {
 
 		User user = User.createLocalUser(
 			email,
+			nickname,
 			encodedPassword,
 			serviceTermsAgreed,
 			electronicFinanceTermsAgreed,

--- a/auth-server/src/main/java/com/truve/platform/auth/service/service/AuthService.java
+++ b/auth-server/src/main/java/com/truve/platform/auth/service/service/AuthService.java
@@ -123,7 +123,15 @@ public class AuthService {
 
 		String encodedPassword = passwordEncoder.encode(password);
 
-		User user = User.createLocalUser(email, encodedPassword);
+		User user = User.createLocalUser(
+			email,
+			encodedPassword,
+			serviceTermsAgreed,
+			electronicFinanceTermsAgreed,
+			privacyCollectionAgreed,
+			marketingInfoAgreed,
+			over14Agreed
+		);
 
 		userRepository.save(user);
 		emailVerificationRepository.deleteVerifiedEmail(email);

--- a/auth-server/src/main/resources/application.yml
+++ b/auth-server/src/main/resources/application.yml
@@ -13,7 +13,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: validate
+      ddl-auto: update
     show-sql: false
 
   kafka:

--- a/auth-server/src/test/java/com/truve/platform/auth/service/controller/AuthControllerTest.java
+++ b/auth-server/src/test/java/com/truve/platform/auth/service/controller/AuthControllerTest.java
@@ -45,7 +45,12 @@ class AuthControllerTest {
 		String body = """
 			{
 			  "email": "new@test.com",
-			  "password": "password123"
+			  "password": "password123",
+			  "serviceTermsAgreed": true,
+			  "electronicFinanceTermsAgreed": true,
+			  "privacyCollectionAgreed": true,
+			  "marketingInfoAgreed": false,
+			  "over14Agreed": true
 			}
 			""";
 
@@ -57,7 +62,7 @@ class AuthControllerTest {
 		// then
 		resultActions.andExpect(status().isOk())
 			.andExpect(jsonPath("$.code").value("ok"));
-		verify(authService).signUp("new@test.com", "password123");
+		verify(authService).signUp("new@test.com", "password123", true, true, true, false, true);
 	}
 
 	@Test
@@ -67,11 +72,16 @@ class AuthControllerTest {
 		String body = """
 			{
 			  "email": "dup@test.com",
-			  "password": "password123"
+			  "password": "password123",
+			  "serviceTermsAgreed": true,
+			  "electronicFinanceTermsAgreed": true,
+			  "privacyCollectionAgreed": true,
+			  "marketingInfoAgreed": false,
+			  "over14Agreed": true
 			}
 			""";
 		willThrow(new CustomException(ErrorCode.ALREADY_EXISTS_EMAIL))
-			.given(authService).signUp(anyString(), anyString());
+			.given(authService).signUp(anyString(), anyString(), anyBoolean(), anyBoolean(), anyBoolean(), anyBoolean(), anyBoolean());
 
 		// when
 		ResultActions resultActions = mockMvc.perform(post("/api/auth/sign-up")

--- a/auth-server/src/test/java/com/truve/platform/auth/service/controller/AuthControllerTest.java
+++ b/auth-server/src/test/java/com/truve/platform/auth/service/controller/AuthControllerTest.java
@@ -46,6 +46,7 @@ class AuthControllerTest {
 			{
 			  "email": "new@test.com",
 			  "password": "password123",
+			  "nickname": "tester",
 			  "serviceTermsAgreed": true,
 			  "electronicFinanceTermsAgreed": true,
 			  "privacyCollectionAgreed": true,
@@ -62,7 +63,7 @@ class AuthControllerTest {
 		// then
 		resultActions.andExpect(status().isOk())
 			.andExpect(jsonPath("$.code").value("ok"));
-		verify(authService).signUp("new@test.com", "password123", true, true, true, false, true);
+		verify(authService).signUp("new@test.com", "tester", "password123", true, true, true, false, true);
 	}
 
 	@Test
@@ -73,6 +74,7 @@ class AuthControllerTest {
 			{
 			  "email": "dup@test.com",
 			  "password": "password123",
+			  "nickname": "tester",
 			  "serviceTermsAgreed": true,
 			  "electronicFinanceTermsAgreed": true,
 			  "privacyCollectionAgreed": true,
@@ -81,7 +83,7 @@ class AuthControllerTest {
 			}
 			""";
 		willThrow(new CustomException(ErrorCode.ALREADY_EXISTS_EMAIL))
-			.given(authService).signUp(anyString(), anyString(), anyBoolean(), anyBoolean(), anyBoolean(), anyBoolean(), anyBoolean());
+			.given(authService).signUp(anyString(), anyString(), anyString(), anyBoolean(), anyBoolean(), anyBoolean(), anyBoolean(), anyBoolean());
 
 		// when
 		ResultActions resultActions = mockMvc.perform(post("/api/auth/sign-up")
@@ -102,6 +104,7 @@ class AuthControllerTest {
 			{
 			  "email": "new@test.com",
 			  "password": "password123",
+			  "nickname": "tester",
 			  "serviceTermsAgreed": true,
 			  "electronicFinanceTermsAgreed": false,
 			  "privacyCollectionAgreed": true,
@@ -110,7 +113,7 @@ class AuthControllerTest {
 			}
 			""";
 		willThrow(new CustomException(ErrorCode.REQUIRED_TERMS_NOT_AGREED))
-			.given(authService).signUp(anyString(), anyString(), anyBoolean(), anyBoolean(), anyBoolean(), anyBoolean(), anyBoolean());
+			.given(authService).signUp(anyString(), anyString(), anyString(), anyBoolean(), anyBoolean(), anyBoolean(), anyBoolean(), anyBoolean());
 
 		// when
 		ResultActions resultActions = mockMvc.perform(post("/api/auth/sign-up")

--- a/auth-server/src/test/java/com/truve/platform/auth/service/controller/AuthControllerTest.java
+++ b/auth-server/src/test/java/com/truve/platform/auth/service/controller/AuthControllerTest.java
@@ -127,6 +127,36 @@ class AuthControllerTest {
 	}
 
 	@Test
+	@DisplayName("닉네임 형식 오류로 회원가입 요청하면 400을 반환한다.")
+	void 회원가입_실패_닉네임_형식_오류() throws Exception {
+		// given
+		String body = """
+			{
+			  "email": "new@test.com",
+			  "password": "password123",
+			  "nickname": "a b",
+			  "serviceTermsAgreed": true,
+			  "electronicFinanceTermsAgreed": true,
+			  "privacyCollectionAgreed": true,
+			  "marketingInfoAgreed": false,
+			  "over14Agreed": true
+			}
+			""";
+		willThrow(new CustomException(ErrorCode.INVALID_NICKNAME))
+			.given(authService).signUp(anyString(), anyString(), anyString(), anyBoolean(), anyBoolean(), anyBoolean(), anyBoolean(), anyBoolean());
+
+		// when
+		ResultActions resultActions = mockMvc.perform(post("/api/auth/sign-up")
+			.contentType(MediaType.APPLICATION_JSON)
+			.content(body));
+
+		// then
+		resultActions.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.errorType").value("CLIENT_ERROR"))
+			.andExpect(jsonPath("$.code").value(ErrorCode.INVALID_NICKNAME.getCode()));
+	}
+
+	@Test
 	@DisplayName("로그인에 성공하면 accessToken을 반환하고 refreshToken 쿠키를 설정한다.")
 	void 로그인_성공() throws Exception {
 		// given

--- a/auth-server/src/test/java/com/truve/platform/auth/service/controller/AuthControllerTest.java
+++ b/auth-server/src/test/java/com/truve/platform/auth/service/controller/AuthControllerTest.java
@@ -95,6 +95,35 @@ class AuthControllerTest {
 	}
 
 	@Test
+	@DisplayName("필수 약관 미동의로 회원가입 요청하면 400을 반환한다.")
+	void 회원가입_실패_필수_약관_미동의() throws Exception {
+		// given
+		String body = """
+			{
+			  "email": "new@test.com",
+			  "password": "password123",
+			  "serviceTermsAgreed": true,
+			  "electronicFinanceTermsAgreed": false,
+			  "privacyCollectionAgreed": true,
+			  "marketingInfoAgreed": false,
+			  "over14Agreed": true
+			}
+			""";
+		willThrow(new CustomException(ErrorCode.REQUIRED_TERMS_NOT_AGREED))
+			.given(authService).signUp(anyString(), anyString(), anyBoolean(), anyBoolean(), anyBoolean(), anyBoolean(), anyBoolean());
+
+		// when
+		ResultActions resultActions = mockMvc.perform(post("/api/auth/sign-up")
+			.contentType(MediaType.APPLICATION_JSON)
+			.content(body));
+
+		// then
+		resultActions.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.errorType").value("CLIENT_ERROR"))
+			.andExpect(jsonPath("$.code").value(ErrorCode.REQUIRED_TERMS_NOT_AGREED.getCode()));
+	}
+
+	@Test
 	@DisplayName("로그인에 성공하면 accessToken을 반환하고 refreshToken 쿠키를 설정한다.")
 	void 로그인_성공() throws Exception {
 		// given

--- a/auth-server/src/test/java/com/truve/platform/auth/service/domain/entity/UserTest.java
+++ b/auth-server/src/test/java/com/truve/platform/auth/service/domain/entity/UserTest.java
@@ -28,7 +28,7 @@ class UserTest {
 		@DisplayName("createLocalUser 호출 시 LOCAL/MEMBER 권한으로 사용자를 생성한다.")
 		void createLocalUser_success() {
 			// when
-			User user = User.createLocalUser(EMAIL, PASSWORD);
+			User user = User.createLocalUser(EMAIL, PASSWORD, true, true, true, false, true);
 
 			// then
 			assertAll(
@@ -37,6 +37,11 @@ class UserTest {
 				() -> assertThat(user.getPassword()).isEqualTo(PASSWORD),
 				() -> assertThat(user.getProvider()).isEqualTo(AuthProvider.LOCAL),
 				() -> assertThat(user.getRole()).isEqualTo(UserRole.MEMBER),
+				() -> assertThat(user.isServiceTermsAgreed()).isTrue(),
+				() -> assertThat(user.isElectronicFinanceTermsAgreed()).isTrue(),
+				() -> assertThat(user.isPrivacyCollectionAgreed()).isTrue(),
+				() -> assertThat(user.isMarketingInfoAgreed()).isFalse(),
+				() -> assertThat(user.isOver14Agreed()).isTrue(),
 				() -> assertThat(user.getOAuthUserId()).isNull(),
 				() -> assertThat(user.getOAuthAccessToken()).isNull(),
 				() -> assertThat(user.getOAuthRefreshToken()).isNull()
@@ -67,6 +72,11 @@ class UserTest {
 				() -> assertThat(user.getPassword()).isNull(),
 				() -> assertThat(user.getProvider()).isEqualTo(AuthProvider.KAKAO),
 				() -> assertThat(user.getRole()).isEqualTo(UserRole.MEMBER),
+				() -> assertThat(user.isServiceTermsAgreed()).isFalse(),
+				() -> assertThat(user.isElectronicFinanceTermsAgreed()).isFalse(),
+				() -> assertThat(user.isPrivacyCollectionAgreed()).isFalse(),
+				() -> assertThat(user.isMarketingInfoAgreed()).isFalse(),
+				() -> assertThat(user.isOver14Agreed()).isFalse(),
 				() -> assertThat(user.getOAuthUserId()).isEqualTo(OAUTH_USER_ID),
 				() -> assertThat(user.getOAuthAccessToken()).isEqualTo(OAUTH_ACCESS_TOKEN),
 				() -> assertThat(user.getOAuthRefreshToken()).isEqualTo(OAUTH_REFRESH_TOKEN)

--- a/auth-server/src/test/java/com/truve/platform/auth/service/domain/entity/UserTest.java
+++ b/auth-server/src/test/java/com/truve/platform/auth/service/domain/entity/UserTest.java
@@ -15,6 +15,7 @@ import com.truve.platform.common.constants.UserRole;
 class UserTest {
 
 	private static final String EMAIL = "test@truve.com";
+	private static final String NICKNAME = "tester";
 	private static final String PASSWORD = "encoded-password";
 	private static final String OAUTH_USER_ID = "oauth-user-id";
 	private static final String OAUTH_ACCESS_TOKEN = "oauth-access-token";
@@ -28,12 +29,13 @@ class UserTest {
 		@DisplayName("createLocalUser 호출 시 LOCAL/MEMBER 권한으로 사용자를 생성한다.")
 		void createLocalUser_success() {
 			// when
-			User user = User.createLocalUser(EMAIL, PASSWORD, true, true, true, false, true);
+			User user = User.createLocalUser(EMAIL, NICKNAME, PASSWORD, true, true, true, false, true);
 
 			// then
 			assertAll(
 				() -> assertThat(user.getPublicId()).isInstanceOf(UUID.class),
 				() -> assertThat(user.getEmail()).isEqualTo(EMAIL),
+				() -> assertThat(user.getNickname()).isEqualTo(NICKNAME),
 				() -> assertThat(user.getPassword()).isEqualTo(PASSWORD),
 				() -> assertThat(user.getProvider()).isEqualTo(AuthProvider.LOCAL),
 				() -> assertThat(user.getRole()).isEqualTo(UserRole.MEMBER),
@@ -69,6 +71,7 @@ class UserTest {
 			assertAll(
 				() -> assertThat(user.getPublicId()).isInstanceOf(UUID.class),
 				() -> assertThat(user.getEmail()).isEqualTo(EMAIL),
+				() -> assertThat(user.getNickname()).isNull(),
 				() -> assertThat(user.getPassword()).isNull(),
 				() -> assertThat(user.getProvider()).isEqualTo(AuthProvider.KAKAO),
 				() -> assertThat(user.getRole()).isEqualTo(UserRole.MEMBER),

--- a/auth-server/src/test/java/com/truve/platform/auth/service/service/AuthServiceTest.java
+++ b/auth-server/src/test/java/com/truve/platform/auth/service/service/AuthServiceTest.java
@@ -313,5 +313,29 @@ class AuthServiceTest {
 			verify(emailVerificationRepository, never()).deleteVerifiedEmail(anyString());
 			verify(userSignedUpEventPublisher, never()).publish(anyString(), any());
 		}
+
+		@Test
+		@DisplayName("필수 약관에 동의하지 않으면 예외가 발생한다.")
+		void 회원가입_실패_필수_약관_미동의() {
+			// given
+			String email = "new@test.com";
+			String password = "plain";
+
+			given(emailVerificationRepository.isVerifiedEmail(email)).willReturn("1700000000000");
+			given(userRepository.existsByEmail(email)).willReturn(false);
+
+			// when
+			CustomException exception = assertThrows(
+				CustomException.class,
+				() -> authService.signUp(email, password, true, false, true, false, true)
+			);
+
+			// then
+			assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.REQUIRED_TERMS_NOT_AGREED);
+			verify(passwordEncoder, never()).encode(anyString());
+			verify(userRepository, never()).save(any(User.class));
+			verify(emailVerificationRepository, never()).deleteVerifiedEmail(anyString());
+			verify(userSignedUpEventPublisher, never()).publish(anyString(), any());
+		}
 	}
 }

--- a/auth-server/src/test/java/com/truve/platform/auth/service/service/AuthServiceTest.java
+++ b/auth-server/src/test/java/com/truve/platform/auth/service/service/AuthServiceTest.java
@@ -52,8 +52,10 @@ class AuthServiceTest {
 	@InjectMocks
 	private AuthService authService;
 
+	private static final String NICKNAME = "tester";
+
 	private User createUser(Long id, String email, String encodedPassword) {
-		User user = User.createLocalUser(email, encodedPassword, true, true, true, false, true);
+		User user = User.createLocalUser(email, NICKNAME, encodedPassword, true, true, true, false, true);
 		ReflectionTestUtils.setField(user, "id", id);
 		return user;
 	}
@@ -246,7 +248,7 @@ class AuthServiceTest {
 			});
 
 			// when
-			authService.signUp(email, password, true, true, true, false, true);
+			authService.signUp(email, NICKNAME, password, true, true, true, false, true);
 
 			// then
 			ArgumentCaptor<User> savedUserCaptor = ArgumentCaptor.forClass(User.class);
@@ -258,6 +260,7 @@ class AuthServiceTest {
 			verify(userSignedUpEventPublisher).publish(keyCaptor.capture(), eventCaptor.capture());
 
 			assertThat(savedUserCaptor.getValue().getEmail()).isEqualTo(email);
+			assertThat(savedUserCaptor.getValue().getNickname()).isEqualTo(NICKNAME);
 			assertThat(savedUserCaptor.getValue().getPassword()).isEqualTo("encoded");
 			assertThat(savedUserCaptor.getValue().getRole()).isEqualTo(UserRole.MEMBER);
 			assertThat(savedUserCaptor.getValue().isServiceTermsAgreed()).isTrue();
@@ -282,7 +285,7 @@ class AuthServiceTest {
 			// when
 			CustomException exception = assertThrows(
 				CustomException.class,
-				() -> authService.signUp(email, password, true, true, true, false, true)
+				() -> authService.signUp(email, NICKNAME, password, true, true, true, false, true)
 			);
 
 			// then
@@ -304,7 +307,7 @@ class AuthServiceTest {
 			// when
 			CustomException exception = assertThrows(
 				CustomException.class,
-				() -> authService.signUp(email, password, true, true, true, false, true)
+				() -> authService.signUp(email, NICKNAME, password, true, true, true, false, true)
 			);
 
 			// then
@@ -327,7 +330,7 @@ class AuthServiceTest {
 			// when
 			CustomException exception = assertThrows(
 				CustomException.class,
-				() -> authService.signUp(email, password, true, false, true, false, true)
+				() -> authService.signUp(email, NICKNAME, password, true, false, true, false, true)
 			);
 
 			// then

--- a/auth-server/src/test/java/com/truve/platform/auth/service/service/AuthServiceTest.java
+++ b/auth-server/src/test/java/com/truve/platform/auth/service/service/AuthServiceTest.java
@@ -240,6 +240,7 @@ class AuthServiceTest {
 
 			given(emailVerificationRepository.isVerifiedEmail(email)).willReturn(verifiedAt);
 			given(userRepository.existsByEmail(email)).willReturn(false);
+			given(userRepository.existsByNickname(NICKNAME)).willReturn(false);
 			given(passwordEncoder.encode(password)).willReturn("encoded");
 			given(userRepository.save(any(User.class))).willAnswer(invocation -> {
 				User savedUser = invocation.getArgument(0);
@@ -326,6 +327,7 @@ class AuthServiceTest {
 
 			given(emailVerificationRepository.isVerifiedEmail(email)).willReturn("1700000000000");
 			given(userRepository.existsByEmail(email)).willReturn(false);
+			given(userRepository.existsByNickname(NICKNAME)).willReturn(false);
 
 			// when
 			CustomException exception = assertThrows(
@@ -339,6 +341,49 @@ class AuthServiceTest {
 			verify(userRepository, never()).save(any(User.class));
 			verify(emailVerificationRepository, never()).deleteVerifiedEmail(anyString());
 			verify(userSignedUpEventPublisher, never()).publish(anyString(), any());
+		}
+
+		@Test
+		@DisplayName("닉네임 형식이 유효하지 않으면 예외가 발생한다.")
+		void 회원가입_실패_닉네임_형식_오류() {
+			// given
+			String email = "new@test.com";
+			String password = "plain";
+
+			given(emailVerificationRepository.isVerifiedEmail(email)).willReturn("1700000000000");
+			given(userRepository.existsByEmail(email)).willReturn(false);
+
+			// when
+			CustomException exception = assertThrows(
+				CustomException.class,
+				() -> authService.signUp(email, "a b", password, true, true, true, false, true)
+			);
+
+			// then
+			assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.INVALID_NICKNAME);
+			verify(userRepository, never()).save(any(User.class));
+		}
+
+		@Test
+		@DisplayName("이미 사용 중인 닉네임이면 예외가 발생한다.")
+		void 회원가입_실패_중복_닉네임() {
+			// given
+			String email = "new@test.com";
+			String password = "plain";
+
+			given(emailVerificationRepository.isVerifiedEmail(email)).willReturn("1700000000000");
+			given(userRepository.existsByEmail(email)).willReturn(false);
+			given(userRepository.existsByNickname(NICKNAME)).willReturn(true);
+
+			// when
+			CustomException exception = assertThrows(
+				CustomException.class,
+				() -> authService.signUp(email, NICKNAME, password, true, true, true, false, true)
+			);
+
+			// then
+			assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.ALREADY_EXISTS_NICKNAME);
+			verify(userRepository, never()).save(any(User.class));
 		}
 	}
 }

--- a/auth-server/src/test/java/com/truve/platform/auth/service/service/AuthServiceTest.java
+++ b/auth-server/src/test/java/com/truve/platform/auth/service/service/AuthServiceTest.java
@@ -246,7 +246,7 @@ class AuthServiceTest {
 			});
 
 			// when
-			authService.signUp(email, password);
+			authService.signUp(email, password, true, true, true, false, true);
 
 			// then
 			ArgumentCaptor<User> savedUserCaptor = ArgumentCaptor.forClass(User.class);
@@ -275,7 +275,10 @@ class AuthServiceTest {
 			given(emailVerificationRepository.isVerifiedEmail(email)).willReturn("");
 
 			// when
-			CustomException exception = assertThrows(CustomException.class, () -> authService.signUp(email, password));
+			CustomException exception = assertThrows(
+				CustomException.class,
+				() -> authService.signUp(email, password, true, true, true, false, true)
+			);
 
 			// then
 			assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.NOT_VERIFIED_EMAIL);
@@ -294,7 +297,10 @@ class AuthServiceTest {
 			given(userRepository.existsByEmail(email)).willReturn(true);
 
 			// when
-			CustomException exception = assertThrows(CustomException.class, () -> authService.signUp(email, password));
+			CustomException exception = assertThrows(
+				CustomException.class,
+				() -> authService.signUp(email, password, true, true, true, false, true)
+			);
 
 			// then
 			assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.ALREADY_EXISTS_EMAIL);

--- a/auth-server/src/test/java/com/truve/platform/auth/service/service/AuthServiceTest.java
+++ b/auth-server/src/test/java/com/truve/platform/auth/service/service/AuthServiceTest.java
@@ -53,7 +53,7 @@ class AuthServiceTest {
 	private AuthService authService;
 
 	private User createUser(Long id, String email, String encodedPassword) {
-		User user = User.createLocalUser(email, encodedPassword);
+		User user = User.createLocalUser(email, encodedPassword, true, true, true, false, true);
 		ReflectionTestUtils.setField(user, "id", id);
 		return user;
 	}
@@ -260,6 +260,11 @@ class AuthServiceTest {
 			assertThat(savedUserCaptor.getValue().getEmail()).isEqualTo(email);
 			assertThat(savedUserCaptor.getValue().getPassword()).isEqualTo("encoded");
 			assertThat(savedUserCaptor.getValue().getRole()).isEqualTo(UserRole.MEMBER);
+			assertThat(savedUserCaptor.getValue().isServiceTermsAgreed()).isTrue();
+			assertThat(savedUserCaptor.getValue().isElectronicFinanceTermsAgreed()).isTrue();
+			assertThat(savedUserCaptor.getValue().isPrivacyCollectionAgreed()).isTrue();
+			assertThat(savedUserCaptor.getValue().isMarketingInfoAgreed()).isFalse();
+			assertThat(savedUserCaptor.getValue().isOver14Agreed()).isTrue();
 			assertThat(savedUserCaptor.getValue().getPublicId()).isInstanceOf(UUID.class);
 			assertThat(keyCaptor.getValue()).isEqualTo(savedUserCaptor.getValue().getPublicId().toString());
 			assertThat(eventCaptor.getValue()).isInstanceOf(UserSignedUpEvent.class);

--- a/common/src/main/java/com/truve/platform/common/exception/ErrorCode.java
+++ b/common/src/main/java/com/truve/platform/common/exception/ErrorCode.java
@@ -19,6 +19,8 @@ public enum ErrorCode {
 	INVALID_REFRESH_TOKEN(HttpStatus.BAD_REQUEST, "리프레시 토큰이 올바르지 않습니다.", "A08"),
 	KAKAO_USERINFO_FAILED(HttpStatus.BAD_REQUEST, "카카오 사용자 정보를 가져오지 못했습니다.", "A09"),
 	REQUIRED_TERMS_NOT_AGREED(HttpStatus.BAD_REQUEST, "필수 약관 동의가 필요합니다.", "A10"),
+	INVALID_NICKNAME(HttpStatus.BAD_REQUEST, "유효하지 않은 닉네임입니다.", "A11"),
+	ALREADY_EXISTS_NICKNAME(HttpStatus.BAD_REQUEST, "중복된 닉네임입니다.", "A12"),
 
 	NOT_FOUND_PAYMENT(HttpStatus.BAD_REQUEST, "존재하지 않는 결제입니다.", "P01"),
 	INVALID_PAYMENT_AMOUNT(HttpStatus.BAD_REQUEST, "유효하지 않은 결제 금액입니다.", "P02"),

--- a/common/src/main/java/com/truve/platform/common/exception/ErrorCode.java
+++ b/common/src/main/java/com/truve/platform/common/exception/ErrorCode.java
@@ -18,6 +18,7 @@ public enum ErrorCode {
 	ALREADY_VERIFIED_EMAIL(HttpStatus.BAD_REQUEST, "이미 인증된 이메일입니다.", "A07"),
 	INVALID_REFRESH_TOKEN(HttpStatus.BAD_REQUEST, "리프레시 토큰이 올바르지 않습니다.", "A08"),
 	KAKAO_USERINFO_FAILED(HttpStatus.BAD_REQUEST, "카카오 사용자 정보를 가져오지 못했습니다.", "A09"),
+	REQUIRED_TERMS_NOT_AGREED(HttpStatus.BAD_REQUEST, "필수 약관 동의가 필요합니다.", "A10"),
 
 	NOT_FOUND_PAYMENT(HttpStatus.BAD_REQUEST, "존재하지 않는 결제입니다.", "P01"),
 	INVALID_PAYMENT_AMOUNT(HttpStatus.BAD_REQUEST, "유효하지 않은 결제 금액입니다.", "P02"),


### PR DESCRIPTION
## 변경 사항

- [x] 전체 테스트 코드 성공 여부
- **자체 회원가입 약관 동의 여부 추가**
피그마 UI에 맞게 약관 동의 여부 API로 입력 받습니다.
- **자체 회원가입 닉네임 입력 추가**
닉네임 검증까지 회원가입에서 추가합니다.
닉네임 규칙 정규식 AI 사용하여 임의로 넣었습니다.

소셜로그인 유저도 약관 동의, 닉네임 입력 받아야하는데
소셜 회원가입 이후 약관동의, 닉네임을 따로 입력 받아야해서 설계가 조금 달라야하여
생각해보고 변경하겠습니다.


## 관련 이슈

- Notion Ticket: [#29](https://www.notion.so/3049e3e335cc80d5af32c30a24d3f4ba?source=copy_link)

## 참고사항 (선택)

---