### PR TITLE
feat(auth): 내 정보 조회 구현

### DIFF
--- a/api-gateway/src/main/resources/application.yml
+++ b/api-gateway/src/main/resources/application.yml
@@ -59,13 +59,13 @@ spring:
                 - Path=/api/musical/v3/api-docs
 
             # service
-            - id: auth-jwt
+            - id: auth-protected
               uri: ${AUTH_SERVER_URI:http://localhost:8081}
               predicates:
-                - Path=/api/auth/logout
+                - Path=/api/auth/me,/api/auth/me/**,/api/auth/logout
               filters:
                 - JwtAuthenticationFilter
-            - id: auth
+            - id: auth-public
               uri: ${AUTH_SERVER_URI:http://localhost:8081}
               predicates:
                 - Path=/api/auth/**

--- a/auth-server/src/main/java/com/truve/platform/auth/service/controller/AccountController.java
+++ b/auth-server/src/main/java/com/truve/platform/auth/service/controller/AccountController.java
@@ -1,0 +1,70 @@
+package com.truve.platform.auth.service.controller;
+
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.truve.platform.auth.service.domain.dto.response.AuthResponse;
+import com.truve.platform.auth.service.security.AuthCookieManager;
+import com.truve.platform.auth.service.service.AuthService;
+import com.truve.platform.common.response.ApiResult;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/auth")
+@Tag(name = "Account", description = "내 계정 API")
+public class AccountController {
+	private final AuthService authService;
+	private final AuthCookieManager authCookieManager;
+
+	@Operation(summary = "내 정보 조회")
+	@ApiResponses({
+		@ApiResponse(
+			responseCode = "200",
+			description = "내 정보 조회 성공",
+			content = @Content(
+				schema = @Schema(implementation = AuthResponse.Me.class)
+			)
+		)
+	})
+	@GetMapping("/me")
+	public ApiResult<AuthResponse.Me> getMe(
+		@Parameter(hidden = true)
+		@RequestHeader("X-Token") String accessToken
+	) {
+		System.out.println(accessToken);
+		return ApiResult.ok(authService.getMe(accessToken));
+	}
+
+	@Operation(summary = "로그아웃")
+	@ApiResponses({
+		@ApiResponse(
+			responseCode = "200",
+			description = "로그아웃 성공"
+		),
+	})
+	@DeleteMapping("/logout")
+	public ApiResult<Void> logout(
+		@Parameter(hidden = true)
+		@RequestHeader("X-Token") String accessToken,
+		HttpServletResponse httpServletResponse
+	) {
+
+		authService.logout(accessToken);
+		authCookieManager.clearRefreshToken(httpServletResponse);
+
+		return ApiResult.ok();
+	}
+}

--- a/auth-server/src/main/java/com/truve/platform/auth/service/controller/AuthController.java
+++ b/auth-server/src/main/java/com/truve/platform/auth/service/controller/AuthController.java
@@ -38,7 +38,15 @@ public class AuthController {
 	public ApiResult<Void> signUp(
 		@RequestBody  @Valid AuthRequest.SignUp request
 	) {
-		authService.signUp(request.getEmail(), request.getPassword());
+		authService.signUp(
+			request.getEmail(),
+			request.getPassword(),
+			request.isServiceTermsAgreed(),
+			request.isElectronicFinanceTermsAgreed(),
+			request.isPrivacyCollectionAgreed(),
+			request.isMarketingInfoAgreed(),
+			request.isOver14Agreed()
+		);
 
 		return ApiResult.ok();
 	}

--- a/auth-server/src/main/java/com/truve/platform/auth/service/controller/AuthController.java
+++ b/auth-server/src/main/java/com/truve/platform/auth/service/controller/AuthController.java
@@ -3,11 +3,8 @@ package com.truve.platform.auth.service.controller;
 import org.springframework.data.util.Pair;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CookieValue;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -17,11 +14,9 @@ import com.truve.platform.auth.service.domain.dto.response.AuthResponse;
 import com.truve.platform.auth.service.security.AuthCookieManager;
 import com.truve.platform.auth.service.service.AuthService;
 
-import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -116,44 +111,4 @@ public class AuthController {
 
 		return ApiResult.ok(response);
 	}
-
-	@Operation(summary = "내 정보 조회")
-	@ApiResponses({
-		@ApiResponse(
-			responseCode = "200",
-			description = "내 정보 조회 성공",
-			content = @Content(
-				schema = @Schema(implementation = AuthResponse.Me.class)
-			)
-		)
-	})
-	@GetMapping("/me")
-	public ApiResult<AuthResponse.Me> getMe(
-		@Parameter(hidden = true)
-		@RequestHeader("X-Token") String accessToken
-	) {
-		return ApiResult.ok(authService.getMe(accessToken));
-	}
-
-	@Operation(summary = "로그아웃")
-	@ApiResponses({
-		@ApiResponse(
-			responseCode = "200",
-			description = "로그아웃 성공"
-		),
-	})
-	@DeleteMapping("/logout")
-	public ApiResult<Void> logout(
-		@RequestHeader("X-Token") String accessToken,
-		HttpServletResponse httpServletResponse
-	) {
-
-		authService.logout(accessToken);
-
-		authCookieManager.clearRefreshToken(httpServletResponse);
-
-		return ApiResult.ok();
-	}
-
-
 }

--- a/auth-server/src/main/java/com/truve/platform/auth/service/controller/AuthController.java
+++ b/auth-server/src/main/java/com/truve/platform/auth/service/controller/AuthController.java
@@ -4,6 +4,7 @@ import org.springframework.data.util.Pair;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -16,9 +17,11 @@ import com.truve.platform.auth.service.domain.dto.response.AuthResponse;
 import com.truve.platform.auth.service.security.AuthCookieManager;
 import com.truve.platform.auth.service.service.AuthService;
 
+import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -114,6 +117,23 @@ public class AuthController {
 		return ApiResult.ok(response);
 	}
 
+	@Operation(summary = "내 정보 조회")
+	@ApiResponses({
+		@ApiResponse(
+			responseCode = "200",
+			description = "내 정보 조회 성공",
+			content = @Content(
+				schema = @Schema(implementation = AuthResponse.Me.class)
+			)
+		)
+	})
+	@GetMapping("/me")
+	public ApiResult<AuthResponse.Me> getMe(
+		@Parameter(hidden = true)
+		@RequestHeader("X-Token") String accessToken
+	) {
+		return ApiResult.ok(authService.getMe(accessToken));
+	}
 
 	@Operation(summary = "로그아웃")
 	@ApiResponses({

--- a/auth-server/src/main/java/com/truve/platform/auth/service/controller/AuthController.java
+++ b/auth-server/src/main/java/com/truve/platform/auth/service/controller/AuthController.java
@@ -40,6 +40,7 @@ public class AuthController {
 	) {
 		authService.signUp(
 			request.getEmail(),
+			request.getNickname(),
 			request.getPassword(),
 			request.isServiceTermsAgreed(),
 			request.isElectronicFinanceTermsAgreed(),

--- a/auth-server/src/main/java/com/truve/platform/auth/service/domain/dto/request/AuthRequest.java
+++ b/auth-server/src/main/java/com/truve/platform/auth/service/domain/dto/request/AuthRequest.java
@@ -19,6 +19,9 @@ public class AuthRequest {
 		@NotBlank
 		private String password;
 
+		@NotBlank
+		private String nickname;
+
 		private boolean serviceTermsAgreed;
 
 		private boolean electronicFinanceTermsAgreed;

--- a/auth-server/src/main/java/com/truve/platform/auth/service/domain/dto/request/AuthRequest.java
+++ b/auth-server/src/main/java/com/truve/platform/auth/service/domain/dto/request/AuthRequest.java
@@ -18,6 +18,16 @@ public class AuthRequest {
 
 		@NotBlank
 		private String password;
+
+		private boolean serviceTermsAgreed;
+
+		private boolean electronicFinanceTermsAgreed;
+
+		private boolean privacyCollectionAgreed;
+
+		private boolean marketingInfoAgreed;
+
+		private boolean over14Agreed;
 	}
 
 	@Getter

--- a/auth-server/src/main/java/com/truve/platform/auth/service/domain/dto/response/AuthResponse.java
+++ b/auth-server/src/main/java/com/truve/platform/auth/service/domain/dto/response/AuthResponse.java
@@ -1,5 +1,7 @@
 package com.truve.platform.auth.service.domain.dto.response;
 
+import com.truve.platform.auth.service.domain.entity.User;
+
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -12,5 +14,27 @@ public class AuthResponse {
 	public static class Login {
 		@Schema(description = "AccessToken(Authorization 헤더에 Bearer 토큰 사용)")
 		public String accessToken;
+	}
+
+	@Getter
+	@AllArgsConstructor
+	@Schema(description = "내 정보 조회 응답")
+	public static class Me {
+		@Schema(description = "이메일")
+		private final String email;
+
+		@Schema(description = "닉네임")
+		private final String nickname;
+
+		@Schema(description = "마케팅 정보 수신 동의 여부")
+		private final boolean marketingInfoAgreed;
+
+		public static Me from(User user) {
+			return new Me(
+				user.getEmail(),
+				user.getNickname(),
+				user.isMarketingInfoAgreed()
+			);
+		}
 	}
 }

--- a/auth-server/src/main/java/com/truve/platform/auth/service/domain/entity/User.java
+++ b/auth-server/src/main/java/com/truve/platform/auth/service/domain/entity/User.java
@@ -47,10 +47,38 @@ public class User extends BaseEntity {
 
 	private String oAuthRefreshToken;
 
+	@Column(nullable = false)
+	private boolean serviceTermsAgreed;
+
+	@Column(nullable = false)
+	private boolean electronicFinanceTermsAgreed;
+
+	@Column(nullable = false)
+	private boolean privacyCollectionAgreed;
+
+	@Column(nullable = false)
+	private boolean marketingInfoAgreed;
+
+	@Column(nullable = false)
+	private boolean over14Agreed;
+
 
 	@Builder
-	private User(UUID publicId, String email, String password, AuthProvider provider,
-		UserRole role,  String oAuthUserId, String oAuthAccessToken, String oAuthRefreshToken) {
+	private User(
+		UUID publicId,
+		String email,
+		String password,
+		AuthProvider provider,
+		UserRole role,
+		String oAuthUserId,
+		String oAuthAccessToken,
+		String oAuthRefreshToken,
+		boolean serviceTermsAgreed,
+		boolean electronicFinanceTermsAgreed,
+		boolean privacyCollectionAgreed,
+		boolean marketingInfoAgreed,
+		boolean over14Agreed
+	) {
 		this.publicId = publicId;
 		this.email = email;
 		this.password = password;
@@ -59,15 +87,33 @@ public class User extends BaseEntity {
 		this.oAuthUserId = oAuthUserId;
 		this.oAuthAccessToken = oAuthAccessToken;
 		this.oAuthRefreshToken = oAuthRefreshToken;
+		this.serviceTermsAgreed = serviceTermsAgreed;
+		this.electronicFinanceTermsAgreed = electronicFinanceTermsAgreed;
+		this.privacyCollectionAgreed = privacyCollectionAgreed;
+		this.marketingInfoAgreed = marketingInfoAgreed;
+		this.over14Agreed = over14Agreed;
 	}
 
-	public static User createLocalUser(String email, String password) {
+	public static User createLocalUser(
+		String email,
+		String password,
+		boolean serviceTermsAgreed,
+		boolean electronicFinanceTermsAgreed,
+		boolean privacyCollectionAgreed,
+		boolean marketingInfoAgreed,
+		boolean over14Agreed
+	) {
 		return User.builder()
 			.publicId(UUID.randomUUID())
 			.email(email)
 			.password(password)
 			.provider(AuthProvider.LOCAL)
 			.role(UserRole.MEMBER)
+			.serviceTermsAgreed(serviceTermsAgreed)
+			.electronicFinanceTermsAgreed(electronicFinanceTermsAgreed)
+			.privacyCollectionAgreed(privacyCollectionAgreed)
+			.marketingInfoAgreed(marketingInfoAgreed)
+			.over14Agreed(over14Agreed)
 			.build();
 	}
 
@@ -86,6 +132,11 @@ public class User extends BaseEntity {
 			.oAuthUserId(oAuthUserId)
 			.oAuthAccessToken(oAuthAccessToken)
 			.oAuthRefreshToken(oAuthRefreshToken)
+			.serviceTermsAgreed(false)
+			.electronicFinanceTermsAgreed(false)
+			.privacyCollectionAgreed(false)
+			.marketingInfoAgreed(false)
+			.over14Agreed(false)
 			.build();
 	}
 }

--- a/auth-server/src/main/java/com/truve/platform/auth/service/domain/entity/User.java
+++ b/auth-server/src/main/java/com/truve/platform/auth/service/domain/entity/User.java
@@ -30,6 +30,9 @@ public class User extends BaseEntity {
 	@Column(nullable = false, unique = true)
 	private String email;
 
+	@Column(unique = true)
+	private String nickname;
+
 	// TODO: 기획 논의 이후 비밀번호 정책 정규식 설정
 	private String password;
 
@@ -67,6 +70,7 @@ public class User extends BaseEntity {
 	private User(
 		UUID publicId,
 		String email,
+		String nickname,
 		String password,
 		AuthProvider provider,
 		UserRole role,
@@ -81,6 +85,7 @@ public class User extends BaseEntity {
 	) {
 		this.publicId = publicId;
 		this.email = email;
+		this.nickname = nickname;
 		this.password = password;
 		this.provider = provider;
 		this.role = role;
@@ -96,6 +101,7 @@ public class User extends BaseEntity {
 
 	public static User createLocalUser(
 		String email,
+		String nickname,
 		String password,
 		boolean serviceTermsAgreed,
 		boolean electronicFinanceTermsAgreed,
@@ -106,6 +112,7 @@ public class User extends BaseEntity {
 		return User.builder()
 			.publicId(UUID.randomUUID())
 			.email(email)
+			.nickname(nickname)
 			.password(password)
 			.provider(AuthProvider.LOCAL)
 			.role(UserRole.MEMBER)
@@ -127,6 +134,7 @@ public class User extends BaseEntity {
 		return User.builder()
 			.publicId(UUID.randomUUID())
 			.email(email)
+			.nickname(null)
 			.provider(provider)
 			.role(UserRole.MEMBER)
 			.oAuthUserId(oAuthUserId)

--- a/auth-server/src/main/java/com/truve/platform/auth/service/event/UserSignedUpEvent.java
+++ b/auth-server/src/main/java/com/truve/platform/auth/service/event/UserSignedUpEvent.java
@@ -27,8 +27,7 @@ public class UserSignedUpEvent {
 			EVENT_TYPE,
 			LocalDateTime.now(),
 			user.getPublicId(),
-			// TODO: 닉네임으로 변경 예정
-			user.getEmail()
+			user.getNickname()
 		);
 	}
 }

--- a/auth-server/src/main/java/com/truve/platform/auth/service/repository/UserRepository.java
+++ b/auth-server/src/main/java/com/truve/platform/auth/service/repository/UserRepository.java
@@ -17,6 +17,8 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
 	boolean existsByEmail(String email);
 
+	boolean existsByNickname(String nickname);
+
 	default User findByEmailOrThrow(String email) {
 		return findByEmail(email).orElseThrow(
 			() -> new CustomException(ErrorCode.NOT_FOUND_EMAIL)

--- a/auth-server/src/main/java/com/truve/platform/auth/service/service/AuthService.java
+++ b/auth-server/src/main/java/com/truve/platform/auth/service/service/AuthService.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.truve.platform.auth.service.event.UserSignedUpEvent;
+import com.truve.platform.auth.service.domain.dto.response.AuthResponse;
 import com.truve.platform.common.exception.CustomException;
 import com.truve.platform.common.exception.ErrorCode;
 import com.truve.platform.common.support.Preconditions;
@@ -33,6 +34,13 @@ public class AuthService {
 	private final RefreshTokenService refreshTokenService;
 	private final AccessTokenBlacklistService accessTokenBlacklistService;
 	private final UserSignedUpEventPublisher  userSignedUpEventPublisher;
+
+	@Transactional(readOnly = true)
+	public AuthResponse.Me getMe(String accessToken) {
+		User user = getUserByAccessToken(accessToken);
+
+		return AuthResponse.Me.from(user);
+	}
 
 	@Transactional
 	public Pair<String, String> login(String email, String password) {
@@ -150,6 +158,17 @@ public class AuthService {
 
 		UserSignedUpEvent event = UserSignedUpEvent.from(user);
 		userSignedUpEventPublisher.publish(user.getPublicId().toString(), event);
+	}
+
+	private User getUserByAccessToken(String accessToken) {
+		try {
+			UUID userPublicId = jwtService.parsePublicId(accessToken);
+
+			return userRepository.findByPublicId(userPublicId)
+				.orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_USER));
+		} catch (JwtException | IllegalArgumentException e) {
+			throw new CustomException(ErrorCode.INVALID_REFRESH_TOKEN);
+		}
 	}
 
 }

--- a/auth-server/src/main/java/com/truve/platform/auth/service/service/AuthService.java
+++ b/auth-server/src/main/java/com/truve/platform/auth/service/service/AuthService.java
@@ -99,7 +99,15 @@ public class AuthService {
 	}
 
 	@Transactional
-	public void signUp(String email, String password) {
+	public void signUp(
+		String email,
+		String password,
+		boolean serviceTermsAgreed,
+		boolean electronicFinanceTermsAgreed,
+		boolean privacyCollectionAgreed,
+		boolean marketingInfoAgreed,
+		boolean over14Agreed
+	) {
 
 		String verifiedAt = emailVerificationRepository.isVerifiedEmail(email);
 		Preconditions.validate(!(verifiedAt == null || verifiedAt.isBlank()), ErrorCode.NOT_VERIFIED_EMAIL);
@@ -107,6 +115,10 @@ public class AuthService {
 		Preconditions.validate(
 			!userRepository.existsByEmail(email),
 			ErrorCode.ALREADY_EXISTS_EMAIL
+		);
+		Preconditions.validate(
+			serviceTermsAgreed && electronicFinanceTermsAgreed && privacyCollectionAgreed && over14Agreed,
+			ErrorCode.REQUIRED_TERMS_NOT_AGREED
 		);
 
 		String encodedPassword = passwordEncoder.encode(password);

--- a/auth-server/src/main/java/com/truve/platform/auth/service/service/AuthService.java
+++ b/auth-server/src/main/java/com/truve/platform/auth/service/service/AuthService.java
@@ -1,6 +1,7 @@
 package com.truve.platform.auth.service.service;
 
 import java.util.UUID;
+import java.util.regex.Pattern;
 
 import org.springframework.data.util.Pair;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -23,6 +24,7 @@ import lombok.RequiredArgsConstructor;
 @Service
 @RequiredArgsConstructor
 public class AuthService {
+	private static final Pattern NICKNAME_PATTERN = Pattern.compile("^[a-zA-Z0-9가-힣]{2,10}$");
 
 	private final UserRepository userRepository;
 	private final EmailVerificationRepository emailVerificationRepository;
@@ -116,6 +118,14 @@ public class AuthService {
 		Preconditions.validate(
 			!userRepository.existsByEmail(email),
 			ErrorCode.ALREADY_EXISTS_EMAIL
+		);
+		Preconditions.validate(
+			nickname != null && NICKNAME_PATTERN.matcher(nickname).matches(),
+			ErrorCode.INVALID_NICKNAME
+		);
+		Preconditions.validate(
+			!userRepository.existsByNickname(nickname),
+			ErrorCode.ALREADY_EXISTS_NICKNAME
 		);
 		Preconditions.validate(
 			serviceTermsAgreed && electronicFinanceTermsAgreed && privacyCollectionAgreed && over14Agreed,

--- a/auth-server/src/main/java/com/truve/platform/auth/service/service/AuthService.java
+++ b/auth-server/src/main/java/com/truve/platform/auth/service/service/AuthService.java
@@ -101,6 +101,7 @@ public class AuthService {
 	@Transactional
 	public void signUp(
 		String email,
+		String nickname,
 		String password,
 		boolean serviceTermsAgreed,
 		boolean electronicFinanceTermsAgreed,
@@ -125,6 +126,7 @@ public class AuthService {
 
 		User user = User.createLocalUser(
 			email,
+			nickname,
 			encodedPassword,
 			serviceTermsAgreed,
 			electronicFinanceTermsAgreed,

--- a/auth-server/src/main/java/com/truve/platform/auth/service/service/AuthService.java
+++ b/auth-server/src/main/java/com/truve/platform/auth/service/service/AuthService.java
@@ -123,7 +123,15 @@ public class AuthService {
 
 		String encodedPassword = passwordEncoder.encode(password);
 
-		User user = User.createLocalUser(email, encodedPassword);
+		User user = User.createLocalUser(
+			email,
+			encodedPassword,
+			serviceTermsAgreed,
+			electronicFinanceTermsAgreed,
+			privacyCollectionAgreed,
+			marketingInfoAgreed,
+			over14Agreed
+		);
 
 		userRepository.save(user);
 		emailVerificationRepository.deleteVerifiedEmail(email);

--- a/auth-server/src/main/resources/application.yml
+++ b/auth-server/src/main/resources/application.yml
@@ -13,7 +13,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: validate
+      ddl-auto: update
     show-sql: false
 
   kafka:

--- a/auth-server/src/test/java/com/truve/platform/auth/service/controller/AccountControllerTest.java
+++ b/auth-server/src/test/java/com/truve/platform/auth/service/controller/AccountControllerTest.java
@@ -1,0 +1,73 @@
+package com.truve.platform.auth.service.controller;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+import com.truve.platform.auth.service.domain.dto.response.AuthResponse;
+import com.truve.platform.auth.service.security.AuthCookieManager;
+import com.truve.platform.auth.service.security.config.SecurityConfig;
+import com.truve.platform.auth.service.service.AuthService;
+
+import jakarta.servlet.http.HttpServletResponse;
+
+@WebMvcTest(controllers = AccountController.class)
+@Import(SecurityConfig.class)
+class AccountControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+	@MockitoBean
+	private AuthService authService;
+	@MockitoBean
+	private AuthCookieManager authCookieManager;
+	@MockitoBean
+	private JpaMetamodelMappingContext jpaMetamodelMappingContext;
+
+	@Test
+	@DisplayName("내 정보 조회에 성공하면 200 OK와 사용자 정보를 반환한다.")
+	void 내정보조회_성공() throws Exception {
+		// given
+		given(authService.getMe("access-token"))
+			.willReturn(new AuthResponse.Me("user@test.com", "tester", false));
+
+		// when
+		ResultActions resultActions = mockMvc.perform(get("/api/auth/me")
+			.header("X-Token", "access-token"));
+
+		// then
+		resultActions.andExpect(status().isOk())
+			.andExpect(jsonPath("$.code").value("ok"))
+			.andExpect(jsonPath("$.data.email").value("user@test.com"))
+			.andExpect(jsonPath("$.data.nickname").value("tester"))
+			.andExpect(jsonPath("$.data.marketingInfoAgreed").value(false));
+		verify(authService).getMe("access-token");
+	}
+
+	@Test
+	@DisplayName("로그아웃에 성공하면 200 OK를 반환하고 refreshToken 쿠키를 제거한다.")
+	void 로그아웃_성공() throws Exception {
+		// when
+		ResultActions resultActions = mockMvc.perform(delete("/api/auth/logout")
+			.header("X-Token", "access-token"));
+
+		// then
+		resultActions.andExpect(status().isOk())
+			.andExpect(jsonPath("$.code").value("ok"));
+		verify(authService).logout("access-token");
+		verify(authCookieManager).clearRefreshToken(org.mockito.ArgumentMatchers.any(HttpServletResponse.class));
+	}
+}

--- a/auth-server/src/test/java/com/truve/platform/auth/service/controller/AuthControllerTest.java
+++ b/auth-server/src/test/java/com/truve/platform/auth/service/controller/AuthControllerTest.java
@@ -45,7 +45,12 @@ class AuthControllerTest {
 		String body = """
 			{
 			  "email": "new@test.com",
-			  "password": "password123"
+			  "password": "password123",
+			  "serviceTermsAgreed": true,
+			  "electronicFinanceTermsAgreed": true,
+			  "privacyCollectionAgreed": true,
+			  "marketingInfoAgreed": false,
+			  "over14Agreed": true
 			}
 			""";
 
@@ -57,7 +62,7 @@ class AuthControllerTest {
 		// then
 		resultActions.andExpect(status().isOk())
 			.andExpect(jsonPath("$.code").value("ok"));
-		verify(authService).signUp("new@test.com", "password123");
+		verify(authService).signUp("new@test.com", "password123", true, true, true, false, true);
 	}
 
 	@Test
@@ -67,11 +72,16 @@ class AuthControllerTest {
 		String body = """
 			{
 			  "email": "dup@test.com",
-			  "password": "password123"
+			  "password": "password123",
+			  "serviceTermsAgreed": true,
+			  "electronicFinanceTermsAgreed": true,
+			  "privacyCollectionAgreed": true,
+			  "marketingInfoAgreed": false,
+			  "over14Agreed": true
 			}
 			""";
 		willThrow(new CustomException(ErrorCode.ALREADY_EXISTS_EMAIL))
-			.given(authService).signUp(anyString(), anyString());
+			.given(authService).signUp(anyString(), anyString(), anyBoolean(), anyBoolean(), anyBoolean(), anyBoolean(), anyBoolean());
 
 		// when
 		ResultActions resultActions = mockMvc.perform(post("/api/auth/sign-up")

--- a/auth-server/src/test/java/com/truve/platform/auth/service/controller/AuthControllerTest.java
+++ b/auth-server/src/test/java/com/truve/platform/auth/service/controller/AuthControllerTest.java
@@ -46,6 +46,7 @@ class AuthControllerTest {
 			{
 			  "email": "new@test.com",
 			  "password": "password123",
+			  "nickname": "tester",
 			  "serviceTermsAgreed": true,
 			  "electronicFinanceTermsAgreed": true,
 			  "privacyCollectionAgreed": true,
@@ -62,7 +63,7 @@ class AuthControllerTest {
 		// then
 		resultActions.andExpect(status().isOk())
 			.andExpect(jsonPath("$.code").value("ok"));
-		verify(authService).signUp("new@test.com", "password123", true, true, true, false, true);
+		verify(authService).signUp("new@test.com", "tester", "password123", true, true, true, false, true);
 	}
 
 	@Test
@@ -73,6 +74,7 @@ class AuthControllerTest {
 			{
 			  "email": "dup@test.com",
 			  "password": "password123",
+			  "nickname": "tester",
 			  "serviceTermsAgreed": true,
 			  "electronicFinanceTermsAgreed": true,
 			  "privacyCollectionAgreed": true,
@@ -81,7 +83,7 @@ class AuthControllerTest {
 			}
 			""";
 		willThrow(new CustomException(ErrorCode.ALREADY_EXISTS_EMAIL))
-			.given(authService).signUp(anyString(), anyString(), anyBoolean(), anyBoolean(), anyBoolean(), anyBoolean(), anyBoolean());
+			.given(authService).signUp(anyString(), anyString(), anyString(), anyBoolean(), anyBoolean(), anyBoolean(), anyBoolean(), anyBoolean());
 
 		// when
 		ResultActions resultActions = mockMvc.perform(post("/api/auth/sign-up")
@@ -102,6 +104,7 @@ class AuthControllerTest {
 			{
 			  "email": "new@test.com",
 			  "password": "password123",
+			  "nickname": "tester",
 			  "serviceTermsAgreed": true,
 			  "electronicFinanceTermsAgreed": false,
 			  "privacyCollectionAgreed": true,
@@ -110,7 +113,7 @@ class AuthControllerTest {
 			}
 			""";
 		willThrow(new CustomException(ErrorCode.REQUIRED_TERMS_NOT_AGREED))
-			.given(authService).signUp(anyString(), anyString(), anyBoolean(), anyBoolean(), anyBoolean(), anyBoolean(), anyBoolean());
+			.given(authService).signUp(anyString(), anyString(), anyString(), anyBoolean(), anyBoolean(), anyBoolean(), anyBoolean(), anyBoolean());
 
 		// when
 		ResultActions resultActions = mockMvc.perform(post("/api/auth/sign-up")

--- a/auth-server/src/test/java/com/truve/platform/auth/service/controller/AuthControllerTest.java
+++ b/auth-server/src/test/java/com/truve/platform/auth/service/controller/AuthControllerTest.java
@@ -127,6 +127,36 @@ class AuthControllerTest {
 	}
 
 	@Test
+	@DisplayName("닉네임 형식 오류로 회원가입 요청하면 400을 반환한다.")
+	void 회원가입_실패_닉네임_형식_오류() throws Exception {
+		// given
+		String body = """
+			{
+			  "email": "new@test.com",
+			  "password": "password123",
+			  "nickname": "a b",
+			  "serviceTermsAgreed": true,
+			  "electronicFinanceTermsAgreed": true,
+			  "privacyCollectionAgreed": true,
+			  "marketingInfoAgreed": false,
+			  "over14Agreed": true
+			}
+			""";
+		willThrow(new CustomException(ErrorCode.INVALID_NICKNAME))
+			.given(authService).signUp(anyString(), anyString(), anyString(), anyBoolean(), anyBoolean(), anyBoolean(), anyBoolean(), anyBoolean());
+
+		// when
+		ResultActions resultActions = mockMvc.perform(post("/api/auth/sign-up")
+			.contentType(MediaType.APPLICATION_JSON)
+			.content(body));
+
+		// then
+		resultActions.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.errorType").value("CLIENT_ERROR"))
+			.andExpect(jsonPath("$.code").value(ErrorCode.INVALID_NICKNAME.getCode()));
+	}
+
+	@Test
 	@DisplayName("로그인에 성공하면 accessToken을 반환하고 refreshToken 쿠키를 설정한다.")
 	void 로그인_성공() throws Exception {
 		// given

--- a/auth-server/src/test/java/com/truve/platform/auth/service/controller/AuthControllerTest.java
+++ b/auth-server/src/test/java/com/truve/platform/auth/service/controller/AuthControllerTest.java
@@ -95,6 +95,35 @@ class AuthControllerTest {
 	}
 
 	@Test
+	@DisplayName("필수 약관 미동의로 회원가입 요청하면 400을 반환한다.")
+	void 회원가입_실패_필수_약관_미동의() throws Exception {
+		// given
+		String body = """
+			{
+			  "email": "new@test.com",
+			  "password": "password123",
+			  "serviceTermsAgreed": true,
+			  "electronicFinanceTermsAgreed": false,
+			  "privacyCollectionAgreed": true,
+			  "marketingInfoAgreed": false,
+			  "over14Agreed": true
+			}
+			""";
+		willThrow(new CustomException(ErrorCode.REQUIRED_TERMS_NOT_AGREED))
+			.given(authService).signUp(anyString(), anyString(), anyBoolean(), anyBoolean(), anyBoolean(), anyBoolean(), anyBoolean());
+
+		// when
+		ResultActions resultActions = mockMvc.perform(post("/api/auth/sign-up")
+			.contentType(MediaType.APPLICATION_JSON)
+			.content(body));
+
+		// then
+		resultActions.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.errorType").value("CLIENT_ERROR"))
+			.andExpect(jsonPath("$.code").value(ErrorCode.REQUIRED_TERMS_NOT_AGREED.getCode()));
+	}
+
+	@Test
 	@DisplayName("로그인에 성공하면 accessToken을 반환하고 refreshToken 쿠키를 설정한다.")
 	void 로그인_성공() throws Exception {
 		// given

--- a/auth-server/src/test/java/com/truve/platform/auth/service/controller/AuthControllerTest.java
+++ b/auth-server/src/test/java/com/truve/platform/auth/service/controller/AuthControllerTest.java
@@ -19,6 +19,7 @@ import org.springframework.test.web.servlet.ResultActions;
 import com.truve.platform.auth.service.security.AuthCookieManager;
 import com.truve.platform.auth.service.security.config.SecurityConfig;
 import com.truve.platform.auth.service.service.AuthService;
+import com.truve.platform.auth.service.domain.dto.response.AuthResponse;
 import com.truve.platform.common.exception.CustomException;
 import com.truve.platform.common.exception.ErrorCode;
 
@@ -196,6 +197,26 @@ class AuthControllerTest {
 			.andExpect(jsonPath("$.code").value("ok"))
 			.andExpect(jsonPath("$.data.accessToken").value("new-access-token"));
 		verify(authCookieManager).setRefreshToken(any(HttpServletResponse.class), eq("new-refresh-token"), eq(1209600L));
+	}
+
+	@Test
+	@DisplayName("내 정보 조회에 성공하면 200 OK와 사용자 정보를 반환한다.")
+	void 내정보조회_성공() throws Exception {
+		// given
+		given(authService.getMe("access-token"))
+			.willReturn(new AuthResponse.Me("user@test.com", "tester", false));
+
+		// when
+		ResultActions resultActions = mockMvc.perform(get("/api/auth/me")
+			.header("X-Token", "access-token"));
+
+		// then
+		resultActions.andExpect(status().isOk())
+			.andExpect(jsonPath("$.code").value("ok"))
+			.andExpect(jsonPath("$.data.email").value("user@test.com"))
+			.andExpect(jsonPath("$.data.nickname").value("tester"))
+			.andExpect(jsonPath("$.data.marketingInfoAgreed").value(false));
+		verify(authService).getMe("access-token");
 	}
 
 	@Test

--- a/auth-server/src/test/java/com/truve/platform/auth/service/controller/AuthControllerTest.java
+++ b/auth-server/src/test/java/com/truve/platform/auth/service/controller/AuthControllerTest.java
@@ -19,12 +19,10 @@ import org.springframework.test.web.servlet.ResultActions;
 import com.truve.platform.auth.service.security.AuthCookieManager;
 import com.truve.platform.auth.service.security.config.SecurityConfig;
 import com.truve.platform.auth.service.service.AuthService;
-import com.truve.platform.auth.service.domain.dto.response.AuthResponse;
 import com.truve.platform.common.exception.CustomException;
 import com.truve.platform.common.exception.ErrorCode;
 
 import jakarta.servlet.http.HttpServletResponse;
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 @WebMvcTest(controllers = AuthController.class)
 @Import(SecurityConfig.class)
@@ -199,37 +197,4 @@ class AuthControllerTest {
 		verify(authCookieManager).setRefreshToken(any(HttpServletResponse.class), eq("new-refresh-token"), eq(1209600L));
 	}
 
-	@Test
-	@DisplayName("내 정보 조회에 성공하면 200 OK와 사용자 정보를 반환한다.")
-	void 내정보조회_성공() throws Exception {
-		// given
-		given(authService.getMe("access-token"))
-			.willReturn(new AuthResponse.Me("user@test.com", "tester", false));
-
-		// when
-		ResultActions resultActions = mockMvc.perform(get("/api/auth/me")
-			.header("X-Token", "access-token"));
-
-		// then
-		resultActions.andExpect(status().isOk())
-			.andExpect(jsonPath("$.code").value("ok"))
-			.andExpect(jsonPath("$.data.email").value("user@test.com"))
-			.andExpect(jsonPath("$.data.nickname").value("tester"))
-			.andExpect(jsonPath("$.data.marketingInfoAgreed").value(false));
-		verify(authService).getMe("access-token");
-	}
-
-	@Test
-	@DisplayName("로그아웃에 성공하면 200 OK를 반환하고 refreshToken 쿠키를 제거한다.")
-	void 로그아웃_성공() throws Exception {
-		// when
-		ResultActions resultActions = mockMvc.perform(delete("/api/auth/logout")
-			.header("X-Token", "access-token"));
-
-		// then
-		resultActions.andExpect(status().isOk())
-			.andExpect(jsonPath("$.code").value("ok"));
-		verify(authService).logout("access-token");
-		verify(authCookieManager).clearRefreshToken(any(HttpServletResponse.class));
-	}
 }

--- a/auth-server/src/test/java/com/truve/platform/auth/service/domain/entity/UserTest.java
+++ b/auth-server/src/test/java/com/truve/platform/auth/service/domain/entity/UserTest.java
@@ -28,7 +28,7 @@ class UserTest {
 		@DisplayName("createLocalUser 호출 시 LOCAL/MEMBER 권한으로 사용자를 생성한다.")
 		void createLocalUser_success() {
 			// when
-			User user = User.createLocalUser(EMAIL, PASSWORD);
+			User user = User.createLocalUser(EMAIL, PASSWORD, true, true, true, false, true);
 
 			// then
 			assertAll(
@@ -37,6 +37,11 @@ class UserTest {
 				() -> assertThat(user.getPassword()).isEqualTo(PASSWORD),
 				() -> assertThat(user.getProvider()).isEqualTo(AuthProvider.LOCAL),
 				() -> assertThat(user.getRole()).isEqualTo(UserRole.MEMBER),
+				() -> assertThat(user.isServiceTermsAgreed()).isTrue(),
+				() -> assertThat(user.isElectronicFinanceTermsAgreed()).isTrue(),
+				() -> assertThat(user.isPrivacyCollectionAgreed()).isTrue(),
+				() -> assertThat(user.isMarketingInfoAgreed()).isFalse(),
+				() -> assertThat(user.isOver14Agreed()).isTrue(),
 				() -> assertThat(user.getOAuthUserId()).isNull(),
 				() -> assertThat(user.getOAuthAccessToken()).isNull(),
 				() -> assertThat(user.getOAuthRefreshToken()).isNull()
@@ -67,6 +72,11 @@ class UserTest {
 				() -> assertThat(user.getPassword()).isNull(),
 				() -> assertThat(user.getProvider()).isEqualTo(AuthProvider.KAKAO),
 				() -> assertThat(user.getRole()).isEqualTo(UserRole.MEMBER),
+				() -> assertThat(user.isServiceTermsAgreed()).isFalse(),
+				() -> assertThat(user.isElectronicFinanceTermsAgreed()).isFalse(),
+				() -> assertThat(user.isPrivacyCollectionAgreed()).isFalse(),
+				() -> assertThat(user.isMarketingInfoAgreed()).isFalse(),
+				() -> assertThat(user.isOver14Agreed()).isFalse(),
 				() -> assertThat(user.getOAuthUserId()).isEqualTo(OAUTH_USER_ID),
 				() -> assertThat(user.getOAuthAccessToken()).isEqualTo(OAUTH_ACCESS_TOKEN),
 				() -> assertThat(user.getOAuthRefreshToken()).isEqualTo(OAUTH_REFRESH_TOKEN)

--- a/auth-server/src/test/java/com/truve/platform/auth/service/domain/entity/UserTest.java
+++ b/auth-server/src/test/java/com/truve/platform/auth/service/domain/entity/UserTest.java
@@ -15,6 +15,7 @@ import com.truve.platform.common.constants.UserRole;
 class UserTest {
 
 	private static final String EMAIL = "test@truve.com";
+	private static final String NICKNAME = "tester";
 	private static final String PASSWORD = "encoded-password";
 	private static final String OAUTH_USER_ID = "oauth-user-id";
 	private static final String OAUTH_ACCESS_TOKEN = "oauth-access-token";
@@ -28,12 +29,13 @@ class UserTest {
 		@DisplayName("createLocalUser 호출 시 LOCAL/MEMBER 권한으로 사용자를 생성한다.")
 		void createLocalUser_success() {
 			// when
-			User user = User.createLocalUser(EMAIL, PASSWORD, true, true, true, false, true);
+			User user = User.createLocalUser(EMAIL, NICKNAME, PASSWORD, true, true, true, false, true);
 
 			// then
 			assertAll(
 				() -> assertThat(user.getPublicId()).isInstanceOf(UUID.class),
 				() -> assertThat(user.getEmail()).isEqualTo(EMAIL),
+				() -> assertThat(user.getNickname()).isEqualTo(NICKNAME),
 				() -> assertThat(user.getPassword()).isEqualTo(PASSWORD),
 				() -> assertThat(user.getProvider()).isEqualTo(AuthProvider.LOCAL),
 				() -> assertThat(user.getRole()).isEqualTo(UserRole.MEMBER),
@@ -69,6 +71,7 @@ class UserTest {
 			assertAll(
 				() -> assertThat(user.getPublicId()).isInstanceOf(UUID.class),
 				() -> assertThat(user.getEmail()).isEqualTo(EMAIL),
+				() -> assertThat(user.getNickname()).isNull(),
 				() -> assertThat(user.getPassword()).isNull(),
 				() -> assertThat(user.getProvider()).isEqualTo(AuthProvider.KAKAO),
 				() -> assertThat(user.getRole()).isEqualTo(UserRole.MEMBER),

--- a/auth-server/src/test/java/com/truve/platform/auth/service/service/AuthServiceTest.java
+++ b/auth-server/src/test/java/com/truve/platform/auth/service/service/AuthServiceTest.java
@@ -20,6 +20,7 @@ import org.springframework.data.util.Pair;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import com.truve.platform.auth.service.domain.dto.response.AuthResponse;
 import com.truve.platform.auth.service.domain.entity.User;
 import com.truve.platform.auth.service.event.UserSignedUpEvent;
 import com.truve.platform.auth.service.repository.EmailVerificationRepository;
@@ -58,6 +59,62 @@ class AuthServiceTest {
 		User user = User.createLocalUser(email, NICKNAME, encodedPassword, true, true, true, false, true);
 		ReflectionTestUtils.setField(user, "id", id);
 		return user;
+	}
+
+	@Nested
+	@DisplayName("내 정보 조회 테스트")
+	class GetMeTest {
+
+		@Test
+		@DisplayName("유효한 액세스 토큰이면 내 정보를 반환한다.")
+		void 내정보조회_성공() {
+			// given
+			String accessToken = "access-token";
+			User user = createUser(1L, "user@test.com", "encoded");
+
+			given(jwtService.parsePublicId(accessToken)).willReturn(user.getPublicId());
+			given(userRepository.findByPublicId(user.getPublicId())).willReturn(java.util.Optional.of(user));
+
+			// when
+			AuthResponse.Me result = authService.getMe(accessToken);
+
+			// then
+			assertThat(result.getEmail()).isEqualTo(user.getEmail());
+			assertThat(result.getNickname()).isEqualTo(user.getNickname());
+			assertThat(result.isMarketingInfoAgreed()).isEqualTo(user.isMarketingInfoAgreed());
+		}
+
+		@Test
+		@DisplayName("액세스 토큰 파싱에 실패하면 예외가 발생한다.")
+		void 내정보조회_실패_유효하지_않은_토큰() {
+			// given
+			String accessToken = "invalid-access-token";
+			given(jwtService.parsePublicId(accessToken)).willThrow(new JwtException("invalid"));
+
+			// when
+			CustomException exception = assertThrows(CustomException.class, () -> authService.getMe(accessToken));
+
+			// then
+			assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.INVALID_REFRESH_TOKEN);
+			verify(userRepository, never()).findByPublicId(any());
+		}
+
+		@Test
+		@DisplayName("토큰은 유효하지만 사용자가 없으면 예외가 발생한다.")
+		void 내정보조회_실패_사용자없음() {
+			// given
+			String accessToken = "access-token";
+			UUID userPublicId = UUID.randomUUID();
+
+			given(jwtService.parsePublicId(accessToken)).willReturn(userPublicId);
+			given(userRepository.findByPublicId(userPublicId)).willReturn(java.util.Optional.empty());
+
+			// when
+			CustomException exception = assertThrows(CustomException.class, () -> authService.getMe(accessToken));
+
+			// then
+			assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.NOT_FOUND_USER);
+		}
 	}
 
 	@Nested

--- a/auth-server/src/test/java/com/truve/platform/auth/service/service/AuthServiceTest.java
+++ b/auth-server/src/test/java/com/truve/platform/auth/service/service/AuthServiceTest.java
@@ -313,5 +313,29 @@ class AuthServiceTest {
 			verify(emailVerificationRepository, never()).deleteVerifiedEmail(anyString());
 			verify(userSignedUpEventPublisher, never()).publish(anyString(), any());
 		}
+
+		@Test
+		@DisplayName("필수 약관에 동의하지 않으면 예외가 발생한다.")
+		void 회원가입_실패_필수_약관_미동의() {
+			// given
+			String email = "new@test.com";
+			String password = "plain";
+
+			given(emailVerificationRepository.isVerifiedEmail(email)).willReturn("1700000000000");
+			given(userRepository.existsByEmail(email)).willReturn(false);
+
+			// when
+			CustomException exception = assertThrows(
+				CustomException.class,
+				() -> authService.signUp(email, password, true, false, true, false, true)
+			);
+
+			// then
+			assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.REQUIRED_TERMS_NOT_AGREED);
+			verify(passwordEncoder, never()).encode(anyString());
+			verify(userRepository, never()).save(any(User.class));
+			verify(emailVerificationRepository, never()).deleteVerifiedEmail(anyString());
+			verify(userSignedUpEventPublisher, never()).publish(anyString(), any());
+		}
 	}
 }

--- a/auth-server/src/test/java/com/truve/platform/auth/service/service/AuthServiceTest.java
+++ b/auth-server/src/test/java/com/truve/platform/auth/service/service/AuthServiceTest.java
@@ -52,8 +52,10 @@ class AuthServiceTest {
 	@InjectMocks
 	private AuthService authService;
 
+	private static final String NICKNAME = "tester";
+
 	private User createUser(Long id, String email, String encodedPassword) {
-		User user = User.createLocalUser(email, encodedPassword, true, true, true, false, true);
+		User user = User.createLocalUser(email, NICKNAME, encodedPassword, true, true, true, false, true);
 		ReflectionTestUtils.setField(user, "id", id);
 		return user;
 	}
@@ -246,7 +248,7 @@ class AuthServiceTest {
 			});
 
 			// when
-			authService.signUp(email, password, true, true, true, false, true);
+			authService.signUp(email, NICKNAME, password, true, true, true, false, true);
 
 			// then
 			ArgumentCaptor<User> savedUserCaptor = ArgumentCaptor.forClass(User.class);
@@ -258,6 +260,7 @@ class AuthServiceTest {
 			verify(userSignedUpEventPublisher).publish(keyCaptor.capture(), eventCaptor.capture());
 
 			assertThat(savedUserCaptor.getValue().getEmail()).isEqualTo(email);
+			assertThat(savedUserCaptor.getValue().getNickname()).isEqualTo(NICKNAME);
 			assertThat(savedUserCaptor.getValue().getPassword()).isEqualTo("encoded");
 			assertThat(savedUserCaptor.getValue().getRole()).isEqualTo(UserRole.MEMBER);
 			assertThat(savedUserCaptor.getValue().isServiceTermsAgreed()).isTrue();
@@ -282,7 +285,7 @@ class AuthServiceTest {
 			// when
 			CustomException exception = assertThrows(
 				CustomException.class,
-				() -> authService.signUp(email, password, true, true, true, false, true)
+				() -> authService.signUp(email, NICKNAME, password, true, true, true, false, true)
 			);
 
 			// then
@@ -304,7 +307,7 @@ class AuthServiceTest {
 			// when
 			CustomException exception = assertThrows(
 				CustomException.class,
-				() -> authService.signUp(email, password, true, true, true, false, true)
+				() -> authService.signUp(email, NICKNAME, password, true, true, true, false, true)
 			);
 
 			// then
@@ -327,7 +330,7 @@ class AuthServiceTest {
 			// when
 			CustomException exception = assertThrows(
 				CustomException.class,
-				() -> authService.signUp(email, password, true, false, true, false, true)
+				() -> authService.signUp(email, NICKNAME, password, true, false, true, false, true)
 			);
 
 			// then

--- a/auth-server/src/test/java/com/truve/platform/auth/service/service/AuthServiceTest.java
+++ b/auth-server/src/test/java/com/truve/platform/auth/service/service/AuthServiceTest.java
@@ -240,6 +240,7 @@ class AuthServiceTest {
 
 			given(emailVerificationRepository.isVerifiedEmail(email)).willReturn(verifiedAt);
 			given(userRepository.existsByEmail(email)).willReturn(false);
+			given(userRepository.existsByNickname(NICKNAME)).willReturn(false);
 			given(passwordEncoder.encode(password)).willReturn("encoded");
 			given(userRepository.save(any(User.class))).willAnswer(invocation -> {
 				User savedUser = invocation.getArgument(0);
@@ -326,6 +327,7 @@ class AuthServiceTest {
 
 			given(emailVerificationRepository.isVerifiedEmail(email)).willReturn("1700000000000");
 			given(userRepository.existsByEmail(email)).willReturn(false);
+			given(userRepository.existsByNickname(NICKNAME)).willReturn(false);
 
 			// when
 			CustomException exception = assertThrows(
@@ -339,6 +341,49 @@ class AuthServiceTest {
 			verify(userRepository, never()).save(any(User.class));
 			verify(emailVerificationRepository, never()).deleteVerifiedEmail(anyString());
 			verify(userSignedUpEventPublisher, never()).publish(anyString(), any());
+		}
+
+		@Test
+		@DisplayName("닉네임 형식이 유효하지 않으면 예외가 발생한다.")
+		void 회원가입_실패_닉네임_형식_오류() {
+			// given
+			String email = "new@test.com";
+			String password = "plain";
+
+			given(emailVerificationRepository.isVerifiedEmail(email)).willReturn("1700000000000");
+			given(userRepository.existsByEmail(email)).willReturn(false);
+
+			// when
+			CustomException exception = assertThrows(
+				CustomException.class,
+				() -> authService.signUp(email, "a b", password, true, true, true, false, true)
+			);
+
+			// then
+			assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.INVALID_NICKNAME);
+			verify(userRepository, never()).save(any(User.class));
+		}
+
+		@Test
+		@DisplayName("이미 사용 중인 닉네임이면 예외가 발생한다.")
+		void 회원가입_실패_중복_닉네임() {
+			// given
+			String email = "new@test.com";
+			String password = "plain";
+
+			given(emailVerificationRepository.isVerifiedEmail(email)).willReturn("1700000000000");
+			given(userRepository.existsByEmail(email)).willReturn(false);
+			given(userRepository.existsByNickname(NICKNAME)).willReturn(true);
+
+			// when
+			CustomException exception = assertThrows(
+				CustomException.class,
+				() -> authService.signUp(email, NICKNAME, password, true, true, true, false, true)
+			);
+
+			// then
+			assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.ALREADY_EXISTS_NICKNAME);
+			verify(userRepository, never()).save(any(User.class));
 		}
 	}
 }

--- a/auth-server/src/test/java/com/truve/platform/auth/service/service/AuthServiceTest.java
+++ b/auth-server/src/test/java/com/truve/platform/auth/service/service/AuthServiceTest.java
@@ -246,7 +246,7 @@ class AuthServiceTest {
 			});
 
 			// when
-			authService.signUp(email, password);
+			authService.signUp(email, password, true, true, true, false, true);
 
 			// then
 			ArgumentCaptor<User> savedUserCaptor = ArgumentCaptor.forClass(User.class);
@@ -275,7 +275,10 @@ class AuthServiceTest {
 			given(emailVerificationRepository.isVerifiedEmail(email)).willReturn("");
 
 			// when
-			CustomException exception = assertThrows(CustomException.class, () -> authService.signUp(email, password));
+			CustomException exception = assertThrows(
+				CustomException.class,
+				() -> authService.signUp(email, password, true, true, true, false, true)
+			);
 
 			// then
 			assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.NOT_VERIFIED_EMAIL);
@@ -294,7 +297,10 @@ class AuthServiceTest {
 			given(userRepository.existsByEmail(email)).willReturn(true);
 
 			// when
-			CustomException exception = assertThrows(CustomException.class, () -> authService.signUp(email, password));
+			CustomException exception = assertThrows(
+				CustomException.class,
+				() -> authService.signUp(email, password, true, true, true, false, true)
+			);
 
 			// then
 			assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.ALREADY_EXISTS_EMAIL);

--- a/auth-server/src/test/java/com/truve/platform/auth/service/service/AuthServiceTest.java
+++ b/auth-server/src/test/java/com/truve/platform/auth/service/service/AuthServiceTest.java
@@ -53,7 +53,7 @@ class AuthServiceTest {
 	private AuthService authService;
 
 	private User createUser(Long id, String email, String encodedPassword) {
-		User user = User.createLocalUser(email, encodedPassword);
+		User user = User.createLocalUser(email, encodedPassword, true, true, true, false, true);
 		ReflectionTestUtils.setField(user, "id", id);
 		return user;
 	}
@@ -260,6 +260,11 @@ class AuthServiceTest {
 			assertThat(savedUserCaptor.getValue().getEmail()).isEqualTo(email);
 			assertThat(savedUserCaptor.getValue().getPassword()).isEqualTo("encoded");
 			assertThat(savedUserCaptor.getValue().getRole()).isEqualTo(UserRole.MEMBER);
+			assertThat(savedUserCaptor.getValue().isServiceTermsAgreed()).isTrue();
+			assertThat(savedUserCaptor.getValue().isElectronicFinanceTermsAgreed()).isTrue();
+			assertThat(savedUserCaptor.getValue().isPrivacyCollectionAgreed()).isTrue();
+			assertThat(savedUserCaptor.getValue().isMarketingInfoAgreed()).isFalse();
+			assertThat(savedUserCaptor.getValue().isOver14Agreed()).isTrue();
 			assertThat(savedUserCaptor.getValue().getPublicId()).isInstanceOf(UUID.class);
 			assertThat(keyCaptor.getValue()).isEqualTo(savedUserCaptor.getValue().getPublicId().toString());
 			assertThat(eventCaptor.getValue()).isInstanceOf(UserSignedUpEvent.class);

--- a/common/src/main/java/com/truve/platform/common/exception/ErrorCode.java
+++ b/common/src/main/java/com/truve/platform/common/exception/ErrorCode.java
@@ -19,6 +19,8 @@ public enum ErrorCode {
 	INVALID_REFRESH_TOKEN(HttpStatus.BAD_REQUEST, "리프레시 토큰이 올바르지 않습니다.", "A08"),
 	KAKAO_USERINFO_FAILED(HttpStatus.BAD_REQUEST, "카카오 사용자 정보를 가져오지 못했습니다.", "A09"),
 	REQUIRED_TERMS_NOT_AGREED(HttpStatus.BAD_REQUEST, "필수 약관 동의가 필요합니다.", "A10"),
+	INVALID_NICKNAME(HttpStatus.BAD_REQUEST, "유효하지 않은 닉네임입니다.", "A11"),
+	ALREADY_EXISTS_NICKNAME(HttpStatus.BAD_REQUEST, "중복된 닉네임입니다.", "A12"),
 
 	NOT_FOUND_PAYMENT(HttpStatus.BAD_REQUEST, "존재하지 않는 결제입니다.", "P01"),
 	INVALID_PAYMENT_AMOUNT(HttpStatus.BAD_REQUEST, "유효하지 않은 결제 금액입니다.", "P02"),

--- a/common/src/main/java/com/truve/platform/common/exception/ErrorCode.java
+++ b/common/src/main/java/com/truve/platform/common/exception/ErrorCode.java
@@ -18,6 +18,7 @@ public enum ErrorCode {
 	ALREADY_VERIFIED_EMAIL(HttpStatus.BAD_REQUEST, "이미 인증된 이메일입니다.", "A07"),
 	INVALID_REFRESH_TOKEN(HttpStatus.BAD_REQUEST, "리프레시 토큰이 올바르지 않습니다.", "A08"),
 	KAKAO_USERINFO_FAILED(HttpStatus.BAD_REQUEST, "카카오 사용자 정보를 가져오지 못했습니다.", "A09"),
+	REQUIRED_TERMS_NOT_AGREED(HttpStatus.BAD_REQUEST, "필수 약관 동의가 필요합니다.", "A10"),
 
 	NOT_FOUND_PAYMENT(HttpStatus.BAD_REQUEST, "존재하지 않는 결제입니다.", "P01"),
 	INVALID_PAYMENT_AMOUNT(HttpStatus.BAD_REQUEST, "유효하지 않은 결제 금액입니다.", "P02"),


### PR DESCRIPTION
## 변경 사항
추가/변경 사항과 사유를 작성해 주세요.

- [x] 전체 테스트 코드 성공 여부

### GET /api/auth/me 구현
마이페이지 활용 내 정보 조회 입니다.

### AccountController 분리

auth 서비스 내 로그인 필요한 기능들은 분리진행했습니다.
컨트롤러별로 엔드포인트 나누면 api-gateway에서 필터 적용할 때 용이할 것 같은데,
엔드포인트 계속 생각해보겠습니다!

로그인 필요한 api는 auth-protected로 관리하겠습니다.

## 관련 이슈

- Notion Ticket: [#75](https://www.notion.so/32c9e3e335cc80a49412f59e8fabf238?source=copy_link)

## 참고사항 (선택)

마이페이지 쓰기 작업들은 다음 피알에서 다루겠습니다.