### PR TITLE
feat(reservation): 예매 취소 정보 조회 API 구현

### DIFF
--- a/common/src/main/java/com/truve/platform/common/exception/ErrorCode.java
+++ b/common/src/main/java/com/truve/platform/common/exception/ErrorCode.java
@@ -49,6 +49,7 @@ public enum ErrorCode {
 	INVALID_HOLD_SEAT(HttpStatus.BAD_REQUEST, "타인이 점유한 좌석입니다.", "T11"),
 
 	INVALID_RESERVATION_STATUS(HttpStatus.BAD_REQUEST, "유효하지 않은 예약 상태입니다.", "B01"),
+	CANCEL_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "관람일 당일에는 취소가 불가능합니다.", "B02"),
 
 	NOT_FOUND_SHOW(HttpStatus.NOT_FOUND, "존재하지 않는 공연입니다.", "M01"),
 	NOT_FOUND_ARTIST(HttpStatus.NOT_FOUND, "존재하지 않는 배우입니다.", "M02"),

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/controller/BookingController.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/controller/BookingController.java
@@ -74,4 +74,15 @@ public class BookingController {
 		bookingService.paymentReady(reservationNumber, request);
 		return ApiResult.ok();
 	}
+
+	@Operation(summary = "예매 취소 정보 조회",
+		description = "전체 티켓 정보와 선택된 티켓의 취소 수수료를 조회합니다. "
+			+ "선택된 티켓이 없을 경우, ticketIds를 null로 요청하면 전체 취소 수수료를 조회합니다.")
+	@GetMapping("/{reservation_number}/cancel")
+	public ApiResult<BookingResponse.Cancel> getCancel(
+		@PathVariable("reservation_number") String reservationNumber,
+		@RequestParam(required = false) List<Long> ticketIds
+	) {
+		return ApiResult.ok(bookingService.getCancel(reservationNumber, ticketIds));
+	}
 }

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/domain/entity/Reservation.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/domain/entity/Reservation.java
@@ -202,11 +202,15 @@ public class Reservation extends BaseEntity {
 	}
 
 	public Long calculateRefundAmount(LocalDateTime canceledAt) {
-		return this.totalAmount - serviceFee - calculateCancelFee(canceledAt);
+		boolean isBookedDay = bookedAt.toLocalDate().isEqual(canceledAt.toLocalDate());
+		return this.totalAmount - (isBookedDay ? 0L : serviceFee) - calculateCancelFee(canceledAt);
 	}
 
 	public Long calculateRefundAmount(LocalDateTime canceledAt, List<Long> ticketIds) {
-		return getTicketAmount(ticketIds) - calculateCancelFee(canceledAt, ticketIds);
+		boolean isBookedDay = bookedAt.toLocalDate().isEqual(canceledAt.toLocalDate());
+		return getTicketAmount(ticketIds)
+			+ (isBookedDay ? TICKET_SERVICE_FEE * ticketIds.size() : 0L)
+			- calculateCancelFee(canceledAt, ticketIds);
 	}
 
 	private List<Ticket> getTicketsByIds(List<Long> ticketIds) {

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/domain/entity/Reservation.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/domain/entity/Reservation.java
@@ -9,6 +9,7 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 
 import org.truve.platform.ticketing.service.booking.domain.constant.ReservationStatus;
+import org.truve.platform.ticketing.service.booking.domain.policy.CancellationPolicy;
 
 import com.truve.platform.common.support.BaseEntity;
 
@@ -190,5 +191,29 @@ public class Reservation extends BaseEntity {
 		if (isWaitingDeposit())
 			return virtualAccount.getDueDate();
 		return null;
+	}
+
+	public Long calculateCancelFee(LocalDateTime canceledAt) {
+		return CancellationPolicy.calculate(this, canceledAt);
+	}
+
+	public Long calculateCancelFee(LocalDateTime canceledAt, List<Long> ticketIds) {
+		return CancellationPolicy.calculate(this, getTicketsByIds(ticketIds), canceledAt);
+	}
+
+	public Long calculateRefundAmount(LocalDateTime canceledAt) {
+		return this.totalAmount - serviceFee - calculateCancelFee(canceledAt);
+	}
+
+	public Long calculateRefundAmount(LocalDateTime canceledAt, List<Long> ticketIds) {
+		return getTicketAmount(ticketIds) - calculateCancelFee(canceledAt, ticketIds);
+	}
+
+	private List<Ticket> getTicketsByIds(List<Long> ticketIds) {
+		return tickets.stream().filter(t -> ticketIds.contains(t.getId())).toList();
+	}
+
+	private Long getTicketAmount(List<Long> ticketIds) {
+		return getTicketsByIds(ticketIds).stream().mapToLong(Ticket::getPriceSnapshot).sum();
 	}
 }

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/domain/entity/Reservation.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/domain/entity/Reservation.java
@@ -208,8 +208,7 @@ public class Reservation extends BaseEntity {
 
 	public Long calculateRefundAmount(LocalDateTime canceledAt, List<Long> ticketIds) {
 		boolean isBookedDay = bookedAt.toLocalDate().isEqual(canceledAt.toLocalDate());
-		return getTicketAmount(ticketIds)
-			+ (isBookedDay ? TICKET_SERVICE_FEE * ticketIds.size() : 0L)
+		return (isBookedDay ? getTicketTotalAmount(ticketIds) : getTicketAmount(ticketIds))
 			- calculateCancelFee(canceledAt, ticketIds);
 	}
 
@@ -219,5 +218,9 @@ public class Reservation extends BaseEntity {
 
 	private Long getTicketAmount(List<Long> ticketIds) {
 		return getTicketsByIds(ticketIds).stream().mapToLong(Ticket::getPriceSnapshot).sum();
+	}
+
+	public Long getTicketTotalAmount(List<Long> ticketIds) {
+		return getTicketAmount(ticketIds) + TICKET_SERVICE_FEE * ticketIds.size();
 	}
 }

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/domain/entity/Reservation.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/domain/entity/Reservation.java
@@ -45,7 +45,7 @@ public class Reservation extends BaseEntity {
 	private Long serviceFee;
 
 	@Column(nullable = false)
-	private Long refundFee;
+	private Long cancelFee;
 
 	@Column(nullable = false)
 	private String gradeSummary;
@@ -86,7 +86,7 @@ public class Reservation extends BaseEntity {
 		this.number = number;
 		this.totalAmount = 0L;
 		this.serviceFee = 0L;
-		this.refundFee = 0L;
+		this.cancelFee = 0L;
 		this.gradeSummary = gradeSummary;
 		this.showInfo = showInfo;
 		this.status = ReservationStatus.CREATED;
@@ -181,7 +181,7 @@ public class Reservation extends BaseEntity {
 
 	public Long getRefundAmount() {
 		Long canceledTicketPrice = getCancelTickets().stream().mapToLong(Ticket::getPriceSnapshot).sum();
-		return canceledTicketPrice - refundFee;
+		return canceledTicketPrice - cancelFee;
 	}
 
 	public LocalDateTime getDeadline() {

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/domain/entity/Reservation.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/domain/entity/Reservation.java
@@ -193,17 +193,8 @@ public class Reservation extends BaseEntity {
 		return null;
 	}
 
-	public Long calculateCancelFee(LocalDateTime canceledAt) {
-		return CancellationPolicy.calculate(this, canceledAt);
-	}
-
 	public Long calculateCancelFee(LocalDateTime canceledAt, List<Long> ticketIds) {
 		return CancellationPolicy.calculate(this, getTicketsByIds(ticketIds), canceledAt);
-	}
-
-	public Long calculateRefundAmount(LocalDateTime canceledAt) {
-		boolean isBookedDay = bookedAt.toLocalDate().isEqual(canceledAt.toLocalDate());
-		return this.totalAmount - (isBookedDay ? 0L : serviceFee) - calculateCancelFee(canceledAt);
 	}
 
 	public Long calculateRefundAmount(LocalDateTime canceledAt, List<Long> ticketIds) {

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/domain/policy/CancellationPolicy.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/domain/policy/CancellationPolicy.java
@@ -1,0 +1,53 @@
+package org.truve.platform.ticketing.service.booking.domain.policy;
+
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+
+import org.truve.platform.ticketing.service.booking.domain.entity.Reservation;
+
+import com.truve.platform.common.exception.ErrorCode;
+import com.truve.platform.common.support.Preconditions;
+
+public class CancellationPolicy {
+
+	public static Long calculate(Reservation reservation, LocalDateTime cancelAt) {
+		LocalDateTime showAt = reservation.getShowInfo().getStartAt();
+		long daysUntilShow = ChronoUnit.DAYS.between(cancelAt.toLocalDate(), showAt.toLocalDate());
+		long daysSinceBooked = ChronoUnit.DAYS.between(reservation.getBookedAt().toLocalDate(), cancelAt.toLocalDate());
+		boolean isBookedDay = cancelAt.toLocalDate().equals(reservation.getBookedAt().toLocalDate());
+
+		Preconditions.validate(daysUntilShow > 0, ErrorCode.CANCEL_NOT_ALLOWED);
+
+		if (isFreeCancelPeriod(isBookedDay, daysUntilShow, daysSinceBooked))
+			return 0L;
+
+		if (daysUntilShow <= 9)
+			return calculatePercentFee(reservation, daysUntilShow);
+
+		return calculateFlatFee(reservation);
+	}
+
+	private static boolean isFreeCancelPeriod(boolean isBookedDay, long daysUntilShow, long daysSinceBooked) {
+		return isBookedDay || (daysSinceBooked <= 7 && daysUntilShow > 9);
+	}
+
+	private static Long calculatePercentFee(Reservation reservation, long daysUntilShow) {
+		if (daysUntilShow <= 1)
+			return applyPercent(reservation, 30);
+		if (daysUntilShow <= 3)
+			return applyPercent(reservation, 20);
+		return applyPercent(reservation, 10);
+	}
+
+	private static Long calculateFlatFee(Reservation reservation) {
+		long flatFee = (long)reservation.getTickets().size() * 4000L;
+		long maxFee = applyPercent(reservation, 10);
+		return Math.min(flatFee, maxFee);
+	}
+
+	private static Long applyPercent(Reservation reservation, int percent) {
+		return reservation.getTickets().stream()
+			.mapToLong(t -> t.getPriceSnapshot() * percent / 100)
+			.sum();
+	}
+}

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/domain/policy/CancellationPolicy.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/domain/policy/CancellationPolicy.java
@@ -2,8 +2,10 @@ package org.truve.platform.ticketing.service.booking.domain.policy;
 
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
+import java.util.List;
 
 import org.truve.platform.ticketing.service.booking.domain.entity.Reservation;
+import org.truve.platform.ticketing.service.booking.domain.entity.Ticket;
 
 import com.truve.platform.common.exception.ErrorCode;
 import com.truve.platform.common.support.Preconditions;
@@ -11,6 +13,10 @@ import com.truve.platform.common.support.Preconditions;
 public class CancellationPolicy {
 
 	public static Long calculate(Reservation reservation, LocalDateTime cancelAt) {
+		return calculate(reservation, reservation.getTickets(), cancelAt);
+	}
+
+	public static Long calculate(Reservation reservation, List<Ticket> tickets, LocalDateTime cancelAt) {
 		LocalDateTime showAt = reservation.getShowInfo().getStartAt();
 		long daysUntilShow = ChronoUnit.DAYS.between(cancelAt.toLocalDate(), showAt.toLocalDate());
 		long daysSinceBooked = ChronoUnit.DAYS.between(reservation.getBookedAt().toLocalDate(), cancelAt.toLocalDate());
@@ -22,31 +28,31 @@ public class CancellationPolicy {
 			return 0L;
 
 		if (daysUntilShow <= 9)
-			return calculatePercentFee(reservation, daysUntilShow);
+			return calculatePercentFee(tickets, daysUntilShow);
 
-		return calculateFlatFee(reservation);
+		return calculateFlatFee(tickets);
 	}
 
 	private static boolean isFreeCancelPeriod(boolean isBookedDay, long daysUntilShow, long daysSinceBooked) {
 		return isBookedDay || (daysSinceBooked <= 7 && daysUntilShow > 9);
 	}
 
-	private static Long calculatePercentFee(Reservation reservation, long daysUntilShow) {
+	private static Long calculatePercentFee(List<Ticket> tickets, long daysUntilShow) {
 		if (daysUntilShow <= 1)
-			return applyPercent(reservation, 30);
+			return applyPercent(tickets, 30);
 		if (daysUntilShow <= 3)
-			return applyPercent(reservation, 20);
-		return applyPercent(reservation, 10);
+			return applyPercent(tickets, 20);
+		return applyPercent(tickets, 10);
 	}
 
-	private static Long calculateFlatFee(Reservation reservation) {
-		long flatFee = (long)reservation.getTickets().size() * 4000L;
-		long maxFee = applyPercent(reservation, 10);
+	private static Long calculateFlatFee(List<Ticket> tickets) {
+		long flatFee = (long)tickets.size() * 4000L;
+		long maxFee = applyPercent(tickets, 10);
 		return Math.min(flatFee, maxFee);
 	}
 
-	private static Long applyPercent(Reservation reservation, int percent) {
-		return reservation.getTickets().stream()
+	private static Long applyPercent(List<Ticket> tickets, int percent) {
+		return tickets.stream()
 			.mapToLong(t -> t.getPriceSnapshot() * percent / 100)
 			.sum();
 	}

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/dto/BookingDetail.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/dto/BookingDetail.java
@@ -1,0 +1,199 @@
+package org.truve.platform.ticketing.service.booking.dto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.truve.platform.ticketing.service.booking.domain.entity.Reservation;
+import org.truve.platform.ticketing.service.booking.domain.entity.ShowInfo;
+import org.truve.platform.ticketing.service.booking.domain.entity.Ticket;
+import org.truve.platform.ticketing.service.booking.util.DateTimeUtil;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+public class BookingDetail {
+	@Getter
+	@AllArgsConstructor
+	@Builder
+	public static class Show {
+		private final String posterUrl;
+		private final String title;
+		private final String showDate;
+		private final String showTime;
+		private final String venueName;
+
+		public static Show from(ShowInfo showInfo) {
+			return Show.builder()
+				.posterUrl(showInfo.getPosterImg())
+				.title(showInfo.getTitle())
+				.showDate(DateTimeUtil.formatDate(showInfo.getStartAt(), "yyyy.MM.dd(E)"))
+				.showTime(DateTimeUtil.formatDate(showInfo.getStartAt(), "a h:mm"))
+				.venueName(showInfo.getVenueName())
+				.build();
+		}
+	}
+
+	@Getter
+	@AllArgsConstructor
+	@Builder
+	public static class Status {
+		private final String label;
+		private final String subText;
+
+		public static Status from(Reservation reservation) {
+			return Status.builder()
+				.label(reservation.getStatus().getDescription())
+				.subText(getSubText(reservation))
+				.build();
+		}
+
+		private static String getSubText(Reservation reservation) {
+			LocalDateTime deadline = reservation.getDeadline();
+			if (deadline == null)
+				return null;
+
+			if (reservation.isWaitingDeposit())
+				return DateTimeUtil.formatDuration(LocalDateTime.now(), deadline, "입금 마감 ", "전");
+			else
+				return DateTimeUtil.formatDuration(LocalDateTime.now(), deadline, "입장까지 ", "남음");
+		}
+	}
+
+	@Getter
+	@AllArgsConstructor
+	@Builder
+	public static class Price {
+		private final List<Long> ticketUnitPrices;
+		private final Long serviceFee;
+		private final Long totalPrice;
+		private final List<GradePrice> gradePrices;
+
+		public static Price from(Reservation reservation) {
+			return Price.builder()
+				.ticketUnitPrices(reservation.getTicketPrices())
+				.serviceFee(reservation.getServiceFee())
+				.totalPrice(reservation.getTotalAmount())
+				.gradePrices(getGradePrices(reservation))
+				.build();
+		}
+
+		private static List<GradePrice> getGradePrices(Reservation reservation) {
+			return reservation.getTicketsGroupedByGrade()
+				.entrySet().stream()
+				.map(entry -> GradePrice.from(entry.getKey(), entry.getValue()))
+				.toList();
+		}
+
+		@Getter
+		@AllArgsConstructor
+		@Builder
+		private static class GradePrice {
+			private final String grade;
+			private final int count;
+			private final Long totalPrice;
+
+			private static GradePrice from(String grade, List<Ticket> tickets) {
+				return GradePrice.builder()
+					.grade(grade)
+					.count(tickets.size())
+					.totalPrice(tickets.stream().mapToLong(Ticket::getPriceSnapshot).sum())
+					.build();
+			}
+		}
+	}
+
+	@Getter
+	@AllArgsConstructor
+	@Builder
+	public static class Payment {
+		private final String paymentMethod;
+		private final String paidAt;
+		private final VirtualAccount virtualAccount;
+
+		public static Payment from(Reservation reservation) {
+			return Payment.builder()
+				.paymentMethod(reservation.getPaymentMethod())
+				.paidAt(reservation.getPaidAt() == null ? null :
+					DateTimeUtil.formatDate(reservation.getPaidAt(), "yyyy.MM.dd(E) HH:mm:ss"))
+				.virtualAccount(VirtualAccount.from(reservation))
+				.build();
+		}
+
+		@Getter
+		@AllArgsConstructor
+		@Builder
+		public static class VirtualAccount {
+			private final String accountNumber;
+			private final String bank;
+			private final String customerName;
+			private final String dueDate;
+
+			public static VirtualAccount from(Reservation reservation) {
+				if (reservation.getVirtualAccount() == null)
+					return null;
+
+				org.truve.platform.ticketing.service.booking.domain.entity.VirtualAccount virtualAccount = reservation.getVirtualAccount();
+
+				return VirtualAccount.builder()
+					.accountNumber(virtualAccount.getAccountNumber())
+					.bank(virtualAccount.getBank())
+					.customerName(virtualAccount.getCustomerName())
+					.dueDate(DateTimeUtil.formatDate(virtualAccount.getDueDate(), "yyyy.MM.dd(E) HH:mm까지"))
+					.build();
+			}
+		}
+	}
+
+	@Getter
+	@AllArgsConstructor
+	@Builder
+	public static class Cancel {
+		private final List<String> seats;
+		private final Long cancelFee;
+		private final Long refundAmount;
+		private final String canceledAt;
+		private final String method;
+
+		public static Cancel from(Reservation reservation) {
+			if (!reservation.isCanceled())
+				return null;
+
+			return Cancel.builder()
+				.seats(reservation.getCanceledSeatDetails())
+				.cancelFee(reservation.getCancelFee())
+				.refundAmount(reservation.getRefundAmount())
+				.canceledAt(DateTimeUtil.formatDate(reservation.getCanceledAt(), "yyyy.MM.dd(E) HH:mm:ss"))
+				.method(reservation.getPaymentMethod())
+				.build();
+		}
+	}
+
+	@Getter
+	@AllArgsConstructor
+	@Builder
+	public static class RefundInfo {
+		private final String method;
+		private final Long paidAmount;
+		private final Long cancelFee;
+		private final Long refundAmount;
+
+		public static RefundInfo from(Reservation reservation, LocalDateTime canceledAt) {
+			return RefundInfo.builder()
+				.method(reservation.getPaymentMethod())
+				.paidAmount(reservation.getTotalAmount())
+				.cancelFee(reservation.calculateCancelFee(canceledAt))
+				.refundAmount(reservation.calculateRefundAmount(canceledAt))
+				.build();
+		}
+
+		public static RefundInfo from(Reservation reservation, List<Long> ticketIds, LocalDateTime canceledAt) {
+			return RefundInfo.builder()
+				.method(reservation.getPaymentMethod())
+				.paidAmount(reservation.getTicketTotalAmount(ticketIds))
+				.cancelFee(reservation.calculateCancelFee(canceledAt, ticketIds))
+				.refundAmount(reservation.calculateRefundAmount(canceledAt, ticketIds))
+				.build();
+		}
+	}
+}

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/dto/BookingDetail.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/dto/BookingDetail.java
@@ -178,15 +178,6 @@ public class BookingDetail {
 		private final Long cancelFee;
 		private final Long refundAmount;
 
-		public static RefundInfo from(Reservation reservation, LocalDateTime canceledAt) {
-			return RefundInfo.builder()
-				.method(reservation.getPaymentMethod())
-				.paidAmount(reservation.getTotalAmount())
-				.cancelFee(reservation.calculateCancelFee(canceledAt))
-				.refundAmount(reservation.calculateRefundAmount(canceledAt))
-				.build();
-		}
-
 		public static RefundInfo from(Reservation reservation, List<Long> ticketIds, LocalDateTime canceledAt) {
 			return RefundInfo.builder()
 				.method(reservation.getPaymentMethod())

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/dto/BookingResponse.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/dto/BookingResponse.java
@@ -331,12 +331,14 @@ public class BookingResponse {
 		@Builder
 		private static class RefundInfo {
 			private final String method;
+			private final Long paidAmount;
 			private final Long cancelFee;
 			private final Long refundAmount;
 
 			private static RefundInfo from(Reservation reservation, LocalDateTime canceledAt) {
 				return RefundInfo.builder()
 					.method(reservation.getPaymentMethod())
+					.paidAmount(reservation.getTotalAmount())
 					.cancelFee(reservation.calculateCancelFee(canceledAt))
 					.refundAmount(reservation.calculateRefundAmount(canceledAt))
 					.build();
@@ -345,6 +347,7 @@ public class BookingResponse {
 			private static RefundInfo from(Reservation reservation, List<Long> ticketIds, LocalDateTime canceledAt) {
 				return RefundInfo.builder()
 					.method(reservation.getPaymentMethod())
+					.paidAmount(reservation.getTicketTotalAmount(ticketIds))
 					.cancelFee(reservation.calculateCancelFee(canceledAt, ticketIds))
 					.refundAmount(reservation.calculateRefundAmount(canceledAt, ticketIds))
 					.build();

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/dto/BookingResponse.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/dto/BookingResponse.java
@@ -330,11 +330,13 @@ public class BookingResponse {
 		@AllArgsConstructor
 		@Builder
 		private static class RefundInfo {
+			private final String method;
 			private final Long cancelFee;
 			private final Long refundAmount;
 
 			private static RefundInfo from(Reservation reservation, LocalDateTime canceledAt) {
 				return RefundInfo.builder()
+					.method(reservation.getPaymentMethod())
 					.cancelFee(reservation.calculateCancelFee(canceledAt))
 					.refundAmount(reservation.calculateRefundAmount(canceledAt))
 					.build();
@@ -342,6 +344,7 @@ public class BookingResponse {
 
 			private static RefundInfo from(Reservation reservation, List<Long> ticketIds, LocalDateTime canceledAt) {
 				return RefundInfo.builder()
+					.method(reservation.getPaymentMethod())
 					.cancelFee(reservation.calculateCancelFee(canceledAt, ticketIds))
 					.refundAmount(reservation.calculateRefundAmount(canceledAt, ticketIds))
 					.build();

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/dto/BookingResponse.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/dto/BookingResponse.java
@@ -25,15 +25,15 @@ public class BookingResponse {
 	@Builder
 	public static class Order {
 		private final String reservationNumber;
-		private final Detail.Show show;
-		private final Detail.Price price;
+		private final BookingDetail.Show show;
+		private final BookingDetail.Price price;
 		private final List<GradeSeat> gradeSeats;
 
 		public static Order from(Reservation reservation) {
 			return Order.builder()
 				.reservationNumber(reservation.getNumber())
-				.show(Detail.Show.from(reservation.getShowInfo()))
-				.price(Detail.Price.from(reservation))
+				.show(BookingDetail.Show.from(reservation.getShowInfo()))
+				.price(BookingDetail.Price.from(reservation))
 				.gradeSeats(getGradeSeats(reservation))
 				.build();
 		}
@@ -71,8 +71,8 @@ public class BookingResponse {
 	public static class Summary {
 		private final String reservationNumber;
 		private final String reservationDate;
-		private final Detail.Status status;
-		private final Detail.Show show;
+		private final BookingDetail.Status status;
+		private final BookingDetail.Show show;
 		private final String gradeSummary;
 		private final Long showId;
 		private final boolean canCancel;
@@ -83,8 +83,8 @@ public class BookingResponse {
 			return Summary.builder()
 				.reservationNumber(reservation.getNumber())
 				.reservationDate(DateTimeUtil.formatDate(reservation.getBookedAt(), "yyyy.MM.dd"))
-				.status(Detail.Status.from(reservation))
-				.show(Detail.Show.from(reservation.getShowInfo()))
+				.status(BookingDetail.Status.from(reservation))
+				.show(BookingDetail.Show.from(reservation.getShowInfo()))
 				.gradeSummary(reservation.getGradeSummary())
 				.showId(reservation.getShowInfo().getShowId())
 				.canCancel(reservation.isCancelable())
@@ -99,22 +99,22 @@ public class BookingResponse {
 	@Builder
 	public static class ReservationDetail {
 		private final String reservationNumber;
-		private final Detail.Status status;
-		private final Detail.Show show;
+		private final BookingDetail.Status status;
+		private final BookingDetail.Show show;
 		private final String gradeSummary;
-		private final Detail.Price price;
-		private final Detail.Payment payment;
-		private final Detail.Cancel cancel;
+		private final BookingDetail.Price price;
+		private final BookingDetail.Payment payment;
+		private final BookingDetail.Cancel cancel;
 
 		public static ReservationDetail from(Reservation reservation) {
 			return ReservationDetail.builder()
 				.reservationNumber(reservation.getNumber())
-				.status(Detail.Status.from(reservation))
-				.show(Detail.Show.from(reservation.getShowInfo()))
+				.status(BookingDetail.Status.from(reservation))
+				.show(BookingDetail.Show.from(reservation.getShowInfo()))
 				.gradeSummary(reservation.getGradeSummary())
-				.price(Detail.Price.from(reservation))
-				.payment(Detail.Payment.from(reservation))
-				.cancel(Detail.Cancel.from(reservation))
+				.price(BookingDetail.Price.from(reservation))
+				.payment(BookingDetail.Payment.from(reservation))
+				.cancel(BookingDetail.Cancel.from(reservation))
 				.build();
 		}
 	}
@@ -123,17 +123,17 @@ public class BookingResponse {
 	@AllArgsConstructor
 	@Builder
 	public static class Cancel {
-		private final Detail.RefundInfo refundInfo;
+		private final BookingDetail.RefundInfo refundInfo;
 		private final List<TicketInfo> tickets;
 
 		public static Cancel from(Reservation reservation, List<Long> ticketIds, LocalDateTime canceledAt) {
-			Detail.RefundInfo refundInfo = ticketIds == null
-				? Detail.RefundInfo.from(reservation, canceledAt)
-				: Detail.RefundInfo.from(reservation, ticketIds, canceledAt);
+			BookingDetail.RefundInfo refundInfo = ticketIds == null
+				? BookingDetail.RefundInfo.from(reservation, canceledAt)
+				: BookingDetail.RefundInfo.from(reservation, ticketIds, canceledAt);
 			return build(reservation, refundInfo);
 		}
 
-		private static Cancel build(Reservation reservation, Detail.RefundInfo refundInfo) {
+		private static Cancel build(Reservation reservation, BookingDetail.RefundInfo refundInfo) {
 			String title = formatTitle(reservation.getShowInfo());
 			return Cancel.builder()
 				.refundInfo(refundInfo)
@@ -163,193 +163,6 @@ public class BookingResponse {
 					.ticketId(ticket.getId())
 					.title(title)
 					.seatDetail(ticket.getSeatDetail())
-					.build();
-			}
-		}
-	}
-
-	private static class Detail {
-
-		@Getter
-		@AllArgsConstructor
-		@Builder
-		private static class Show {
-			private final String posterUrl;
-			private final String title;
-			private final String showDate;
-			private final String showTime;
-			private final String venueName;
-
-			private static Show from(ShowInfo showInfo) {
-				return Show.builder()
-					.posterUrl(showInfo.getPosterImg())
-					.title(showInfo.getTitle())
-					.showDate(DateTimeUtil.formatDate(showInfo.getStartAt(), "yyyy.MM.dd(E)"))
-					.showTime(DateTimeUtil.formatDate(showInfo.getStartAt(), "a h:mm"))
-					.venueName(showInfo.getVenueName())
-					.build();
-			}
-		}
-
-		@Getter
-		@AllArgsConstructor
-		@Builder
-		private static class Status {
-			private final String label;
-			private final String subText;
-
-			private static Status from(Reservation reservation) {
-				return Status.builder()
-					.label(reservation.getStatus().getDescription())
-					.subText(getSubText(reservation))
-					.build();
-			}
-
-			private static String getSubText(Reservation reservation) {
-				LocalDateTime deadline = reservation.getDeadline();
-				if (deadline == null)
-					return null;
-
-				if (reservation.isWaitingDeposit())
-					return DateTimeUtil.formatDuration(LocalDateTime.now(), deadline, "입금 마감 ", "전");
-				else
-					return DateTimeUtil.formatDuration(LocalDateTime.now(), deadline, "입장까지 ", "남음");
-			}
-		}
-
-		@Getter
-		@AllArgsConstructor
-		@Builder
-		private static class Price {
-			private final List<Long> ticketUnitPrices;
-			private final Long serviceFee;
-			private final Long totalPrice;
-			private final List<GradePrice> gradePrices;
-
-			private static Price from(Reservation reservation) {
-				return Price.builder()
-					.ticketUnitPrices(reservation.getTicketPrices())
-					.serviceFee(reservation.getServiceFee())
-					.totalPrice(reservation.getTotalAmount())
-					.gradePrices(getGradePrices(reservation))
-					.build();
-			}
-
-			private static List<GradePrice> getGradePrices(Reservation reservation) {
-				return reservation.getTicketsGroupedByGrade()
-					.entrySet().stream()
-					.map(entry -> GradePrice.from(entry.getKey(), entry.getValue()))
-					.toList();
-			}
-
-			@Getter
-			@AllArgsConstructor
-			@Builder
-			private static class GradePrice {
-				private final String grade;
-				private final int count;
-				private final Long totalPrice;
-
-				private static GradePrice from(String grade, List<Ticket> tickets) {
-					return GradePrice.builder()
-						.grade(grade)
-						.count(tickets.size())
-						.totalPrice(tickets.stream().mapToLong(Ticket::getPriceSnapshot).sum())
-						.build();
-				}
-			}
-		}
-
-		@Getter
-		@AllArgsConstructor
-		@Builder
-		private static class Payment {
-			private final String paymentMethod;
-			private final String paidAt;
-			private final VirtualAccount virtualAccount;
-
-			private static Payment from(Reservation reservation) {
-				return Payment.builder()
-					.paymentMethod(reservation.getPaymentMethod())
-					.paidAt(reservation.getPaidAt() == null ? null :
-						DateTimeUtil.formatDate(reservation.getPaidAt(), "yyyy.MM.dd(E) HH:mm:ss"))
-					.virtualAccount(VirtualAccount.from(reservation))
-					.build();
-			}
-
-			@Getter
-			@AllArgsConstructor
-			@Builder
-			private static class VirtualAccount {
-				private final String accountNumber;
-				private final String bank;
-				private final String customerName;
-				private final String dueDate;
-
-				private static VirtualAccount from(Reservation reservation) {
-					if (reservation.getVirtualAccount() == null)
-						return null;
-
-					org.truve.platform.ticketing.service.booking.domain.entity.VirtualAccount virtualAccount = reservation.getVirtualAccount();
-
-					return VirtualAccount.builder()
-						.accountNumber(virtualAccount.getAccountNumber())
-						.bank(virtualAccount.getBank())
-						.customerName(virtualAccount.getCustomerName())
-						.dueDate(DateTimeUtil.formatDate(virtualAccount.getDueDate(), "yyyy.MM.dd(E) HH:mm까지"))
-						.build();
-				}
-			}
-		}
-
-		@Getter
-		@AllArgsConstructor
-		@Builder
-		private static class Cancel {
-			private final List<String> seats;
-			private final Long cancelFee;
-			private final Long refundAmount;
-			private final String canceledAt;
-			private final String method;
-
-			private static Cancel from(Reservation reservation) {
-				if (!reservation.isCanceled())
-					return null;
-
-				return Cancel.builder()
-					.seats(reservation.getCanceledSeatDetails())
-					.cancelFee(reservation.getCancelFee())
-					.refundAmount(reservation.getRefundAmount())
-					.canceledAt(DateTimeUtil.formatDate(reservation.getCanceledAt(), "yyyy.MM.dd(E) HH:mm:ss"))
-					.method(reservation.getPaymentMethod())
-					.build();
-			}
-		}
-
-		@Getter
-		@AllArgsConstructor
-		@Builder
-		private static class RefundInfo {
-			private final String method;
-			private final Long paidAmount;
-			private final Long cancelFee;
-			private final Long refundAmount;
-
-			private static RefundInfo from(Reservation reservation, LocalDateTime canceledAt) {
-				return RefundInfo.builder()
-					.method(reservation.getPaymentMethod())
-					.paidAmount(reservation.getTotalAmount())
-					.cancelFee(reservation.calculateCancelFee(canceledAt))
-					.refundAmount(reservation.calculateRefundAmount(canceledAt))
-					.build();
-			}
-
-			private static RefundInfo from(Reservation reservation, List<Long> ticketIds, LocalDateTime canceledAt) {
-				return RefundInfo.builder()
-					.method(reservation.getPaymentMethod())
-					.paidAmount(reservation.getTicketTotalAmount(ticketIds))
-					.cancelFee(reservation.calculateCancelFee(canceledAt, ticketIds))
-					.refundAmount(reservation.calculateRefundAmount(canceledAt, ticketIds))
 					.build();
 			}
 		}

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/dto/BookingResponse.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/dto/BookingResponse.java
@@ -119,6 +119,55 @@ public class BookingResponse {
 		}
 	}
 
+	@Getter
+	@AllArgsConstructor
+	@Builder
+	public static class Cancel {
+		private final Detail.RefundInfo refundInfo;
+		private final List<TicketInfo> tickets;
+
+		public static Cancel from(Reservation reservation, List<Long> ticketIds, LocalDateTime canceledAt) {
+			Detail.RefundInfo refundInfo = ticketIds == null
+				? Detail.RefundInfo.from(reservation, canceledAt)
+				: Detail.RefundInfo.from(reservation, ticketIds, canceledAt);
+			return build(reservation, refundInfo);
+		}
+
+		private static Cancel build(Reservation reservation, Detail.RefundInfo refundInfo) {
+			String title = formatTitle(reservation.getShowInfo());
+			return Cancel.builder()
+				.refundInfo(refundInfo)
+				.tickets(getTicketInfos(reservation.getTickets(), title))
+				.build();
+		}
+
+		private static String formatTitle(ShowInfo showInfo) {
+			String date = DateTimeUtil.formatDate(showInfo.getStartAt(), "yyyy.MM.dd.(E)");
+			return showInfo.getTitle() + " " + date;
+		}
+
+		private static List<TicketInfo> getTicketInfos(List<Ticket> tickets, String title) {
+			return tickets.stream().map(t -> TicketInfo.from(t, title)).toList();
+		}
+
+		@Getter
+		@AllArgsConstructor
+		@Builder
+		private static class TicketInfo {
+			private final Long ticketId;
+			private final String title;
+			private final String seatDetail;
+
+			public static TicketInfo from(Ticket ticket, String title) {
+				return TicketInfo.builder()
+					.ticketId(ticket.getId())
+					.title(title)
+					.seatDetail(ticket.getSeatDetail())
+					.build();
+			}
+		}
+	}
+
 	private static class Detail {
 
 		@Getter
@@ -273,6 +322,28 @@ public class BookingResponse {
 					.refundAmount(reservation.getRefundAmount())
 					.canceledAt(DateTimeUtil.formatDate(reservation.getCanceledAt(), "yyyy.MM.dd(E) HH:mm:ss"))
 					.method(reservation.getPaymentMethod())
+					.build();
+			}
+		}
+
+		@Getter
+		@AllArgsConstructor
+		@Builder
+		private static class RefundInfo {
+			private final Long cancelFee;
+			private final Long refundAmount;
+
+			private static RefundInfo from(Reservation reservation, LocalDateTime canceledAt) {
+				return RefundInfo.builder()
+					.cancelFee(reservation.calculateCancelFee(canceledAt))
+					.refundAmount(reservation.calculateRefundAmount(canceledAt))
+					.build();
+			}
+
+			private static RefundInfo from(Reservation reservation, List<Long> ticketIds, LocalDateTime canceledAt) {
+				return RefundInfo.builder()
+					.cancelFee(reservation.calculateCancelFee(canceledAt, ticketIds))
+					.refundAmount(reservation.calculateRefundAmount(canceledAt, ticketIds))
 					.build();
 			}
 		}

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/dto/BookingResponse.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/dto/BookingResponse.java
@@ -127,16 +127,9 @@ public class BookingResponse {
 		private final List<TicketInfo> tickets;
 
 		public static Cancel from(Reservation reservation, List<Long> ticketIds, LocalDateTime canceledAt) {
-			BookingDetail.RefundInfo refundInfo = ticketIds == null
-				? BookingDetail.RefundInfo.from(reservation, canceledAt)
-				: BookingDetail.RefundInfo.from(reservation, ticketIds, canceledAt);
-			return build(reservation, refundInfo);
-		}
-
-		private static Cancel build(Reservation reservation, BookingDetail.RefundInfo refundInfo) {
 			String title = formatTitle(reservation.getShowInfo());
 			return Cancel.builder()
-				.refundInfo(refundInfo)
+				.refundInfo(BookingDetail.RefundInfo.from(reservation, ticketIds, canceledAt))
 				.tickets(getTicketInfos(reservation.getTickets(), title))
 				.build();
 		}

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/dto/BookingResponse.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/dto/BookingResponse.java
@@ -258,7 +258,7 @@ public class BookingResponse {
 		@Builder
 		private static class Cancel {
 			private final List<String> seats;
-			private final Long refundFee;
+			private final Long cancelFee;
 			private final Long refundAmount;
 			private final String canceledAt;
 			private final String method;
@@ -269,7 +269,7 @@ public class BookingResponse {
 
 				return Cancel.builder()
 					.seats(reservation.getCanceledSeatDetails())
-					.refundFee(reservation.getRefundFee())
+					.cancelFee(reservation.getCancelFee())
 					.refundAmount(reservation.getRefundAmount())
 					.canceledAt(DateTimeUtil.formatDate(reservation.getCanceledAt(), "yyyy.MM.dd(E) HH:mm:ss"))
 					.method(reservation.getPaymentMethod())

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/service/BookingService.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/service/BookingService.java
@@ -152,6 +152,10 @@ public class BookingService {
 	@Transactional
 	public BookingResponse.Cancel getCancel(String reservationNumber, List<Long> ticketIds) {
 		Reservation reservation = reservationRepository.findByNumber(reservationNumber);
-		return BookingResponse.Cancel.from(reservation, ticketIds, LocalDateTime.now());
+
+		List<Long> resolvedTicketIds = ticketIds != null ? ticketIds
+			: reservation.getTickets().stream().map(Ticket::getId).toList();
+
+		return BookingResponse.Cancel.from(reservation, resolvedTicketIds, LocalDateTime.now());
 	}
 }

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/service/BookingService.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/service/BookingService.java
@@ -148,4 +148,10 @@ public class BookingService {
 		Reservation reservation = reservationRepository.findByNumber(event.getReservationNumber());
 		reservation.depositReceive(event.getPaidAt());
 	}
+
+	@Transactional
+	public BookingResponse.Cancel getCancel(String reservationNumber, List<Long> ticketIds) {
+		Reservation reservation = reservationRepository.findByNumber(reservationNumber);
+		return BookingResponse.Cancel.from(reservation, ticketIds, LocalDateTime.now());
+	}
 }

--- a/ticketing/src/test/java/org/truve/platform/ticketing/service/booking/domain/entity/ReservationTest.java
+++ b/ticketing/src/test/java/org/truve/platform/ticketing/service/booking/domain/entity/ReservationTest.java
@@ -1,0 +1,114 @@
+package org.truve.platform.ticketing.service.booking.domain.entity;
+
+import static org.assertj.core.api.AssertionsForClassTypes.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.IntStream;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.truve.platform.ticketing.service.booking.domain.constant.ReservationStatus;
+
+public class ReservationTest {
+
+	@Test
+	@DisplayName("티켓 추가 시 총 금액은 서비스 수수료(2000*티켓 수) + 티켓 가격 총합으로 계산된다.")
+	void 티켓추가_총금액_계산() {
+		// given
+		int size = 2;
+		Reservation reservation = createReservation();
+		List<Ticket> tickets = createTickets(reservation, size);
+
+		// when
+		reservation.addTickets(tickets);
+
+		// then
+		assertAll(
+			() -> assertThat(reservation.getServiceFee()).isEqualTo(4000L),
+			() -> assertThat(reservation.getTotalAmount()).isEqualTo(24000L)
+		);
+	}
+
+	@Test
+	@DisplayName("무통장 입금 외 결제를 승인하면 상태가 CONFIRMED로 변경된다.")
+	void 결제승인_일반() {
+		// given
+		Reservation reservation = createReservation();
+		LocalDateTime now = LocalDateTime.now();
+
+		// when
+		reservation.confirm(now, now, "카드", null);
+
+		// then
+		assertThat(reservation.getStatus()).isEqualTo(ReservationStatus.CONFIRMED);
+	}
+
+	@Test
+	@DisplayName("무통장 입금 결제를 승인하면 상태가 PENDING_DEPOSIT으로 변경되고 가상계좌 정보를 저장한다.")
+	void 결제승인_무통장입금() {
+		// given
+		Reservation reservation = createReservation();
+		LocalDateTime now = LocalDateTime.now();
+		VirtualAccount virtualAccount = new VirtualAccount("1111-11-1111111", "bank", "customer", now);
+
+		// when
+		reservation.confirm(now, now, "무통장입금", virtualAccount);
+
+		// then
+		assertAll(
+			() -> assertThat(reservation.getStatus()).isEqualTo(ReservationStatus.PENDING_DEPOSIT),
+			() -> assertThat(reservation.getVirtualAccount()).isEqualTo(virtualAccount)
+		);
+	}
+
+	@Test
+	@DisplayName("CONFIRMED 상태면 공연 시작일을 반환한다.")
+	void 데드라인_CONFIRMED() {
+		// given
+		Reservation reservation = createReservation();
+		reservation.confirm(LocalDateTime.now(), LocalDateTime.now(), "카드", null);
+
+		// when
+		LocalDateTime deadline = reservation.getDeadline();
+
+		// then
+		assertThat(deadline).isEqualTo(reservation.getShowInfo().getStartAt());
+	}
+
+	@Test
+	@DisplayName("PENDING_DEPOSIT 상태면 입금 마감일을 반환한다.")
+	void 데드라인_PENDING_DEPOSIT() {
+		// given
+		Reservation reservation = createReservation();
+		VirtualAccount virtualAccount = new VirtualAccount("1111-11-1111111", "bank", "customer", LocalDateTime.now());
+		reservation.confirm(LocalDateTime.now(), LocalDateTime.now(), "무통장입금", virtualAccount);
+
+		// when
+		LocalDateTime deadline = reservation.getDeadline();
+
+		// then
+		assertThat(deadline).isEqualTo(virtualAccount.getDueDate());
+	}
+
+	private Reservation createReservation() {
+		return Reservation.create(
+			UUID.randomUUID(),
+			"R-001",
+			"VIP석 2인",
+			ShowInfo.builder()
+				.showId(1L)
+				.title("킹키부츠")
+				.startAt(LocalDateTime.now().plusDays(30))
+				.build()
+		);
+	}
+
+	private List<Ticket> createTickets(Reservation reservation, int count) {
+		return IntStream.range(0, count)
+			.mapToObj(i -> Ticket.create(reservation, "T-00" + i, "VIP", 10000L, "1층 A구역 1열 " + i + "번"))
+			.toList();
+	}
+}

--- a/ticketing/src/test/java/org/truve/platform/ticketing/service/booking/domain/entity/ReservationTest.java
+++ b/ticketing/src/test/java/org/truve/platform/ticketing/service/booking/domain/entity/ReservationTest.java
@@ -10,6 +10,7 @@ import java.util.stream.IntStream;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.truve.platform.ticketing.service.booking.domain.constant.ReservationStatus;
 
 public class ReservationTest {
@@ -91,6 +92,40 @@ public class ReservationTest {
 
 		// then
 		assertThat(deadline).isEqualTo(virtualAccount.getDueDate());
+	}
+	
+	@Test
+	@DisplayName("전체 취소 시 환불 금액은 총 금액 - 서비스 수수료 - 환불 수수료로 계산된다.")
+	void 환불금액_계산_전체() {
+		// given
+		Reservation reservation = createReservation();
+		List<Ticket> tickets = createTickets(reservation, 2);
+		reservation.addTickets(tickets);
+		reservation.confirm(LocalDateTime.now(), LocalDateTime.now(), "카드", null);
+
+		// when
+		Long refundAmount = reservation.calculateRefundAmount(LocalDateTime.now());
+
+		// then
+		assertThat(refundAmount).isEqualTo(20000L);
+	}
+
+	@Test
+	@DisplayName("부분 취소 시 환불 금액은 취소 티켓 가격 총액 - 환불 수수료로 계산된다.")
+	void 환불금액_계산_부분() {
+		// given
+		Reservation reservation = createReservation();
+		List<Ticket> tickets = createTickets(reservation, 2);
+		ReflectionTestUtils.setField(tickets.getFirst(), "id", 1L);
+		ReflectionTestUtils.setField(tickets.getLast(), "id", 2L);
+		reservation.addTickets(tickets);
+		reservation.confirm(LocalDateTime.now(), LocalDateTime.now(), "카드", null);
+
+		// when
+		Long refundAmount = reservation.calculateRefundAmount(LocalDateTime.now(), List.of(1L));
+
+		// then
+		assertThat(refundAmount).isEqualTo(10000L);
 	}
 
 	private Reservation createReservation() {

--- a/ticketing/src/test/java/org/truve/platform/ticketing/service/booking/domain/entity/ReservationTest.java
+++ b/ticketing/src/test/java/org/truve/platform/ticketing/service/booking/domain/entity/ReservationTest.java
@@ -10,6 +10,8 @@ import java.util.stream.IntStream;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.truve.platform.ticketing.service.booking.domain.constant.ReservationStatus;
 
@@ -93,26 +95,35 @@ public class ReservationTest {
 		// then
 		assertThat(deadline).isEqualTo(virtualAccount.getDueDate());
 	}
-	
-	@Test
-	@DisplayName("전체 취소 시 환불 금액은 총 금액 - 서비스 수수료 - 환불 수수료로 계산된다.")
-	void 환불금액_계산_전체() {
+
+	@ParameterizedTest
+	@DisplayName("전체 취소 시 환불 금액은 총 금액 - 취소 수수료 - 서비스 수수료로 계산된다. 이때, 예매 당일일 경우 서비스 수수료를 차감하지 않는다.")
+	@CsvSource({
+		"5, 20000", // 24000 - 0 - 4000
+		"0, 24000" // 24000 - 0 - 0
+	})
+	void 환불금액_계산_전체(int daysSinceBooked, long expectedRefundAmount) {
 		// given
 		Reservation reservation = createReservation();
 		List<Ticket> tickets = createTickets(reservation, 2);
 		reservation.addTickets(tickets);
 		reservation.confirm(LocalDateTime.now(), LocalDateTime.now(), "카드", null);
+		LocalDateTime canceledAt = reservation.getBookedAt().plusDays(daysSinceBooked);
 
 		// when
-		Long refundAmount = reservation.calculateRefundAmount(LocalDateTime.now());
+		Long refundAmount = reservation.calculateRefundAmount(canceledAt);
 
 		// then
-		assertThat(refundAmount).isEqualTo(20000L);
+		assertThat(refundAmount).isEqualTo(expectedRefundAmount);
 	}
 
-	@Test
-	@DisplayName("부분 취소 시 환불 금액은 취소 티켓 가격 총액 - 환불 수수료로 계산된다.")
-	void 환불금액_계산_부분() {
+	@ParameterizedTest
+	@DisplayName("부분 취소 시 환불 금액은 티켓 총 금액 - 환불 수수료로 계산된다. 이때, 예매 당일일 경우 티켓 당 서비스 수수료를 더한다.")
+	@CsvSource({
+		"5, 10000", // 10000 - 0
+		"0, 12000" // 10000 - 0 + (2000 * 1)
+	})
+	void 환불금액_계산_부분(int daysSinceBooked, long expectedRefundAmount) {
 		// given
 		Reservation reservation = createReservation();
 		List<Ticket> tickets = createTickets(reservation, 2);
@@ -120,12 +131,13 @@ public class ReservationTest {
 		ReflectionTestUtils.setField(tickets.getLast(), "id", 2L);
 		reservation.addTickets(tickets);
 		reservation.confirm(LocalDateTime.now(), LocalDateTime.now(), "카드", null);
+		LocalDateTime canceledAt = reservation.getBookedAt().plusDays(daysSinceBooked);
 
 		// when
-		Long refundAmount = reservation.calculateRefundAmount(LocalDateTime.now(), List.of(1L));
+		Long refundAmount = reservation.calculateRefundAmount(canceledAt, List.of(1L));
 
 		// then
-		assertThat(refundAmount).isEqualTo(10000L);
+		assertThat(refundAmount).isEqualTo(expectedRefundAmount);
 	}
 
 	private Reservation createReservation() {

--- a/ticketing/src/test/java/org/truve/platform/ticketing/service/booking/domain/entity/ReservationTest.java
+++ b/ticketing/src/test/java/org/truve/platform/ticketing/service/booking/domain/entity/ReservationTest.java
@@ -97,28 +97,7 @@ public class ReservationTest {
 	}
 
 	@ParameterizedTest
-	@DisplayName("전체 취소 시 환불 금액은 총 금액 - 취소 수수료 - 서비스 수수료로 계산된다. 이때, 예매 당일일 경우 서비스 수수료를 차감하지 않는다.")
-	@CsvSource({
-		"5, 20000", // 24000 - 0 - 4000
-		"0, 24000" // 24000 - 0 - 0
-	})
-	void 환불금액_계산_전체(int daysSinceBooked, long expectedRefundAmount) {
-		// given
-		Reservation reservation = createReservation();
-		List<Ticket> tickets = createTickets(reservation, 2);
-		reservation.addTickets(tickets);
-		reservation.confirm(LocalDateTime.now(), LocalDateTime.now(), "카드", null);
-		LocalDateTime canceledAt = reservation.getBookedAt().plusDays(daysSinceBooked);
-
-		// when
-		Long refundAmount = reservation.calculateRefundAmount(canceledAt);
-
-		// then
-		assertThat(refundAmount).isEqualTo(expectedRefundAmount);
-	}
-
-	@ParameterizedTest
-	@DisplayName("부분 취소 시 환불 금액은 티켓 총 금액 - 환불 수수료로 계산된다. 이때, 예매 당일일 경우 티켓 당 서비스 수수료를 더한다.")
+	@DisplayName("취소 시 환불 금액은 티켓 총 금액 - 환불 수수료로 계산된다. 이때, 예매 당일일 경우 티켓 당 서비스 수수료를 더한다.")
 	@CsvSource({
 		"5, 10000", // 10000 - 0
 		"0, 12000" // 10000 - 0 + (2000 * 1)

--- a/ticketing/src/test/java/org/truve/platform/ticketing/service/booking/domain/policy/CancellationPolicyTest.java
+++ b/ticketing/src/test/java/org/truve/platform/ticketing/service/booking/domain/policy/CancellationPolicyTest.java
@@ -1,0 +1,133 @@
+package org.truve.platform.ticketing.service.booking.domain.policy;
+
+import static org.assertj.core.api.AssertionsForClassTypes.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.truve.platform.ticketing.service.booking.domain.entity.Reservation;
+import org.truve.platform.ticketing.service.booking.domain.entity.ShowInfo;
+import org.truve.platform.ticketing.service.booking.domain.entity.Ticket;
+
+import com.truve.platform.common.exception.CustomException;
+
+public class CancellationPolicyTest {
+
+	@Test
+	@DisplayName("공연 당일에는 취소가 불가능하다.")
+	void 공연_당일_취소_불가() {
+		// given
+		LocalDateTime showAt = LocalDateTime.of(2026, 1, 1, 0, 0);
+		LocalDateTime bookedAt = showAt.minusDays(10);
+
+		Reservation reservation = createReservation(showAt, bookedAt, 1000L);
+
+		// when & then
+		assertThatThrownBy(() -> CancellationPolicy.calculate(reservation, showAt))
+			.isInstanceOf(CustomException.class);
+	}
+
+	@Test
+	@DisplayName("예매 당일에는 취소 수수료가 0원이다.")
+	void 예매_당일_취소_수수료_없음() {
+		// given
+		LocalDateTime showAt = LocalDateTime.of(2026, 1, 1, 0, 0);
+		LocalDateTime bookedAt = showAt.minusDays(5);
+
+		Reservation reservation = createReservation(showAt, bookedAt, 1000L);
+
+		// when
+		Long cancelFee = CancellationPolicy.calculate(reservation, bookedAt);
+
+		// then
+		assertThat(cancelFee).isEqualTo(0L);
+	}
+
+	@ParameterizedTest
+	@DisplayName("관람일 9일 이내 취소 수수료 퍼센트 계산 테스트")
+	@CsvSource({
+		"1, 300",
+		"3, 200",
+		"9, 100"
+	})
+	void 관람일_9일_이내_퍼센트_수수료_적용(int daysUntilShow, long expectedCancelFee) {
+		// given
+		LocalDateTime showAt = LocalDateTime.of(2026, 1, 1, 0, 0);
+		LocalDateTime canceledAt = showAt.minusDays(daysUntilShow);
+		LocalDateTime bookedAt = canceledAt.minusDays(10);
+
+		Reservation reservation = createReservation(showAt, bookedAt, 1000L);
+
+		// when
+		Long cancelFee = CancellationPolicy.calculate(reservation, canceledAt);
+
+		// then
+		assertThat(cancelFee).isEqualTo(expectedCancelFee);
+	}
+
+	@Test
+	@DisplayName("예매 후 7일 이내면서 관람일 9일 이내인 경우, 퍼센트 수수료가 계산된다.")
+	void 예매_후_7일_이내_관람일_9일_이내_퍼센트_수수료_적용() {
+		// given
+		LocalDateTime showAt = LocalDateTime.of(2026, 1, 1, 0, 0);
+		LocalDateTime canceledAt = showAt.minusDays(5);
+		LocalDateTime bookedAt = showAt.minusDays(6);
+
+		Reservation reservation = createReservation(showAt, bookedAt, 1000L);
+
+		// when
+		Long cancelFee = CancellationPolicy.calculate(reservation, canceledAt);
+
+		// then
+		assertThat(cancelFee).isEqualTo(100L);
+	}
+
+	@ParameterizedTest
+	@DisplayName("관람일 10일 전까지는 티켓 금액의 10퍼센트랑 티켓 당 4000원 중 더 작은 금액을 적용한다.")
+	@CsvSource({
+		"40000, 4000",
+		"1000, 100"
+	})
+	void 관람일_10일_이상_남은_경우_정액_또는_요율_중_작은_금액_적용(Long price, long expectedCancelFee) {
+		// given
+		LocalDateTime showAt = LocalDateTime.of(2026, 1, 1, 0, 0);
+		LocalDateTime canceledAt = showAt.minusDays(11);
+		LocalDateTime bookedAt = canceledAt.minusDays(10);
+
+		Reservation reservation = createReservation(showAt, bookedAt, price);
+
+		// when
+		Long cancelFee = CancellationPolicy.calculate(reservation, canceledAt);
+
+		// then
+		assertThat(cancelFee).isEqualTo(expectedCancelFee);
+	}
+
+	private Reservation createReservation(LocalDateTime showAt, LocalDateTime bookedAt, Long price) {
+		Reservation reservation = Reservation.create(
+			UUID.randomUUID(),
+			"R-001",
+			"VIP석 2인",
+			ShowInfo.builder()
+				.showId(1L)
+				.title("킹키부츠")
+				.startAt(showAt)
+				.build()
+		);
+
+		Ticket ticket1 = Ticket.create(reservation, "T-001", "VIP", price, "1층 A구역 1열 1번");
+		ReflectionTestUtils.setField(ticket1, "id", 1L);
+
+		reservation.addTickets(List.of(ticket1));
+
+		reservation.confirm(bookedAt, bookedAt, "카드", null);
+
+		return reservation;
+	}
+}

--- a/ticketing/src/test/java/org/truve/platform/ticketing/service/booking/service/BookingServiceTest.java
+++ b/ticketing/src/test/java/org/truve/platform/ticketing/service/booking/service/BookingServiceTest.java
@@ -15,9 +15,13 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.truve.platform.ticketing.service.booking.domain.constant.TicketStatus;
 import org.truve.platform.ticketing.service.booking.domain.entity.Reservation;
+import org.truve.platform.ticketing.service.booking.domain.entity.ShowInfo;
+import org.truve.platform.ticketing.service.booking.domain.entity.Ticket;
 import org.truve.platform.ticketing.service.booking.dto.BookingRequest;
+import org.truve.platform.ticketing.service.booking.dto.BookingResponse;
 import org.truve.platform.ticketing.service.booking.external.client.TicketingClient;
 import org.truve.platform.ticketing.service.booking.external.client.TicketingResponse;
 import org.truve.platform.ticketing.service.booking.repository.ReservationRepository;
@@ -77,4 +81,55 @@ class BookingServiceTest {
 		);
 	}
 
+	@Test
+	@DisplayName("ticketIds가 null이면 전체 티켓 목록을 반환한다.")
+	void 전체티켓목록_반환_성공() {
+		// given
+		Reservation reservation = createReservation();
+		given(reservationRepository.findByNumber("R-001")).willReturn(reservation);
+
+		// when
+		BookingResponse.Cancel res = bookingService.getCancel("R-001", null);
+
+		// then
+		assertThat(res.getTickets()).hasSize(2);
+	}
+
+	@Test
+	@DisplayName("ticketIds가 null이 아니어도 전체 티켓 목록을 반환한다.")
+	void 특정티켓선택시_전체티켓목록_반환_성공() {
+		// given
+		Reservation reservation = createReservation();
+		given(reservationRepository.findByNumber("R-001")).willReturn(reservation);
+
+		// when
+		BookingResponse.Cancel res = bookingService.getCancel("R-001", List.of(1L));
+
+		// then
+		assertThat(res.getTickets()).hasSize(2);
+	}
+
+	private Reservation createReservation() {
+		Reservation reservation = Reservation.create(
+			UUID.randomUUID(),
+			"R-001",
+			"VIP석 2인",
+			ShowInfo.builder()
+				.showId(1L)
+				.title("킹키부츠")
+				.startAt(LocalDateTime.now().plusDays(30))
+				.build()
+		);
+
+		Ticket ticket1 = Ticket.create(reservation, "T-001", "VIP", 120000L, "1층 A구역 1열 1번");
+		ReflectionTestUtils.setField(ticket1, "id", 1L);
+		Ticket ticket2 = Ticket.create(reservation, "T-002", "VIP", 120000L, "1층 A구역 1열 2번");
+		ReflectionTestUtils.setField(ticket2, "id", 2L);
+
+		List<Ticket> tickets = List.of(ticket1, ticket2);
+		reservation.addTickets(tickets);
+		reservation.confirm(LocalDateTime.now(), LocalDateTime.now(), "카드", null);
+
+		return reservation;
+	}
 }


### PR DESCRIPTION
## 변경 사항

---
### 취소 수수료 정책 반영

https://www.notion.so/3189e3e335cc80fbb8ebf9efbf7d7fbc?source=copy_link

위 기획 문서를 기반으로 `CancellationPolicy`를 구현했습니다.

### 취소 정보 조회 API 구현

<img width="482" height="491" alt="스크린샷 2026-03-24 오전 10 35 41" src="https://github.com/user-attachments/assets/1a6a2fd8-8eb0-42c4-8e8c-9298bcef0836" />

취소 수수료 및 티켓 정보를 조회하는 API를 구현했습니다.

- [X] 전체 테스트 코드 성공 여부

## 관련 이슈

---
- Notion Ticket: # 77

## 참고사항 (선택)

---