### PR TITLE
feat(ticketing): 잔여 좌석 조회용 티켓팅 내부 api 구현

### DIFF
--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/ticketing/controller/TicketingInternalController.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/ticketing/controller/TicketingInternalController.java
@@ -16,6 +16,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 @RequestMapping("/api/internal/ticketing")
 @Tag(name = "Internal Ticketing", description = "백엔드 내부 통신 용 API")
+
+// TODO: 내부 서비스 간 통신 시 보안 방식 검토
 public class TicketingInternalController {
 	private final TicketingInternalService ticketingInternalService;
 

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/ticketing/controller/TicketingInternalController.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/ticketing/controller/TicketingInternalController.java
@@ -9,15 +9,17 @@ import org.truve.platform.ticketing.service.ticketing.service.TicketingInternalS
 
 import com.truve.platform.common.response.ApiResult;
 
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/internal/ticketing")
+@RequestMapping("/api/internal/ticketing")
+@Tag(name = "Internal Ticketing", description = "백엔드 내부 통신 용 API")
 public class TicketingInternalController {
 	private final TicketingInternalService ticketingInternalService;
 
-	@GetMapping("/{showScheduleId/remaining")
+	@GetMapping("/{showScheduleId}/remaining")
 	public ApiResult<TicketingInternalResponse.RemainingSeats> getRemainingSeats(
 		@PathVariable Long showScheduleId
 	) {

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/ticketing/controller/TicketingInternalController.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/ticketing/controller/TicketingInternalController.java
@@ -4,6 +4,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.truve.platform.ticketing.service.ticketing.dto.TicketingInternalResponse;
 import org.truve.platform.ticketing.service.ticketing.service.TicketingInternalService;
 
 import com.truve.platform.common.response.ApiResult;
@@ -17,10 +18,9 @@ public class TicketingInternalController {
 	private final TicketingInternalService ticketingInternalService;
 
 	@GetMapping("/{showScheduleId/remaining")
-	public ApiResult<Void> getRemainingSeats(
+	public ApiResult<TicketingInternalResponse.RemainingSeats> getRemainingSeats(
 		@PathVariable Long showScheduleId
 	) {
-		ticketingInternalService.getRemainingSeats(showScheduleId);
-		return ApiResult.ok();
+		return ApiResult.ok(ticketingInternalService.getRemainingSeats(showScheduleId));
 	}
 }

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/ticketing/controller/TicketingInternalController.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/ticketing/controller/TicketingInternalController.java
@@ -14,7 +14,7 @@ import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/internal/ticketing")
+@RequestMapping("/api/ticketing/internal")
 @Tag(name = "Internal Ticketing", description = "백엔드 내부 통신 용 API")
 
 // TODO: 내부 서비스 간 통신 시 보안 방식 검토

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/ticketing/controller/TicketingInternalController.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/ticketing/controller/TicketingInternalController.java
@@ -1,0 +1,26 @@
+package org.truve.platform.ticketing.service.ticketing.controller;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.truve.platform.ticketing.service.ticketing.service.TicketingInternalService;
+
+import com.truve.platform.common.response.ApiResult;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/internal/ticketing")
+public class TicketingInternalController {
+	private final TicketingInternalService ticketingInternalService;
+
+	@GetMapping("/{showScheduleId/remaining")
+	public ApiResult<Void> getRemainingSeats(
+		@PathVariable Long showScheduleId
+	) {
+		ticketingInternalService.getRemainingSeats(showScheduleId);
+		return ApiResult.ok();
+	}
+}

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/ticketing/dto/TicketingInternalResponse.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/ticketing/dto/TicketingInternalResponse.java
@@ -1,0 +1,4 @@
+package org.truve.platform.ticketing.service.ticketing.dto;
+
+public class TicketingInternalResponse {
+}

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/ticketing/dto/TicketingInternalResponse.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/ticketing/dto/TicketingInternalResponse.java
@@ -1,4 +1,22 @@
 package org.truve.platform.ticketing.service.ticketing.dto;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
 public class TicketingInternalResponse {
+
+	@Getter
+	@AllArgsConstructor
+	public static class RemainingSeats {
+		private Long ShowScheduleId;
+		private Grades[] grades;
+	}
+
+	@Getter
+	@AllArgsConstructor
+	private static class Grades {
+		private String gradeName;
+		private Long remainingSeatCount;
+		private Long totalCount;
+	}
 }

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/ticketing/dto/TicketingInternalResponse.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/ticketing/dto/TicketingInternalResponse.java
@@ -1,5 +1,7 @@
 package org.truve.platform.ticketing.service.ticketing.dto;
 
+import java.util.List;
+
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -9,12 +11,16 @@ public class TicketingInternalResponse {
 	@AllArgsConstructor
 	public static class RemainingSeats {
 		private Long ShowScheduleId;
-		private Grades[] grades;
+		private List<GradeRemaining> grades;
+
+		public static RemainingSeats of(Long showScheduleId, List<GradeRemaining> grades) {
+			return new RemainingSeats(showScheduleId, grades);
+		}
 	}
 
 	@Getter
 	@AllArgsConstructor
-	private static class Grades {
+	private static class GradeRemaining {
 		private String gradeName;
 		private Long remainingSeatCount;
 		private Long totalCount;

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/ticketing/dto/TicketingInternalResponse.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/ticketing/dto/TicketingInternalResponse.java
@@ -7,6 +7,12 @@ import lombok.Getter;
 
 public class TicketingInternalResponse {
 
+	public interface FlatRemainingSeatInfo {
+		String getGradeName();
+		Long getRemainingSeatCount();
+		Long getTotalCount();
+	}
+
 	@Getter
 	@AllArgsConstructor
 	public static class RemainingSeats {

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/ticketing/dto/TicketingInternalResponse.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/ticketing/dto/TicketingInternalResponse.java
@@ -26,9 +26,17 @@ public class TicketingInternalResponse {
 
 	@Getter
 	@AllArgsConstructor
-	private static class GradeRemaining {
+	public static class GradeRemaining {
 		private String gradeName;
 		private Long remainingSeatCount;
 		private Long totalCount;
+
+		public static  GradeRemaining from(FlatRemainingSeatInfo flatRemainingSeatInfo) {
+			return new GradeRemaining(
+				flatRemainingSeatInfo.getGradeName(),
+				flatRemainingSeatInfo.getRemainingSeatCount(),
+				flatRemainingSeatInfo.getTotalCount()
+			);
+		}
 	}
 }

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/ticketing/dto/TicketingInternalResponse.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/ticketing/dto/TicketingInternalResponse.java
@@ -16,7 +16,7 @@ public class TicketingInternalResponse {
 	@Getter
 	@AllArgsConstructor
 	public static class RemainingSeats {
-		private Long ShowScheduleId;
+		private Long showScheduleId;
 		private List<GradeRemaining> grades;
 
 		public static RemainingSeats of(Long showScheduleId, List<GradeRemaining> grades) {

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/ticketing/repository/ScheduledSeatRepository.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/ticketing/repository/ScheduledSeatRepository.java
@@ -6,8 +6,10 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.truve.platform.ticketing.service.booking.external.client.TicketingResponse;
+import org.truve.platform.ticketing.service.ticketing.constant.SeatStatus;
 import org.truve.platform.ticketing.service.ticketing.domain.entity.ScheduledSeat;
 import org.truve.platform.ticketing.service.ticketing.dto.SeatSectionsDto;
+import org.truve.platform.ticketing.service.ticketing.dto.TicketingInternalResponse;
 
 public interface ScheduledSeatRepository extends JpaRepository<ScheduledSeat, Long> {
 
@@ -51,4 +53,26 @@ public interface ScheduledSeatRepository extends JpaRepository<ScheduledSeat, Lo
 		WHERE s.id IN :ids
 		""")
 	List<TicketingResponse.FlatSeatInfo> findFlatInfoById(List<Long> ids);
+
+	/*
+	[백엔드 내부 통신 용도 Repository 메서드]
+	*/
+
+	@Query("""
+	select
+		sc.gradeName as gradeName,
+		sum(case when ss.status = :status then 1L else 0L end) as remainingSeatCount
+	from ScheduledSeat ss
+	join ss.seat s
+	join s.seatSection sc
+	where ss.showScheduleId = :showScheduleId
+	group by sc.gradeName
+	order by sc.price asc
+	""")
+	List<TicketingInternalResponse.FlatRemainingSeatInfo> findGradeRemainingSeats(
+		@Param("showScheduleId") Long showScheduleId,
+		@Param("status") SeatStatus status
+	);
+
+
 }

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/ticketing/repository/ScheduledSeatRepository.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/ticketing/repository/ScheduledSeatRepository.java
@@ -61,13 +61,14 @@ public interface ScheduledSeatRepository extends JpaRepository<ScheduledSeat, Lo
 	@Query("""
 	select
 		sc.gradeName as gradeName,
-		sum(case when ss.status = :status then 1L else 0L end) as remainingSeatCount
+		sum(case when ss.status = :status then 1L else 0L end) as remainingSeatCount,
+		count(ss) as totalCount
 	from ScheduledSeat ss
 	join ss.seat s
 	join s.seatSection sc
 	where ss.showScheduleId = :showScheduleId
 	group by sc.gradeName
-	order by sc.price asc
+	order by sc.gradeName asc
 	""")
 	List<TicketingInternalResponse.FlatRemainingSeatInfo> findGradeRemainingSeats(
 		@Param("showScheduleId") Long showScheduleId,

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/ticketing/service/TicketingInternalService.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/ticketing/service/TicketingInternalService.java
@@ -1,18 +1,37 @@
 package org.truve.platform.ticketing.service.ticketing.service;
 
+import java.util.List;
+
 import org.springframework.stereotype.Service;
+import org.truve.platform.ticketing.service.ticketing.constant.SeatStatus;
+import org.truve.platform.ticketing.service.ticketing.dto.TicketingInternalResponse;
 import org.truve.platform.ticketing.service.ticketing.repository.ScheduledSeatRepository;
+import org.truve.platform.ticketing.service.ticketing.repository.ShowScheduledRepository;
+
+import com.truve.platform.common.exception.CustomException;
+import com.truve.platform.common.exception.ErrorCode;
 
 import lombok.RequiredArgsConstructor;
 
-@Service
-@RequiredArgsConstructor
-public class TicketingInternalService {
+		@Service
+		@RequiredArgsConstructor
+		public class TicketingInternalService {
 
-	private final ScheduledSeatRepository scheduledSeatRepository;
+			private final ScheduledSeatRepository scheduledSeatRepository;
+			private final ShowScheduledRepository showScheduledRepository;
 
-	public void getRemainingSeats(Long showScheduleId) {
+			public TicketingInternalResponse.RemainingSeats getRemainingSeats(Long showScheduleId) {
+				showScheduledRepository.findById(showScheduleId)
+					.orElseThrow(() -> new CustomException(ErrorCode.INVALID_SHOW_SCHEDULE));
 
+				List<TicketingInternalResponse.FlatRemainingSeatInfo> grades =
+					scheduledSeatRepository.findGradeRemainingSeats(showScheduleId, SeatStatus.AVAILABLE);
+
+				List<TicketingInternalResponse.GradeRemaining> remainingSeats = grades.stream()
+					.map(TicketingInternalResponse.GradeRemaining::from)
+					.toList();
+
+				return TicketingInternalResponse.RemainingSeats.of(showScheduleId, remainingSeats);
 	}
 
 }

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/ticketing/service/TicketingInternalService.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/ticketing/service/TicketingInternalService.java
@@ -1,0 +1,18 @@
+package org.truve.platform.ticketing.service.ticketing.service;
+
+import org.springframework.stereotype.Service;
+import org.truve.platform.ticketing.service.ticketing.repository.ScheduledSeatRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class TicketingInternalService {
+
+	private final ScheduledSeatRepository scheduledSeatRepository;
+
+	public void getRemainingSeats(Long showScheduleId) {
+
+	}
+
+}

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/ticketing/service/TicketingService.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/ticketing/service/TicketingService.java
@@ -131,7 +131,7 @@ public class TicketingService {
 		ShowScheduled schedule = showScheduledRepository.findById(showScheduleId)
 			.orElseThrow(() -> new CustomException(ErrorCode.INVALID_SHOW_SCHEDULE));
 
-		return TicketingResponse.Show.of(schedule.getTitle(), schedule.getTitle(), schedule.getStartAt());
+		return TicketingResponse.Show.of(schedule.getTitle(), schedule.getVenueName(), schedule.getStartAt());
 	}
 
 	public TicketingResponse.Seats getSeats(Long showScheduleId, UUID userId, String sessionToken) {

--- a/ticketing/src/test/java/org/truve/platform/ticketing/service/ticketing/controller/TicketingInternalControllerTest.java
+++ b/ticketing/src/test/java/org/truve/platform/ticketing/service/ticketing/controller/TicketingInternalControllerTest.java
@@ -55,7 +55,7 @@ class TicketingInternalControllerTest {
 		given(ticketingInternalService.getRemainingSeats(showScheduleId)).willReturn(response);
 
 		// when
-		ResultActions resultActions = mockMvc.perform(get("/api/internal/ticketing/{showScheduleId}/remaining", showScheduleId));
+		ResultActions resultActions = mockMvc.perform(get("/api/ticketing/internal/{showScheduleId}/remaining", showScheduleId));
 
 		// then
 		resultActions.andExpect(status().isOk())

--- a/ticketing/src/test/java/org/truve/platform/ticketing/service/ticketing/controller/TicketingInternalControllerTest.java
+++ b/ticketing/src/test/java/org/truve/platform/ticketing/service/ticketing/controller/TicketingInternalControllerTest.java
@@ -1,0 +1,70 @@
+package org.truve.platform.ticketing.service.ticketing.controller;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.truve.platform.ticketing.service.ticketing.dto.TicketingInternalResponse;
+import org.truve.platform.ticketing.service.ticketing.service.TicketingInternalService;
+
+import com.truve.platform.common.exception.ApiAdvice;
+
+@WebMvcTest(controllers = TicketingInternalController.class)
+@Import(ApiAdvice.class)
+class TicketingInternalControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@MockitoBean
+	private TicketingInternalService ticketingInternalService;
+
+	@MockitoBean
+	private JpaMetamodelMappingContext jpaMetamodelMappingContext;
+
+	@MockitoBean
+	private ApplicationEventPublisher applicationEventPublisher;
+
+	@Test
+	@DisplayName("등급별 잔여 좌석 수 조회에 성공한다.")
+	void 등급별_잔여좌석_조회_성공() throws Exception {
+		// given
+		Long showScheduleId = 1L;
+		TicketingInternalResponse.RemainingSeats response = TicketingInternalResponse.RemainingSeats.of(
+			showScheduleId,
+			List.of(
+				new TicketingInternalResponse.GradeRemaining("VIP", 10L, 20L),
+				new TicketingInternalResponse.GradeRemaining("R", 30L, 50L)
+			)
+		);
+
+		given(ticketingInternalService.getRemainingSeats(showScheduleId)).willReturn(response);
+
+		// when
+		ResultActions resultActions = mockMvc.perform(get("/api/internal/ticketing/{showScheduleId}/remaining", showScheduleId));
+
+		// then
+		resultActions.andExpect(status().isOk())
+			.andExpect(jsonPath("$.code").value("ok"))
+			.andExpect(jsonPath("$.data.grades[0].gradeName").value("VIP"))
+			.andExpect(jsonPath("$.data.grades[0].remainingSeatCount").value(10L))
+			.andExpect(jsonPath("$.data.grades[0].totalCount").value(20L))
+			.andExpect(jsonPath("$.data.grades[1].gradeName").value("R"));
+
+		verify(ticketingInternalService).getRemainingSeats(showScheduleId);
+	}
+}

--- a/ticketing/src/test/java/org/truve/platform/ticketing/service/ticketing/service/TicketingInternalServiceTest.java
+++ b/ticketing/src/test/java/org/truve/platform/ticketing/service/ticketing/service/TicketingInternalServiceTest.java
@@ -1,0 +1,109 @@
+package org.truve.platform.ticketing.service.ticketing.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.truve.platform.ticketing.service.ticketing.constant.SeatStatus;
+import org.truve.platform.ticketing.service.ticketing.domain.entity.ShowScheduled;
+import org.truve.platform.ticketing.service.ticketing.dto.TicketingInternalResponse;
+import org.truve.platform.ticketing.service.ticketing.repository.ScheduledSeatRepository;
+import org.truve.platform.ticketing.service.ticketing.repository.ShowScheduledRepository;
+
+import com.truve.platform.common.exception.CustomException;
+import com.truve.platform.common.exception.ErrorCode;
+
+@ExtendWith(MockitoExtension.class)
+class TicketingInternalServiceTest {
+
+	@Mock
+	private ScheduledSeatRepository scheduledSeatRepository;
+
+	@Mock
+	private ShowScheduledRepository showScheduledRepository;
+
+	@InjectMocks
+	private TicketingInternalService ticketingInternalService;
+
+	@Test
+	@DisplayName("공연 회차가 존재하면 등급별 잔여 좌석 수를 반환한다.")
+	void 등급별_잔여좌석_조회_성공() {
+		// given
+		Long showScheduleId = 1L;
+		ShowScheduled showScheduled = ShowScheduled.builder()
+			.title("지킬앤하이드")
+			.venueName("블루스퀘어")
+			.startAt(LocalDateTime.of(2026, 3, 26, 19, 0))
+			.build();
+		ReflectionTestUtils.setField(showScheduled, "id", showScheduleId);
+
+		TicketingInternalResponse.FlatRemainingSeatInfo vipInfo = flatRemainingSeatInfo("VIP", 10L, 20L);
+		TicketingInternalResponse.FlatRemainingSeatInfo rInfo = flatRemainingSeatInfo("R", 30L, 50L);
+
+		given(showScheduledRepository.findById(showScheduleId)).willReturn(Optional.of(showScheduled));
+		given(scheduledSeatRepository.findGradeRemainingSeats(showScheduleId, SeatStatus.AVAILABLE))
+			.willReturn(List.of(vipInfo, rInfo));
+
+		// when
+		TicketingInternalResponse.RemainingSeats response = ticketingInternalService.getRemainingSeats(showScheduleId);
+
+		// then
+		assertAll(
+			() -> assertThat(response.getShowScheduleId()).isEqualTo(showScheduleId),
+			() -> assertThat(response.getGrades()).hasSize(2),
+			() -> assertThat(response.getGrades().get(0).getGradeName()).isEqualTo("VIP"),
+			() -> assertThat(response.getGrades().get(0).getRemainingSeatCount()).isEqualTo(10L),
+			() -> assertThat(response.getGrades().get(0).getTotalCount()).isEqualTo(20L),
+			() -> assertThat(response.getGrades().get(1).getGradeName()).isEqualTo("R"),
+			() -> assertThat(response.getGrades().get(1).getRemainingSeatCount()).isEqualTo(30L),
+			() -> assertThat(response.getGrades().get(1).getTotalCount()).isEqualTo(50L)
+		);
+		verify(scheduledSeatRepository).findGradeRemainingSeats(showScheduleId, SeatStatus.AVAILABLE);
+	}
+
+	@Test
+	@DisplayName("공연 회차가 존재하지 않으면 INVALID_SHOW_SCHEDULE 예외가 발생한다.")
+	void 등급별_잔여좌석_조회_공연없음() {
+		// given
+		Long showScheduleId = 1L;
+		given(showScheduledRepository.findById(showScheduleId)).willReturn(Optional.empty());
+
+		// when
+		CustomException exception = assertThrows(
+			CustomException.class,
+			() -> ticketingInternalService.getRemainingSeats(showScheduleId)
+		);
+
+		// then
+		assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.INVALID_SHOW_SCHEDULE);
+		verifyNoInteractions(scheduledSeatRepository);
+	}
+
+	private TicketingInternalResponse.FlatRemainingSeatInfo flatRemainingSeatInfo(
+		String gradeName,
+		Long remainingSeatCount,
+		Long totalCount
+	) {
+		TicketingInternalResponse.FlatRemainingSeatInfo info =
+			mock(TicketingInternalResponse.FlatRemainingSeatInfo.class);
+		given(info.getGradeName()).willReturn(gradeName);
+		given(info.getRemainingSeatCount()).willReturn(remainingSeatCount);
+		given(info.getTotalCount()).willReturn(totalCount);
+		return info;
+	}
+}

--- a/ticketing/src/test/java/org/truve/platform/ticketing/service/ticketing/service/TicketingServiceTest.java
+++ b/ticketing/src/test/java/org/truve/platform/ticketing/service/ticketing/service/TicketingServiceTest.java
@@ -125,10 +125,9 @@ class TicketingServiceTest {
 		void 하트비트_성공() {
 			// given
 			given(ticketingProperties.getActiveWindowMs()).willReturn(30_000L);
-			given(ticketingProperties.getSessionTtlSec()).willReturn(300L);
 			given(ticketingRedisRepository.getSessionTokenValue(sessionToken))
 				.willReturn(SessionTicketValueDTO.of(userId, showScheduleId));
-			given(ticketingRedisRepository.refreshSessionTokenTtl(sessionToken, 300L)).willReturn(true);
+			given(ticketingRedisRepository.refreshSessionTokenTtl(sessionToken, 3600L)).willReturn(true);
 
 			// when
 			ticketingService.heartbeat(showScheduleId, userId, sessionToken);
@@ -197,10 +196,9 @@ class TicketingServiceTest {
 		void 하트비트_TTL연장실패() {
 			// given
 			given(ticketingProperties.getActiveWindowMs()).willReturn(30_000L);
-			given(ticketingProperties.getSessionTtlSec()).willReturn(300L);
 			given(ticketingRedisRepository.getSessionTokenValue(sessionToken))
 				.willReturn(SessionTicketValueDTO.of(userId, showScheduleId));
-			given(ticketingRedisRepository.refreshSessionTokenTtl(sessionToken, 300L)).willReturn(false);
+			given(ticketingRedisRepository.refreshSessionTokenTtl(sessionToken, 3600L)).willReturn(false);
 
 			// when
 			CustomException exception = assertThrows(
@@ -224,10 +222,9 @@ class TicketingServiceTest {
 		@BeforeEach
 		void setUpHoldSeat() {
 			given(ticketingProperties.getActiveWindowMs()).willReturn(30_000L);
-			given(ticketingProperties.getSessionTtlSec()).willReturn(300L);
 			given(ticketingRedisRepository.getSessionTokenValue(sessionToken))
 				.willReturn(SessionTicketValueDTO.of(userId, showScheduleId));
-			given(ticketingRedisRepository.refreshSessionTokenTtl(sessionToken, 300L)).willReturn(true);
+			given(ticketingRedisRepository.refreshSessionTokenTtl(sessionToken, 3600L)).willReturn(true);
 
 			showScheduled = ShowScheduled.builder()
 				.title("공연")
@@ -386,10 +383,9 @@ class TicketingServiceTest {
 		@BeforeEach
 		void setUpCancelHoldSeat() {
 			given(ticketingProperties.getActiveWindowMs()).willReturn(30_000L);
-			given(ticketingProperties.getSessionTtlSec()).willReturn(300L);
 			given(ticketingRedisRepository.getSessionTokenValue(sessionToken))
 				.willReturn(SessionTicketValueDTO.of(userId, showScheduleId));
-			given(ticketingRedisRepository.refreshSessionTokenTtl(sessionToken, 300L)).willReturn(true);
+			given(ticketingRedisRepository.refreshSessionTokenTtl(sessionToken, 3600L)).willReturn(true);
 		}
 
 		@Test
@@ -441,10 +437,9 @@ class TicketingServiceTest {
 		@BeforeEach
 		void setUpShow() {
 			given(ticketingProperties.getActiveWindowMs()).willReturn(30_000L);
-			given(ticketingProperties.getSessionTtlSec()).willReturn(300L);
 			given(ticketingRedisRepository.getSessionTokenValue(sessionToken))
 				.willReturn(SessionTicketValueDTO.of(userId, showScheduleId));
-			given(ticketingRedisRepository.refreshSessionTokenTtl(sessionToken, 300L)).willReturn(true);
+			given(ticketingRedisRepository.refreshSessionTokenTtl(sessionToken, 3600L)).willReturn(true);
 		}
 
 		@Test
@@ -465,7 +460,7 @@ class TicketingServiceTest {
 			// then
 			assertAll(
 				() -> assertThat(response.getTitle()).isEqualTo("지킬앤하이드"),
-				() -> assertThat(response.getVenueName()).isEqualTo("지킬앤하이드"),
+				() -> assertThat(response.getVenueName()).isEqualTo("블루스퀘어"),
 				() -> assertThat(response.getStartAt()).isEqualTo(startAt)
 			);
 		}
@@ -494,10 +489,9 @@ class TicketingServiceTest {
 		@BeforeEach
 		void setUpSeats() {
 			given(ticketingProperties.getActiveWindowMs()).willReturn(30_000L);
-			given(ticketingProperties.getSessionTtlSec()).willReturn(300L);
 			given(ticketingRedisRepository.getSessionTokenValue(sessionToken))
 				.willReturn(SessionTicketValueDTO.of(userId, showScheduleId));
-			given(ticketingRedisRepository.refreshSessionTokenTtl(sessionToken, 300L)).willReturn(true);
+			given(ticketingRedisRepository.refreshSessionTokenTtl(sessionToken, 3600L)).willReturn(true);
 		}
 
 		@Test


### PR DESCRIPTION
## 변경 사항

추가/변경 사항과 사유를 작성해 주세요.

- [x] 전체 테스트 코드 성공 여부
### TicketingInternalController, Service 추가 및 잔여 좌석 api 구현
Musical -> Ticketing으로 비동기 요청할 파일 추가했습니다.
Response 파일까지 분리했는데 폴더 내부가 지저분해지네요
/internal로 더 구분할 필요가 있을까 한번 고민해보겠습니다!

엔드포인트 uri를 /internal/ticketing으로 하면 좋겠다고 생각했는데
저희도 스웨거 보면 편하니까 스웨거 표시를 위해 지금처럼 엔드포인트 작성했습니다!
하단 스웨거 스크린샷처럼 명시해놓았습니다!

또한, 내부 요청 시 검증을 해야하나? 하는 의문이 생기는데
우선 저희 VPC 내부에서 통신 진행되니 심각하진 않다고 판단되어 열어두었습니다.
검즘용으로 헤더에 환경변수 사용해 UUID같은거 추가해도 좋을 것 같아요.


## 관련 이슈

- Notion Ticket: [#81](https://www.notion.so/api-32f9e3e335cc80db890bfbfecb2ae313?source=copy_link)

## 참고사항 (선택)

<img width="810" height="300" alt="image" src="https://github.com/user-attachments/assets/880c8f52-ffe4-40d6-8439-badb869663c7" />

@seungh22 
/api/ticketing/internal/{공연스케줄id}/remaining
RestClient 사용하셔서 요청하시고 응답 받으셔서 쓰시면 될 것 같아요!

스웨거에도 명시해놨습니다.

<img width="1507" height="903" alt="image" src="https://github.com/user-attachments/assets/991af506-e5aa-4f0d-be3b-0d60e2d8f065" />


