### PR TITLE
feat(booking): 예매 조회(주문, 목록, 상세) API 및 비즈니스 로직 구현

### DIFF
--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/controller/BookingController.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/controller/BookingController.java
@@ -1,16 +1,20 @@
 package org.truve.platform.ticketing.service.booking.controller;
 
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.truve.platform.ticketing.service.booking.dto.BookingRequest;
 import org.truve.platform.ticketing.service.booking.dto.BookingResponse;
 import org.truve.platform.ticketing.service.booking.service.BookingService;
-
-import java.util.UUID;
 
 import com.truve.platform.common.response.ApiResult;
 
@@ -32,6 +36,32 @@ public class BookingController {
 		@RequestHeader(USER_ID_HEADER) UUID userId,
 		@RequestBody @Valid BookingRequest.Create request) {
 		return ApiResult.ok(bookingService.create(userId, request));
+	}
+
+	@Operation(summary = "예매 주문 정보 조회", description = "좌석 선택 후 생성된 예매 주문 정보를 조회합니다.")
+	@GetMapping("/{reservation_number}/order")
+	public ApiResult<BookingResponse.Order> getOrder(
+		@PathVariable("reservation_number") String reservationNumber
+	) {
+		return ApiResult.ok(bookingService.getOrder(reservationNumber));
+	}
+
+	@Operation(summary = "예매 상세 정보 조회")
+	@GetMapping("/{reservation_number}")
+	public ApiResult<BookingResponse.ReservationDetail> getDetail(
+		@PathVariable("reservation_number") String reservationNumber
+	) {
+		return ApiResult.ok(bookingService.getDetail(reservationNumber));
+	}
+
+	@Operation(summary = "예매 목록 조회", description = "날짜로 필터링된 예매 목록을 조회합니다.")
+	@GetMapping()
+	public ApiResult<List<BookingResponse.Summary>> getSummaries(
+		@RequestHeader(USER_ID_HEADER) UUID userId,
+		@RequestParam(required = false) LocalDate from,
+		@RequestParam(required = false) LocalDate to
+	) {
+		return ApiResult.ok(bookingService.getSummaries(userId, from, to));
 	}
 
 	@Operation(summary = "예매 결제 준비",

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/domain/entity/Reservation.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/domain/entity/Reservation.java
@@ -2,8 +2,11 @@ package org.truve.platform.ticketing.service.booking.domain.entity;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import org.truve.platform.ticketing.service.booking.domain.constant.ReservationStatus;
 
@@ -42,6 +45,9 @@ public class Reservation extends BaseEntity {
 	private Long serviceFee;
 
 	@Column(nullable = false)
+	private Long refundFee;
+
+	@Column(nullable = false)
 	private String gradeSummary;
 
 	@Column(nullable = false)
@@ -53,6 +59,9 @@ public class Reservation extends BaseEntity {
 
 	@Column
 	private LocalDateTime paidAt;
+
+	@Column
+	private LocalDateTime canceledAt;
 
 	@Embedded
 	private VirtualAccount virtualAccount;
@@ -70,12 +79,14 @@ public class Reservation extends BaseEntity {
 	private List<Ticket> tickets = new ArrayList<>();
 
 	@Builder
-	private Reservation(UUID userId, String number, String gradeSummary, ShowInfo showInfo) {
+	private Reservation(UUID userId, String number, String gradeSummary,
+		ShowInfo showInfo) {
 
 		this.userId = userId;
 		this.number = number;
 		this.totalAmount = 0L;
 		this.serviceFee = 0L;
+		this.refundFee = 0L;
 		this.gradeSummary = gradeSummary;
 		this.showInfo = showInfo;
 		this.status = ReservationStatus.CREATED;
@@ -132,5 +143,52 @@ public class Reservation extends BaseEntity {
 	public void depositReceive(LocalDateTime paidAt) {
 		this.paidAt = paidAt;
 		this.status = ReservationStatus.CONFIRMED;
+	}
+
+	public boolean isCancelable() {
+		return status == ReservationStatus.CONFIRMED;
+	}
+
+	public boolean isCanceled() {
+		return status == ReservationStatus.CANCELED || status == ReservationStatus.PARTIAL_CANCELED;
+	}
+
+	public boolean isReviewable() {
+		return status == ReservationStatus.COMPLETED;
+	}
+
+	public boolean isWaitingDeposit() {
+		return status == ReservationStatus.PENDING_DEPOSIT;
+	}
+
+	public List<Long> getTicketPrices() {
+		return tickets.stream().map(Ticket::getPriceSnapshot).toList();
+	}
+
+	public Map<String, List<Ticket>> getTicketsGroupedByGrade() {
+		return Collections.unmodifiableMap(
+			tickets.stream().collect(Collectors.groupingBy(Ticket::getGrade))
+		);
+	}
+
+	public List<Ticket> getCancelTickets() {
+		return tickets.stream().filter(Ticket::isCanceled).toList();
+	}
+
+	public List<String> getCanceledSeatDetails() {
+		return getCancelTickets().stream().map(Ticket::getSeatDetail).toList();
+	}
+
+	public Long getRefundAmount() {
+		Long canceledTicketPrice = getCancelTickets().stream().mapToLong(Ticket::getPriceSnapshot).sum();
+		return canceledTicketPrice - refundFee;
+	}
+
+	public LocalDateTime getDeadline() {
+		if (isCancelable())
+			return showInfo.getStartAt();
+		if (isWaitingDeposit())
+			return virtualAccount.getDueDate();
+		return null;
 	}
 }

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/domain/entity/Ticket.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/domain/entity/Ticket.java
@@ -72,4 +72,8 @@ public class Ticket extends BaseEntity {
 			.seatDetail(seatDetail)
 			.build();
 	}
+
+	public boolean isCanceled() {
+		return status == TicketStatus.CANCELED;
+	}
 }

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/dto/BookingResponse.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/dto/BookingResponse.java
@@ -70,6 +70,7 @@ public class BookingResponse {
 	@Builder
 	public static class Summary {
 		private final String reservationNumber;
+		private final String reservationDate;
 		private final Detail.Status status;
 		private final Detail.Show show;
 		private final String gradeSummary;
@@ -81,6 +82,7 @@ public class BookingResponse {
 		public static Summary from(Reservation reservation) {
 			return Summary.builder()
 				.reservationNumber(reservation.getNumber())
+				.reservationDate(DateTimeUtil.formatDate(reservation.getBookedAt(), "yyyy.MM.dd"))
 				.status(Detail.Status.from(reservation))
 				.show(Detail.Show.from(reservation.getShowInfo()))
 				.gradeSummary(reservation.getGradeSummary())

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/dto/BookingResponse.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/dto/BookingResponse.java
@@ -1,6 +1,15 @@
 package org.truve.platform.ticketing.service.booking.dto;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.truve.platform.ticketing.service.booking.domain.entity.Reservation;
+import org.truve.platform.ticketing.service.booking.domain.entity.ShowInfo;
+import org.truve.platform.ticketing.service.booking.domain.entity.Ticket;
+import org.truve.platform.ticketing.service.booking.util.DateTimeUtil;
+
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 
 public class BookingResponse {
@@ -9,5 +18,261 @@ public class BookingResponse {
 	@AllArgsConstructor
 	public static class Create {
 		private final String reservationNumber;
+	}
+
+	@Getter
+	@AllArgsConstructor
+	@Builder
+	public static class Order {
+		private final String reservationNumber;
+		private final Detail.Show show;
+		private final Detail.Price price;
+		private final List<GradeSeat> gradeSeats;
+
+		public static Order from(Reservation reservation) {
+			return Order.builder()
+				.reservationNumber(reservation.getNumber())
+				.show(Detail.Show.from(reservation.getShowInfo()))
+				.price(Detail.Price.from(reservation))
+				.gradeSeats(getGradeSeats(reservation))
+				.build();
+		}
+
+		private static List<GradeSeat> getGradeSeats(Reservation reservation) {
+			return reservation.getTicketsGroupedByGrade()
+				.entrySet().stream()
+				.map(entry -> GradeSeat.from(entry.getKey(), entry.getValue()))
+				.toList();
+		}
+
+		@Getter
+		@AllArgsConstructor
+		@Builder
+		public static class GradeSeat {
+			private final String grade;
+			private final Long price;
+			private final int count;
+			private final List<String> seatDetails;
+
+			public static GradeSeat from(String grade, List<Ticket> tickets) {
+				return GradeSeat.builder()
+					.grade(grade)
+					.price(tickets.getFirst().getPriceSnapshot())
+					.count(tickets.size())
+					.seatDetails(tickets.stream().map(Ticket::getSeatDetail).toList())
+					.build();
+			}
+		}
+	}
+
+	@Getter
+	@AllArgsConstructor
+	@Builder
+	public static class Summary {
+		private final String reservationNumber;
+		private final Detail.Status status;
+		private final Detail.Show show;
+		private final String gradeSummary;
+		private final Long showId;
+		private final boolean canCancel;
+		private final boolean canReview;
+		private final boolean needsDeposit;
+
+		public static Summary from(Reservation reservation) {
+			return Summary.builder()
+				.reservationNumber(reservation.getNumber())
+				.status(Detail.Status.from(reservation))
+				.show(Detail.Show.from(reservation.getShowInfo()))
+				.gradeSummary(reservation.getGradeSummary())
+				.showId(reservation.getShowInfo().getShowId())
+				.canCancel(reservation.isCancelable())
+				.canReview(reservation.isReviewable())
+				.needsDeposit(reservation.isWaitingDeposit())
+				.build();
+		}
+	}
+
+	@Getter
+	@AllArgsConstructor
+	@Builder
+	public static class ReservationDetail {
+		private final String reservationNumber;
+		private final Detail.Status status;
+		private final Detail.Show show;
+		private final String gradeSummary;
+		private final Detail.Price price;
+		private final Detail.Payment payment;
+		private final Detail.Cancel cancel;
+
+		public static ReservationDetail from(Reservation reservation) {
+			return ReservationDetail.builder()
+				.reservationNumber(reservation.getNumber())
+				.status(Detail.Status.from(reservation))
+				.show(Detail.Show.from(reservation.getShowInfo()))
+				.gradeSummary(reservation.getGradeSummary())
+				.price(Detail.Price.from(reservation))
+				.payment(Detail.Payment.from(reservation))
+				.cancel(Detail.Cancel.from(reservation))
+				.build();
+		}
+	}
+
+	private static class Detail {
+
+		@Getter
+		@AllArgsConstructor
+		@Builder
+		private static class Show {
+			private final String posterUrl;
+			private final String title;
+			private final String showDate;
+			private final String showTime;
+			private final String venueName;
+
+			private static Show from(ShowInfo showInfo) {
+				return Show.builder()
+					.posterUrl(showInfo.getPosterImg())
+					.title(showInfo.getTitle())
+					.showDate(DateTimeUtil.formatDate(showInfo.getStartAt(), "yyyy.MM.dd(E)"))
+					.showTime(DateTimeUtil.formatDate(showInfo.getStartAt(), "a h:mm"))
+					.venueName(showInfo.getVenueName())
+					.build();
+			}
+		}
+
+		@Getter
+		@AllArgsConstructor
+		@Builder
+		private static class Status {
+			private final String label;
+			private final String subText;
+
+			private static Status from(Reservation reservation) {
+				return Status.builder()
+					.label(reservation.getStatus().getDescription())
+					.subText(getSubText(reservation))
+					.build();
+			}
+
+			private static String getSubText(Reservation reservation) {
+				LocalDateTime deadline = reservation.getDeadline();
+				if (deadline == null)
+					return null;
+
+				if (reservation.isWaitingDeposit())
+					return DateTimeUtil.formatDuration(LocalDateTime.now(), deadline, "입금 마감 ", "전");
+				else
+					return DateTimeUtil.formatDuration(LocalDateTime.now(), deadline, "입장까지 ", "남음");
+			}
+		}
+
+		@Getter
+		@AllArgsConstructor
+		@Builder
+		private static class Price {
+			private final List<Long> ticketUnitPrices;
+			private final Long serviceFee;
+			private final Long totalPrice;
+			private final List<GradePrice> gradePrices;
+
+			private static Price from(Reservation reservation) {
+				return Price.builder()
+					.ticketUnitPrices(reservation.getTicketPrices())
+					.serviceFee(reservation.getServiceFee())
+					.totalPrice(reservation.getTotalAmount())
+					.gradePrices(getGradePrices(reservation))
+					.build();
+			}
+
+			private static List<GradePrice> getGradePrices(Reservation reservation) {
+				return reservation.getTicketsGroupedByGrade()
+					.entrySet().stream()
+					.map(entry -> GradePrice.from(entry.getKey(), entry.getValue()))
+					.toList();
+			}
+
+			@Getter
+			@AllArgsConstructor
+			@Builder
+			private static class GradePrice {
+				private final String grade;
+				private final int count;
+				private final Long totalPrice;
+
+				private static GradePrice from(String grade, List<Ticket> tickets) {
+					return GradePrice.builder()
+						.grade(grade)
+						.count(tickets.size())
+						.totalPrice(tickets.stream().mapToLong(Ticket::getPriceSnapshot).sum())
+						.build();
+				}
+			}
+		}
+
+		@Getter
+		@AllArgsConstructor
+		@Builder
+		private static class Payment {
+			private final String paymentMethod;
+			private final String paidAt;
+			private final VirtualAccount virtualAccount;
+
+			private static Payment from(Reservation reservation) {
+				return Payment.builder()
+					.paymentMethod(reservation.getPaymentMethod())
+					.paidAt(reservation.getPaidAt() == null ? null :
+						DateTimeUtil.formatDate(reservation.getPaidAt(), "yyyy.MM.dd(E) HH:mm:ss"))
+					.virtualAccount(VirtualAccount.from(reservation))
+					.build();
+			}
+
+			@Getter
+			@AllArgsConstructor
+			@Builder
+			private static class VirtualAccount {
+				private final String accountNumber;
+				private final String bank;
+				private final String customerName;
+				private final String dueDate;
+
+				private static VirtualAccount from(Reservation reservation) {
+					if (reservation.getVirtualAccount() == null)
+						return null;
+
+					org.truve.platform.ticketing.service.booking.domain.entity.VirtualAccount virtualAccount = reservation.getVirtualAccount();
+
+					return VirtualAccount.builder()
+						.accountNumber(virtualAccount.getAccountNumber())
+						.bank(virtualAccount.getBank())
+						.customerName(virtualAccount.getCustomerName())
+						.dueDate(DateTimeUtil.formatDate(virtualAccount.getDueDate(), "yyyy.MM.dd(E) HH:mm까지"))
+						.build();
+				}
+			}
+		}
+
+		@Getter
+		@AllArgsConstructor
+		@Builder
+		private static class Cancel {
+			private final List<String> seats;
+			private final Long refundFee;
+			private final Long refundAmount;
+			private final String canceledAt;
+			private final String method;
+
+			private static Cancel from(Reservation reservation) {
+				if (!reservation.isCanceled())
+					return null;
+
+				return Cancel.builder()
+					.seats(reservation.getCanceledSeatDetails())
+					.refundFee(reservation.getRefundFee())
+					.refundAmount(reservation.getRefundAmount())
+					.canceledAt(DateTimeUtil.formatDate(reservation.getCanceledAt(), "yyyy.MM.dd(E) HH:mm:ss"))
+					.method(reservation.getPaymentMethod())
+					.build();
+			}
+		}
 	}
 }

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/repository/ReservationRepository.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/repository/ReservationRepository.java
@@ -1,8 +1,10 @@
 package org.truve.platform.ticketing.service.booking.repository;
 
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.truve.platform.ticketing.service.booking.domain.entity.Reservation;
 
 public interface ReservationRepository extends JpaRepository<Reservation, Long> {
+	@EntityGraph(attributePaths = {"tickets"})
 	Reservation findByNumber(String number);
 }

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/repository/ReservationRepository.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/repository/ReservationRepository.java
@@ -1,10 +1,33 @@
 package org.truve.platform.ticketing.service.booking.repository;
 
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.truve.platform.ticketing.service.booking.domain.entity.Reservation;
+
+import io.lettuce.core.dynamic.annotation.Param;
 
 public interface ReservationRepository extends JpaRepository<Reservation, Long> {
 	@EntityGraph(attributePaths = {"tickets"})
 	Reservation findByNumber(String number);
+
+	@Query("""
+		SELECT DISTINCT r
+		FROM Reservation r
+		JOIN FETCH r.tickets
+		WHERE r.userId = :userId
+		  AND (:from IS NULL OR r.bookedAt >= :from)
+		  AND (:to IS NULL OR r.bookedAt <= :to)
+		 	AND r.status IN ('PENDING_DEPOSIT', 'CONFIRMED', 'COMPLETED', 'PARTIAL_CANCELED', 'CANCELED')
+		ORDER BY r.bookedAt DESC
+		""")
+	List<Reservation> findByUserIdAndDateRange(
+		@Param("userId") UUID userId,
+		@Param("from") LocalDateTime from,
+		@Param("to") LocalDateTime to
+	);
 }

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/service/BookingService.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/service/BookingService.java
@@ -21,7 +21,7 @@ import org.truve.platform.ticketing.service.booking.external.kafka.BookingEventC
 import org.truve.platform.ticketing.service.booking.external.kafka.PaymentEventCommand;
 import org.truve.platform.ticketing.service.booking.external.kafka.PaymentPublisher;
 import org.truve.platform.ticketing.service.booking.repository.ReservationRepository;
-import org.truve.platform.ticketing.service.booking.service.util.NumberGenerator;
+import org.truve.platform.ticketing.service.booking.util.NumberGenerator;
 
 import lombok.RequiredArgsConstructor;
 
@@ -34,7 +34,6 @@ public class BookingService {
 
 	private final ReservationRepository reservationRepository;
 	private final TicketingClient ticketingClient;
-	private final NumberGenerator numberGenerator;
 	private final PaymentPublisher paymentPublisher;
 
 	@Transactional
@@ -52,7 +51,7 @@ public class BookingService {
 	private Reservation createReservation(UUID userId, TicketingResponse.SeatInfo seatInfo) {
 		return Reservation.create(
 			userId,
-			numberGenerator.generateReservationNumber(),
+			NumberGenerator.generateReservationNumber(),
 			createGradeSummary(seatInfo),
 			createShowInfo(seatInfo)
 		);
@@ -62,7 +61,7 @@ public class BookingService {
 		return seatInfo.getSeats().stream().map(
 			seat -> Ticket.create(
 				reservation,
-				numberGenerator.generateTicketNumber(),
+				NumberGenerator.generateTicketNumber(),
 				seat.getGradeName(),
 				seat.getPrice(),
 				createSeatDetail(seat)

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/service/BookingService.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/service/BookingService.java
@@ -1,5 +1,6 @@
 package org.truve.platform.ticketing.service.booking.service;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.LinkedHashMap;
@@ -98,6 +99,28 @@ public class BookingService {
 			seat.getSeatRow(),
 			seat.getSeatNumber()
 		);
+	}
+
+	@Transactional(readOnly = true)
+	public BookingResponse.Order getOrder(String reservationNumber) {
+		Reservation reservation = reservationRepository.findByNumber(reservationNumber);
+		return BookingResponse.Order.from(reservation);
+	}
+
+	@Transactional(readOnly = true)
+	public BookingResponse.ReservationDetail getDetail(String reservationNumber) {
+		Reservation reservation = reservationRepository.findByNumber(reservationNumber);
+		return BookingResponse.ReservationDetail.from(reservation);
+	}
+
+	@Transactional(readOnly = true)
+	public List<BookingResponse.Summary> getSummaries(UUID userId, LocalDate from, LocalDate to) {
+		LocalDateTime fromDt = from == null ? null : from.atStartOfDay();
+		LocalDateTime toDt = to == null ? null : to.atTime(LocalTime.MAX);
+
+		List<Reservation> reservations = reservationRepository
+			.findByUserIdAndDateRange(userId, fromDt, toDt);
+		return reservations.stream().map(BookingResponse.Summary::from).toList();
 	}
 
 	@Transactional

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/util/DateTimeUtil.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/util/DateTimeUtil.java
@@ -1,0 +1,40 @@
+package org.truve.platform.ticketing.service.booking.util;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Locale;
+
+public class DateTimeUtil {
+
+	private DateTimeUtil() {
+	}
+
+	public static String formatDate(LocalDateTime showDate, String pattern) {
+		DateTimeFormatter formatter = java.time.format.DateTimeFormatter.ofPattern(pattern, Locale.KOREAN);
+		return showDate.format(formatter);
+	}
+
+	public static String formatDuration(LocalDateTime now, LocalDateTime target, String prefix, String suffix) {
+		Duration duration = Duration.between(now, target);
+		long days = duration.toDays();
+		long hours = duration.toHoursPart();
+		long minutes = duration.toMinutesPart();
+
+		StringBuilder sb = new StringBuilder(prefix);
+		if (days > 0)
+			sb.append(days).append("일 ");
+		if (hours > 0)
+			sb.append(hours).append("시간 ");
+		if (minutes > 0)
+			sb.append(minutes).append("분 ");
+
+		if (sb.length() > prefix.length()) {
+			sb.setLength(sb.length() - 1);
+			sb.append(" ");
+		}
+		sb.append(suffix);
+
+		return sb.toString();
+	}
+}

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/util/DateTimeUtil.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/util/DateTimeUtil.java
@@ -10,9 +10,9 @@ public class DateTimeUtil {
 	private DateTimeUtil() {
 	}
 
-	public static String formatDate(LocalDateTime showDate, String pattern) {
+	public static String formatDate(LocalDateTime dateTime, String pattern) {
 		DateTimeFormatter formatter = java.time.format.DateTimeFormatter.ofPattern(pattern, Locale.KOREAN);
-		return showDate.format(formatter);
+		return dateTime.format(formatter);
 	}
 
 	public static String formatDuration(LocalDateTime now, LocalDateTime target, String prefix, String suffix) {

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/util/NumberGenerator.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/util/NumberGenerator.java
@@ -1,20 +1,21 @@
-package org.truve.platform.ticketing.service.booking.service.util;
+package org.truve.platform.ticketing.service.booking.util;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.UUID;
 
-import org.springframework.stereotype.Component;
-
-@Component
 public class NumberGenerator {
-	public String generateReservationNumber() {
+
+	private NumberGenerator() {
+	}
+
+	public static String generateReservationNumber() {
 		String datePrefix = LocalDate.now().format(DateTimeFormatter.ofPattern("yyyyMMdd"));
 		String randomSuffix = UUID.randomUUID().toString().substring(0, 6).toUpperCase();
 		return "R" + datePrefix + randomSuffix;
 	}
 
-	public String generateTicketNumber() {
+	public static String generateTicketNumber() {
 		return "T-" + UUID.randomUUID().toString().substring(0, 13).toUpperCase();
 	}
 }

--- a/ticketing/src/test/java/org/truve/platform/ticketing/service/booking/service/BookingServiceTest.java
+++ b/ticketing/src/test/java/org/truve/platform/ticketing/service/booking/service/BookingServiceTest.java
@@ -18,11 +18,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.truve.platform.ticketing.service.booking.domain.constant.TicketStatus;
 import org.truve.platform.ticketing.service.booking.domain.entity.Reservation;
 import org.truve.platform.ticketing.service.booking.dto.BookingRequest;
-import org.truve.platform.ticketing.service.booking.dto.BookingResponse;
 import org.truve.platform.ticketing.service.booking.external.client.TicketingClient;
 import org.truve.platform.ticketing.service.booking.external.client.TicketingResponse;
 import org.truve.platform.ticketing.service.booking.repository.ReservationRepository;
-import org.truve.platform.ticketing.service.booking.service.util.NumberGenerator;
 
 @ExtendWith(MockitoExtension.class)
 class BookingServiceTest {
@@ -31,8 +29,6 @@ class BookingServiceTest {
 	private ReservationRepository reservationRepository;
 	@Mock
 	private TicketingClient ticketingClient;
-	@Mock
-	private NumberGenerator numberGenerator;
 
 	@InjectMocks
 	private BookingService bookingService;
@@ -56,18 +52,10 @@ class BookingServiceTest {
 			LocalDateTime.now(),
 			"poster",
 			seats);
-
-		String reservationNumber = "R20260309ABCDEF";
-		String ticketNumber1 = "T-1234567890123";
-		String ticketNumber2 = "T-9876543210987";
-		String ticketNumber3 = "T-1111111111111";
-
 		given(ticketingClient.getSeatInfo(seatIds)).willReturn(seatInfo);
-		given(numberGenerator.generateReservationNumber()).willReturn(reservationNumber);
-		given(numberGenerator.generateTicketNumber()).willReturn(ticketNumber1, ticketNumber2, ticketNumber3);
 
 		// when
-		BookingResponse.Create response = bookingService.create(userId, request);
+		bookingService.create(userId, request);
 
 		// then
 		ArgumentCaptor<Reservation> captor = ArgumentCaptor.forClass(Reservation.class);
@@ -75,14 +63,12 @@ class BookingServiceTest {
 		Reservation savedReservation = captor.getValue();
 
 		assertAll(
-			() -> assertThat(response.getReservationNumber()).isEqualTo(reservationNumber),
 			() -> assertThat(savedReservation.calculateTicketAmount()).isEqualTo(60000L),
 			() -> assertThat(savedReservation.getGradeSummary()).isEqualTo("VIP석 2인\nS석 1인"),
 			() -> assertThat(savedReservation.getTickets()).hasSize(3),
 			() -> assertThat(savedReservation.getServiceFee()).isEqualTo(6000L),
 			() -> {
 				assertNotNull(savedReservation.getTickets());
-				assertThat(savedReservation.getTickets().getFirst().getNumber()).isEqualTo(ticketNumber1);
 				assertThat(savedReservation.getTickets().get(1).getPriceSnapshot()).isEqualTo(20000L);
 				assertThat(savedReservation.getTickets().getLast().getStatus()).isEqualTo(TicketStatus.ISSUED);
 				assertThat(savedReservation.getTickets().get(1).getUsedAt()).isNull();


### PR DESCRIPTION
## 변경 사항

---
### 유틸 패키지 위치 변경 및 LocalDateTime 포맷 유틸 추가

service 패키지 내에 있던 util 패키지를 밖으로 꺼냈습니다.

- `NumberGenerator`: (임의의 예매 번호, 티켓 번호를 생성하는 유틸) 위치 이동 및 컴포넌트 -> 정적 클래스로 변경
- `DateTimeUtil`: DateTime 포맷 유틸

### 예매 조회 API 추가

(결제 전) 주문 조회,  목록 조회, 상세 조회 API를 추가했습니다.

- Reservation, Ticket 엔티티 메서드 추가: 상태 확인 및 데이터 조회성 메서드들을 추가했습니다.
- BookingResponse: 관련 DTO 작성 

- [X] 전체 테스트 코드 성공 여부

## 관련 이슈

---
- Notion Ticket: #

## 참고사항 (선택)

DTO가 너무 조잡해졌는데 차차 리팩토링 해보겠습니다 🥲

---