### PR TITLE
fix(musical): 캐스팅 일정 조회 명세 반영 및 스웨거 응답 스키마 수정

### DIFF
--- a/musical/src/main/java/com/truve/platform/musical/show/dto/ShowCastingResponse.java
+++ b/musical/src/main/java/com/truve/platform/musical/show/dto/ShowCastingResponse.java
@@ -5,6 +5,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -14,6 +15,7 @@ public class ShowCastingResponse {
 	@Getter
 	@AllArgsConstructor
 	@Builder
+	@Schema(name = "ShowCastingScheduleDetailResponse")
 	public static class Detail {
 		private Long showId;
 		private Range range;

--- a/musical/src/main/java/com/truve/platform/musical/show/dto/ShowResponse.java
+++ b/musical/src/main/java/com/truve/platform/musical/show/dto/ShowResponse.java
@@ -3,6 +3,7 @@ package com.truve.platform.musical.show.dto;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -12,6 +13,7 @@ public class ShowResponse {
 	@Getter
 	@AllArgsConstructor
 	@Builder
+	@Schema(name = "ShowDetailResponse")
 	public static class Detail {
 		private Long showId;
 		private String title;

--- a/musical/src/main/java/com/truve/platform/musical/show/service/ShowCastingService.java
+++ b/musical/src/main/java/com/truve/platform/musical/show/service/ShowCastingService.java
@@ -32,6 +32,7 @@ import lombok.RequiredArgsConstructor;
 @Service
 @RequiredArgsConstructor
 public class ShowCastingService {
+	private static final String DEFAULT_UNASSIGNED_CAST_NAME = "미정";
 	private static final DateTimeFormatter SHOW_DATE_LABEL_FORMATTER =
 		DateTimeFormatter.ofPattern("MM/dd(E)", Locale.KOREAN);
 	private static final DateTimeFormatter SHOW_TIME_LABEL_FORMATTER =
@@ -53,8 +54,12 @@ public class ShowCastingService {
 	) {
 		Show show = showRepository.findByIdOrThrow(showId);
 
-		LocalDateTime fromTime = from != null ? from.atStartOfDay() : null;
-		LocalDateTime toTime = to != null ? to.atTime(LocalTime.MAX) : null;
+		LocalDate effectiveFrom = from != null ? from : LocalDate.now();
+		LocalDate effectiveTo = to != null
+			? to
+			: (show.getEndTime() != null ? show.getEndTime().toLocalDate() : null);
+		LocalDateTime fromTime = effectiveFrom != null ? effectiveFrom.atStartOfDay() : null;
+		LocalDateTime toTime = effectiveTo != null ? effectiveTo.atTime(LocalTime.MAX) : null;
 		List<Long> filterArtistIds = artistIds == null ? List.of() : artistIds;
 		boolean artistFilterOff = filterArtistIds.isEmpty();
 		List<Long> queryArtistIds = artistFilterOff ? List.of(-1L) : filterArtistIds;
@@ -93,22 +98,15 @@ public class ShowCastingService {
 				.showTime(schedule.getShowTime())
 				.showDateLabel(toShowDateLabel(schedule.getShowTime()))
 				.showTimeLabel(toShowTimeLabel(schedule.getShowTime()))
-				.casts(castsByScheduleId.getOrDefault(schedule.getId(), Map.of()))
+				.casts(buildRowCasts(schedule.getId(), roles, castsByScheduleId))
 				.build())
 			.toList();
-
-		LocalDate rangeFrom = from != null
-			? from
-			: (show.getStartTime() != null ? show.getStartTime().toLocalDate() : null);
-		LocalDate rangeTo = to != null
-			? to
-			: (show.getEndTime() != null ? show.getEndTime().toLocalDate() : null);
 
 		return ShowCastingResponse.Detail.builder()
 			.showId(show.getId())
 			.range(ShowCastingResponse.Range.builder()
-				.from(rangeFrom)
-				.to(rangeTo)
+				.from(effectiveFrom)
+				.to(effectiveTo)
 				.build())
 			.filters(ShowCastingResponse.Filters.builder()
 				.artists(filterArtists)
@@ -175,6 +173,25 @@ public class ShowCastingService {
 			result.put(scheduleId, casts);
 		});
 		return result;
+	}
+
+	private Map<String, ShowCastingResponse.CastArtist> buildRowCasts(
+		Long scheduleId,
+		List<ShowCastingResponse.Role> roles,
+		Map<Long, Map<String, ShowCastingResponse.CastArtist>> castsByScheduleId
+	) {
+		Map<String, ShowCastingResponse.CastArtist> assignedCasts = castsByScheduleId.getOrDefault(scheduleId, Map.of());
+		Map<String, ShowCastingResponse.CastArtist> rowCasts = new LinkedHashMap<>();
+		roles.forEach(role -> rowCasts.put(role.getRoleName(), createUnassignedCast()));
+		rowCasts.putAll(assignedCasts);
+		return rowCasts;
+	}
+
+	private ShowCastingResponse.CastArtist createUnassignedCast() {
+		return ShowCastingResponse.CastArtist.builder()
+			.artistId(null)
+			.artistName(DEFAULT_UNASSIGNED_CAST_NAME)
+			.build();
 	}
 
 	private String toShowDateLabel(LocalDateTime showTime) {

--- a/musical/src/test/java/com/truve/platform/show/service/service/ShowServiceTest.java
+++ b/musical/src/test/java/com/truve/platform/show/service/service/ShowServiceTest.java
@@ -4,6 +4,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.time.LocalDate;
@@ -286,5 +289,125 @@ class ShowServiceTest {
 
 		assertEquals(requestFrom, result.getRange().getFrom());
 		assertEquals(requestTo, result.getRange().getTo());
+	}
+
+	@Test
+	@DisplayName("캐스팅 미확정 역할은 미정으로 채워 응답한다.")
+	void 캐스팅_일정_조회_미확정_역할은_미정으로_응답() {
+		Long showId = 1L;
+		Show show = org.mockito.Mockito.mock(Show.class);
+		when(show.getId()).thenReturn(showId);
+
+		ShowSchedule schedule1 = org.mockito.Mockito.mock(ShowSchedule.class);
+		when(schedule1.getId()).thenReturn(101L);
+		when(schedule1.getShowTime()).thenReturn(LocalDateTime.of(2026, 1, 2, 19, 0));
+
+		Artist artistCharlie = org.mockito.Mockito.mock(Artist.class);
+		when(artistCharlie.getId()).thenReturn(1L);
+		when(artistCharlie.getName()).thenReturn("김호영");
+
+		Artist artistLola = org.mockito.Mockito.mock(Artist.class);
+		when(artistLola.getId()).thenReturn(10L);
+		when(artistLola.getName()).thenReturn("강홍석");
+
+		Artist artistLauren = org.mockito.Mockito.mock(Artist.class);
+		when(artistLauren.getId()).thenReturn(20L);
+		when(artistLauren.getName()).thenReturn("허윤슬");
+
+		ShowCasting charlieCasting = org.mockito.Mockito.mock(ShowCasting.class);
+		when(charlieCasting.getId()).thenReturn(1001L);
+		when(charlieCasting.getRoleName()).thenReturn("찰리");
+		when(charlieCasting.getCastingOrder()).thenReturn(1);
+		when(charlieCasting.getArtist()).thenReturn(artistCharlie);
+
+		ShowCasting lolaCasting = org.mockito.Mockito.mock(ShowCasting.class);
+		when(lolaCasting.getId()).thenReturn(1002L);
+		when(lolaCasting.getRoleName()).thenReturn("롤라");
+		when(lolaCasting.getCastingOrder()).thenReturn(2);
+		when(lolaCasting.getArtist()).thenReturn(artistLola);
+
+		ShowCasting laurenCasting = org.mockito.Mockito.mock(ShowCasting.class);
+		when(laurenCasting.getId()).thenReturn(1003L);
+		when(laurenCasting.getRoleName()).thenReturn("로렌");
+		when(laurenCasting.getCastingOrder()).thenReturn(3);
+		when(laurenCasting.getArtist()).thenReturn(artistLauren);
+
+		ShowScheduleCasting sc1 = org.mockito.Mockito.mock(ShowScheduleCasting.class);
+		when(sc1.getShowSchedule()).thenReturn(schedule1);
+		when(sc1.getShowCasting()).thenReturn(charlieCasting);
+
+		ShowScheduleCasting sc2 = org.mockito.Mockito.mock(ShowScheduleCasting.class);
+		when(sc2.getShowSchedule()).thenReturn(schedule1);
+		when(sc2.getShowCasting()).thenReturn(lolaCasting);
+
+		when(showRepository.findByIdOrThrow(showId)).thenReturn(show);
+		when(showScheduleRepository.findCastingSchedules(
+			org.mockito.ArgumentMatchers.eq(showId),
+			org.mockito.ArgumentMatchers.any(),
+			org.mockito.ArgumentMatchers.any(),
+			org.mockito.ArgumentMatchers.eq(true),
+			org.mockito.ArgumentMatchers.anyList(),
+			org.mockito.ArgumentMatchers.any(PageRequest.class)
+		)).thenReturn(new PageImpl<>(List.of(schedule1), PageRequest.of(0, 50), 1));
+		when(showCastingRepository.findAllByShowId(showId))
+			.thenReturn(List.of(charlieCasting, lolaCasting, laurenCasting));
+		when(showScheduleCastingRepository.findAllByScheduleIds(List.of(101L))).thenReturn(List.of(sc1, sc2));
+
+		ShowCastingResponse.Detail result = showCastingService.getCastingSchedules(
+			showId,
+			LocalDate.of(2025, 12, 17),
+			LocalDate.of(2026, 3, 29),
+			List.of(),
+			0,
+			50
+		);
+
+		assertEquals("김호영", result.getRows().get(0).getCasts().get("찰리").getArtistName());
+		assertEquals("강홍석", result.getRows().get(0).getCasts().get("롤라").getArtistName());
+		assertNull(result.getRows().get(0).getCasts().get("로렌").getArtistId());
+		assertEquals("미정", result.getRows().get(0).getCasts().get("로렌").getArtistName());
+	}
+
+	@Test
+	@DisplayName("캐스팅 일정 조회는 기간이 없으면 오늘부터 공연 종료일까지 조회한다.")
+	void 캐스팅_일정_조회_기본기간은_오늘부터_공연종료일() {
+		Long showId = 1L;
+		LocalDate today = LocalDate.now();
+		LocalDate showEndDate = today.plusDays(7);
+
+		Show show = org.mockito.Mockito.mock(Show.class);
+		when(show.getId()).thenReturn(showId);
+		when(show.getEndTime()).thenReturn(showEndDate.atStartOfDay());
+
+		when(showRepository.findByIdOrThrow(showId)).thenReturn(show);
+		when(showScheduleRepository.findCastingSchedules(
+			eq(showId),
+			eq(today.atStartOfDay()),
+			eq(showEndDate.atTime(23, 59, 59, 999999999)),
+			eq(true),
+			any(),
+			any(PageRequest.class)
+		)).thenReturn(new PageImpl<>(List.of(), PageRequest.of(0, 50), 0));
+		when(showCastingRepository.findAllByShowId(showId)).thenReturn(List.of());
+
+		ShowCastingResponse.Detail result = showCastingService.getCastingSchedules(
+			showId,
+			null,
+			null,
+			List.of(),
+			0,
+			50
+		);
+
+		assertEquals(today, result.getRange().getFrom());
+		assertEquals(showEndDate, result.getRange().getTo());
+		verify(showScheduleRepository).findCastingSchedules(
+			eq(showId),
+			eq(today.atStartOfDay()),
+			eq(showEndDate.atTime(23, 59, 59, 999999999)),
+			eq(true),
+			any(),
+			any(PageRequest.class)
+		);
 	}
 }


### PR DESCRIPTION
## 변경 사항
---
- 공연 캐스팅 일정 조회의 기본 조회 기간을 `오늘 ~ 공연 종료일`로 변경했습니다.
- 캐스팅 미확정 역할은 응답에서 누락하지 않고 `artistId = null`, `artistName = "미정"`으로 반환하도록 변경했습니다.
- Swagger에서 공연 상세 조회와 캐스팅 일정 조회의 응답 스키마가 혼동되던 문제를 수정했습니다.
## 관련 이슈
---
- Notion Ticket: #
## 참고사항 (선택)
---