### PR TITLE
fix(docker): 서비스 컨테이너 타임존 KST 설정 추가

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,6 +64,7 @@ services:
     ports:
       - "8080:8080"
     environment:
+      - TZ=Asia/Seoul
       - AUTH_SERVER_URI=http://auth-server:8081
       - PAYMENT_SERVER_URI=http://payment:8082
       - QUEUE_SERVER_URI=http://queue:8083
@@ -86,6 +87,7 @@ services:
     ports:
       - "8081:8081"
     environment:
+      - TZ=Asia/Seoul
       - USER_MYSQL_URL=jdbc:mysql://db:3306/user_db
       - USER_MYSQL_USERNAME=root
       - USER_MYSQL_PASSWORD=1234
@@ -124,6 +126,7 @@ services:
     ports:
       - "8082:8082"
     environment:
+      - TZ=Asia/Seoul
       - PAYMENT_MYSQL_URL=jdbc:mysql://db:3306/payment_db
       - PAYMENT_MYSQL_USERNAME=root
       - PAYMENT_MYSQL_PASSWORD=1234
@@ -149,6 +152,7 @@ services:
     ports:
       - "8083:8083"
     environment:
+      - TZ=Asia/Seoul
       - SPRING_PROFILES_ACTIVE=local
       - USER_REDIS_HOST=user-redis
       - USER_REDIS_PORT=6379
@@ -170,6 +174,7 @@ services:
     ports:
       - "8084:8084"
     environment:
+      - TZ=Asia/Seoul
       - TICKETING_MYSQL_URL=jdbc:mysql://db:3306/ticketing_db
       - TICKETING_MYSQL_USERNAME=root
       - TICKETING_MYSQL_PASSWORD=1234
@@ -199,6 +204,7 @@ services:
     ports:
       - "8085:8085"
     environment:
+      - TZ=Asia/Seoul
       - SPRING_PROFILES_ACTIVE=local
       - MUSICAL_MYSQL_URL=jdbc:mysql://db:3306/musical_db
       - MUSICAL_MYSQL_USERNAME=root


### PR DESCRIPTION
## 변경 사항

---
Docker 환경에서 타임존이 지정되어 있지 않아 BaseTimeEntity, 시간 형식 변환이 UTC 기준으로 동작하는 이슈가 있었습니다.
해당 PR 머지 전에 서버 도커 컴포즈에도 반영하겠습니다!

- [ ] 전체 테스트 코드 성공 여부

## 관련 이슈

---
- Notion Ticket: #

## 참고사항 (선택)

---