### PR TITLE
refactor: S3 클라이언트 의존성 제거 및 조회 방식 변경

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -209,10 +209,10 @@ services:
       - MUSICAL_MYSQL_URL=jdbc:mysql://db:3306/musical_db
       - MUSICAL_MYSQL_USERNAME=root
       - MUSICAL_MYSQL_PASSWORD=1234
-      - AWS_S3_BUCKET=truve-media
-      - AWS_REGION=us-east-1
-      - AWS_ACCESS_KEY=test
-      - AWS_SECRET_KEY=test
+      - AWS_S3_BUCKET=truve-dev-bucket
+      - AWS_REGION=ap-northeast-2
+      - AWS_ACCESS_KEY=${AWS_ACCESS_KEY}
+      - AWS_SECRET_KEY=${AWS_SECRET_KEY}
       - AWS_S3_ENDPOINT=http://localstack:4566
       - KAFKA_SERVERS=kafka:9092
     depends_on:

--- a/musical/build.gradle
+++ b/musical/build.gradle
@@ -15,7 +15,4 @@ dependencies {
 
     // [OpenApi]
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui'
-
-    // [AWS S3]
-    implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3:4.0.0'
 }

--- a/musical/src/main/java/com/truve/platform/musical/s3/S3Service.java
+++ b/musical/src/main/java/com/truve/platform/musical/s3/S3Service.java
@@ -8,12 +8,16 @@ import lombok.RequiredArgsConstructor;
 @Service
 @RequiredArgsConstructor
 public class S3Service {
-	@Value("${spring.cloud.aws.s3.endpoint}")
-	private String endpoint;
-	@Value("${spring.cloud.aws.s3.bucket}")
+	@Value("${s3.region}")
+	private String region;
+	@Value("${s3.bucket}")
 	private String bucketName;
 
 	public String getImageUrl(String fileName) {
-		return String.format("%s/%s/%s", endpoint, bucketName, fileName);
+		if (fileName == null || fileName.isEmpty()) {
+			return null;
+		}
+
+		return String.format("https://%s.s3.%s.amazonaws.com/%s", bucketName, region, fileName);
 	}
 }

--- a/musical/src/main/resources/application.yml
+++ b/musical/src/main/resources/application.yml
@@ -38,18 +38,9 @@ spring:
       key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
       value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
 
-  cloud:
-    aws:
-      s3:
-        bucket: ${AWS_S3_BUCKET:truve-media}
-        endpoint: ${AWS_S3_ENDPOINT:http://localstack:4566}
-      region:
-        static: ${AWS_REGION:us-east-1}
-      credentials:
-        access-key: ${AWS_ACCESS_KEY:test}
-        secret-key: ${AWS_SECRET_KEY:test}
-      stack:
-        auto: false
+s3:
+  bucket: ${AWS_S3_BUCKET:-truve-dev-bucket}
+  region: ${AWS_REGION:-ap-northeast-2}
 
 springdoc:
   api-docs:

--- a/musical/src/test/java/com/truve/platform/show/service/service/ArtistServiceTest.java
+++ b/musical/src/test/java/com/truve/platform/show/service/service/ArtistServiceTest.java
@@ -1,13 +1,9 @@
 package com.truve.platform.show.service.service;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -132,7 +128,8 @@ class ArtistServiceTest {
 		when(artist.getProfileImg()).thenReturn("artists/lee.png");
 		when(artistRepository.findDetailById(1L)).thenReturn(Optional.of(artist));
 		when(artistNoticeRepository.findNoticesByArtistId(1L)).thenReturn(List.of());
-		when(showCastingRepository.findCurrentShowsByArtistId(1L, any(LocalDateTime.class))).thenReturn(List.of(currentShow));
+		when(showCastingRepository.findCurrentShowsByArtistId(eq(1L), any(LocalDateTime.class))).thenReturn(
+			List.of(currentShow));
 		when(showCastingRepository.findPastShowsByArtistId(any(Long.class), any(LocalDateTime.class), any(Pageable.class)))
 			.thenReturn(new PageImpl<>(List.of(), PageRequest.of(0, 13), 0));
 		when(currentShow.getShowId()).thenReturn(10L);

--- a/musical/src/test/java/com/truve/platform/show/service/service/ShowServiceTest.java
+++ b/musical/src/test/java/com/truve/platform/show/service/service/ShowServiceTest.java
@@ -1,13 +1,8 @@
 package com.truve.platform.show.service.service;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -315,25 +310,25 @@ class ShowServiceTest {
 		when(artistLauren.getName()).thenReturn("허윤슬");
 
 		ShowCasting charlieCasting = org.mockito.Mockito.mock(ShowCasting.class);
-		when(charlieCasting.getId()).thenReturn(1001L);
+		lenient().when(charlieCasting.getId()).thenReturn(1001L);
 		when(charlieCasting.getRoleName()).thenReturn("찰리");
 		when(charlieCasting.getCastingOrder()).thenReturn(1);
 		when(charlieCasting.getArtist()).thenReturn(artistCharlie);
 
 		ShowCasting lolaCasting = org.mockito.Mockito.mock(ShowCasting.class);
-		when(lolaCasting.getId()).thenReturn(1002L);
+		lenient().when(lolaCasting.getId()).thenReturn(1002L);
 		when(lolaCasting.getRoleName()).thenReturn("롤라");
 		when(lolaCasting.getCastingOrder()).thenReturn(2);
 		when(lolaCasting.getArtist()).thenReturn(artistLola);
 
 		ShowCasting laurenCasting = org.mockito.Mockito.mock(ShowCasting.class);
-		when(laurenCasting.getId()).thenReturn(1003L);
+		lenient().when(laurenCasting.getId()).thenReturn(1003L);
 		when(laurenCasting.getRoleName()).thenReturn("로렌");
 		when(laurenCasting.getCastingOrder()).thenReturn(3);
 		when(laurenCasting.getArtist()).thenReturn(artistLauren);
 
 		ShowScheduleCasting sc1 = org.mockito.Mockito.mock(ShowScheduleCasting.class);
-		when(sc1.getShowSchedule()).thenReturn(schedule1);
+		lenient().when(sc1.getShowSchedule()).thenReturn(schedule1);
 		when(sc1.getShowCasting()).thenReturn(charlieCasting);
 
 		ShowScheduleCasting sc2 = org.mockito.Mockito.mock(ShowScheduleCasting.class);


### PR DESCRIPTION
## 변경 사항

---
S3 이미지 서버 링크 반영했습니다.
추후 S3 이미지 업로드 기능을 염두해 S3 연동 작업을 준비했었는데, 조회 기능만 있을 걸로 판단되어 의존성은 제거했습니다.

- [X] 전체 테스트 코드 성공 여부
: musical 서비스 test 작동하지 않는 부분 수정했습니다.

## 관련 이슈

---
- Notion Ticket: #

## 참고사항 (선택)

---