### PR TITLE
fix: 티켓팅 세션토큰 60분으로 만료시간 변경

### DIFF
--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/ticketing/service/TicketingService.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/ticketing/service/TicketingService.java
@@ -41,8 +41,8 @@ public class TicketingService {
 
 		String sessionToken = UUID.randomUUID().toString();
 
-		// TODO: 만료시간 기획측과 논의
-		ticketingRedisRepository.saveSessionToken(sessionToken, userId, showScheduleId, Duration.ofMinutes(5));
+		// TODO: 만료시간 기획측과 논의, 현재 60분으로 연동 편의성 확보
+		ticketingRedisRepository.saveSessionToken(sessionToken, userId, showScheduleId, Duration.ofMinutes(60));
 		ticketingRedisRepository.addActiveTicketingUser(showScheduleId, sessionToken);
 		long sessionTokenTtl = ticketingRedisRepository.getSessionTokenTtl(sessionToken);
 

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/ticketing/service/TicketingService.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/ticketing/service/TicketingService.java
@@ -58,7 +58,9 @@ public class TicketingService {
 		long activeWindowMs = ticketingProperties.getActiveWindowMs();
 		ticketingRedisRepository.removeInactiveTicketingUsers(showScheduleId, nowMs - activeWindowMs);
 
-		boolean extended = ticketingRedisRepository.refreshSessionTokenTtl(sessionToken, ticketingProperties.getSessionTtlSec());
+		// TODO: 프론트 연동 이후 세션 만료시간 설정값 기반 갱신 로직 주석 해제
+		// boolean extended = ticketingRedisRepository.refreshSessionTokenTtl(sessionToken, ticketingProperties.getSessionTtlSec());
+		boolean extended = ticketingRedisRepository.refreshSessionTokenTtl(sessionToken, Duration.ofMinutes(60).toSeconds());
 		Preconditions.validate(extended, ErrorCode.INVALID_SESSION_TOKEN);
 	}
 

--- a/ticketing/src/test/java/org/truve/platform/ticketing/service/ticketing/service/TicketingServiceTest.java
+++ b/ticketing/src/test/java/org/truve/platform/ticketing/service/ticketing/service/TicketingServiceTest.java
@@ -137,7 +137,7 @@ class TicketingServiceTest {
 			assertAll(
 				() -> verify(ticketingRedisRepository).addActiveTicketingUser(showScheduleId, sessionToken),
 				() -> verify(ticketingRedisRepository).removeInactiveTicketingUsers(eq(showScheduleId), anyLong()),
-				() -> verify(ticketingRedisRepository).refreshSessionTokenTtl(sessionToken, 300L)
+				() -> verify(ticketingRedisRepository).refreshSessionTokenTtl(sessionToken, 3600L)
 			);
 		}
 


### PR DESCRIPTION
## 변경 사항

추가/변경 사항과 사유를 작성해 주세요.

- [x] 전체 테스트 코드 성공 여부

프론트 요청으로 연동 편의성 위해 세션토큰 만료시간 60분으로 변경합니다!

## 관련 이슈

- Notion Ticket: #

## 참고사항 (선택)

---