### PR TITLE
fix(ticketing): 티켓팅간 좌석 id -> 공연스케줄_좌석 id로 변경

### DIFF
--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/ticketing/controller/TicketingController.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/ticketing/controller/TicketingController.java
@@ -119,7 +119,7 @@ public class TicketingController {
 		@RequestHeader(value = SESSION_HEADER) String sessionToken,
 		@RequestBody @Valid TicketingRequest.HoldSeat request
 	) {
-		ticketingService.holdSeat(showScheduleId, userId, sessionToken, request.getSeatIds());
+		ticketingService.holdSeat(showScheduleId, userId, sessionToken, request.getScheduledSeatIds());
 		return ApiResult.ok();
 	}
 
@@ -165,7 +165,7 @@ public class TicketingController {
 		@RequestHeader(value = SESSION_HEADER) String sessionToken,
 		@RequestBody @Valid TicketingRequest.DeleteHoldSeat request
 	) {
-		ticketingService.cancelHoldSeat(showScheduleId, userId, sessionToken, request.getSeatIds());
+		ticketingService.cancelHoldSeat(showScheduleId, userId, sessionToken, request.getScheduledSeatIds());
 		return ApiResult.ok();
 	}
 

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/ticketing/dto/SeatSectionsDto.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/ticketing/dto/SeatSectionsDto.java
@@ -12,7 +12,7 @@ public class SeatSectionsDto {
 	String sectionName;
 	String grade;
 	Long price;
-	Long seatId;
+	Long scheduledSeatId;
 	String row;
 	Long col;
 	SeatStatus status;

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/ticketing/dto/TicketingRequest.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/ticketing/dto/TicketingRequest.java
@@ -12,13 +12,13 @@ public class TicketingRequest {
 	@AllArgsConstructor
 	public static class HoldSeat {
 		@NotEmpty
-		List<Long> seatIds;
+		List<Long> scheduledSeatIds;
 	}
 
 	@Getter
 	@AllArgsConstructor
 	public static class DeleteHoldSeat {
 		@NotEmpty
-		List<Long> seatIds;
+		List<Long> scheduledSeatIds;
 	}
 }

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/ticketing/dto/TicketingResponse.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/ticketing/dto/TicketingResponse.java
@@ -89,7 +89,7 @@ public class TicketingResponse {
 	@Getter
 	@AllArgsConstructor
 	public static class Seat {
-		Long seatId;
+		Long scheduledSeatId;
 		Long col;
 		SeatStatus status;
 	}
@@ -138,12 +138,12 @@ public class TicketingResponse {
 
 		private void addSeat(SeatSectionsDto seatSectionDto) {
 			seats.add(new Seat(
-				seatSectionDto.getSeatId(),
+				seatSectionDto.getScheduledSeatId(),
 				seatSectionDto.getCol(),
 				seatSectionDto.getStatus()
 			));
 		}
-
+		
 		private Row toRow() {
 			return new Row(row, seats);
 		}

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/ticketing/repository/ScheduledSeatRepository.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/ticketing/repository/ScheduledSeatRepository.java
@@ -18,7 +18,7 @@ public interface ScheduledSeatRepository extends JpaRepository<ScheduledSeat, Lo
  			sc.name,
  			sc.gradeName,
  			sc.price,
- 			s.id,
+ 			ss.id,
  			s.seatRow,
  			s.seatNumber,
  			ss.status

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/ticketing/service/TicketingService.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/ticketing/service/TicketingService.java
@@ -62,17 +62,17 @@ public class TicketingService {
 		Preconditions.validate(extended, ErrorCode.INVALID_SESSION_TOKEN);
 	}
 
-	public void holdSeat(Long showScheduleId, UUID userId, String sessionToken, List<Long> seatIds) {
+	public void holdSeat(Long showScheduleId, UUID userId, String sessionToken, List<Long> scheduledSeatIds) {
 		heartbeat(showScheduleId, userId, sessionToken);
 
-		Preconditions.validate(seatIds.size() <= 4, ErrorCode.EXCEEDED_MAX_TICKET_COUNT);
+		Preconditions.validate(scheduledSeatIds.size() <= 4, ErrorCode.EXCEEDED_MAX_TICKET_COUNT);
 
 		ShowScheduled showScheduled = showScheduledRepository.findById(showScheduleId)
 			.orElseThrow(() -> new CustomException(ErrorCode.INVALID_SHOW_SCHEDULE));
 
-		List<ScheduledSeat> seats = scheduledSeatRepository.findAllById(seatIds);
+		List<ScheduledSeat> seats = scheduledSeatRepository.findAllById(scheduledSeatIds);
 
-		Preconditions.validate(seatIds.size() == seats.size(), ErrorCode.NOT_CORRECT_SEAT);
+		Preconditions.validate(scheduledSeatIds.size() == seats.size(), ErrorCode.NOT_CORRECT_SEAT);
 
 		for(ScheduledSeat seat: seats) {
 
@@ -102,11 +102,21 @@ public class TicketingService {
 
 	}
 
-	public void cancelHoldSeat(Long showScheduleId, UUID userId, String sessionToken,List<Long> seatIds) {
+	public void cancelHoldSeat(Long showScheduleId, UUID userId, String sessionToken, List<Long> scheduledSeatIds) {
 
 		heartbeat(showScheduleId, userId, sessionToken);
 
-		for (Long seatId : seatIds) {
+		List<ScheduledSeat> seats = scheduledSeatRepository.findAllById(scheduledSeatIds);
+
+		Preconditions.validate(scheduledSeatIds.size() == seats.size(), ErrorCode.NOT_CORRECT_SEAT);
+
+		for (ScheduledSeat seat : seats) {
+			Preconditions.validate(
+				seat.getShowScheduleId().equals(showScheduleId),
+				ErrorCode.NOT_CORRECT_SEAT
+			);
+
+			Long seatId = seat.getSeat().getId();
 			String savedSessionToken = ticketingRedisRepository.getHoldSeatSessionToken(showScheduleId, seatId);
 			Preconditions.validate(sessionToken.equals(savedSessionToken), ErrorCode.INVALID_HOLD_SEAT);
 			ticketingRedisRepository.deleteHoldSeat(showScheduleId, seatId);

--- a/ticketing/src/test/java/org/truve/platform/ticketing/service/ticketing/controller/TicketingControllerTest.java
+++ b/ticketing/src/test/java/org/truve/platform/ticketing/service/ticketing/controller/TicketingControllerTest.java
@@ -124,6 +124,7 @@ class TicketingControllerTest {
 		resultActions.andExpect(status().isOk())
 			.andExpect(jsonPath("$.data.sections[0].sectionId").value(1L))
 			.andExpect(jsonPath("$.data.sections[0].rows[0].row").value("A"))
+			.andExpect(jsonPath("$.data.sections[0].rows[0].seats[0].scheduledSeatId").value(10L))
 			.andExpect(jsonPath("$.data.sections[0].rows[0].seats[1].status").value("SOLD"));
 		verify(ticketingService).getSeats(1L, userId, "session-token");
 	}

--- a/ticketing/src/test/java/org/truve/platform/ticketing/service/ticketing/service/TicketingServiceTest.java
+++ b/ticketing/src/test/java/org/truve/platform/ticketing/service/ticketing/service/TicketingServiceTest.java
@@ -396,6 +396,9 @@ class TicketingServiceTest {
 		@DisplayName("같은 세션이 점유한 좌석이면 점유를 해제한다.")
 		void 좌석선점취소_성공() {
 			// given
+			ScheduledSeat scheduledSeat1 = createScheduledSeat(10L, showScheduleId, SeatStatus.AVAILABLE);
+			ScheduledSeat scheduledSeat2 = createScheduledSeat(11L, showScheduleId, SeatStatus.AVAILABLE);
+			given(scheduledSeatRepository.findAllById(List.of(10L, 11L))).willReturn(List.of(scheduledSeat1, scheduledSeat2));
 			given(ticketingRedisRepository.getHoldSeatSessionToken(showScheduleId, 10L)).willReturn(sessionToken);
 			given(ticketingRedisRepository.getHoldSeatSessionToken(showScheduleId, 11L)).willReturn(sessionToken);
 
@@ -413,6 +416,8 @@ class TicketingServiceTest {
 		@DisplayName("다른 세션이 점유한 좌석이면 INVALID_HOLD_SEAT 예외가 발생한다.")
 		void 좌석선점취소_타세션점유() {
 			// given
+			ScheduledSeat scheduledSeat = createScheduledSeat(10L, showScheduleId, SeatStatus.AVAILABLE);
+			given(scheduledSeatRepository.findAllById(List.of(10L))).willReturn(List.of(scheduledSeat));
 			given(ticketingRedisRepository.getHoldSeatSessionToken(showScheduleId, 10L)).willReturn("other-session");
 
 			// when
@@ -552,6 +557,7 @@ class TicketingServiceTest {
 			.seat(seat)
 			.showScheduleId(scheduledShowId)
 			.build();
+		ReflectionTestUtils.setField(scheduledSeat, "id", seatId);
 		ReflectionTestUtils.setField(scheduledSeat, "status", status);
 
 		return scheduledSeat;


### PR DESCRIPTION
## 변경 사항

추가/변경 사항과 사유를 작성해 주세요.

- [x] 전체 테스트 코드 성공 여부

조회시에는 seat_id를 내려주고 선점에서는 scheduled_seat_id를 사용하고 있어서
에러가 발생했네요.. 왜 이렇게했었는지 밤에 했나 

좌석 조회쪽에서 scheduled_seat_id 내려주는 방식으로 변경했습니다!

## 관련 이슈

- Notion Ticket: #

## 참고사항 (선택)

영준님 요청으로 급하게 머지 하겠습니다!