### PR TITLE
feat(auth): 탈퇴 유저 재가입 허용

### DIFF
--- a/auth-server/src/main/java/com/truve/platform/auth/service/domain/entity/User.java
+++ b/auth-server/src/main/java/com/truve/platform/auth/service/domain/entity/User.java
@@ -178,4 +178,25 @@ public class User extends BaseEntity {
 	public boolean isWithdrawn() {
 		return withdrawnAt != null;
 	}
+
+	public void reactivate(
+		String nickname,
+		String password,
+		boolean serviceTermsAgreed,
+		boolean electronicFinanceTermsAgreed,
+		boolean privacyCollectionAgreed,
+		boolean marketingInfoAgreed,
+		boolean emailNotificationAgreed,
+		boolean over14Agreed
+	) {
+		this.nickname = nickname;
+		this.password = password;
+		this.serviceTermsAgreed = serviceTermsAgreed;
+		this.electronicFinanceTermsAgreed = electronicFinanceTermsAgreed;
+		this.privacyCollectionAgreed = privacyCollectionAgreed;
+		this.marketingInfoAgreed = marketingInfoAgreed;
+		this.emailNotificationAgreed = emailNotificationAgreed;
+		this.over14Agreed = over14Agreed;
+		this.withdrawnAt = null;
+	}
 }

--- a/auth-server/src/main/java/com/truve/platform/auth/service/service/AuthService.java
+++ b/auth-server/src/main/java/com/truve/platform/auth/service/service/AuthService.java
@@ -1,5 +1,6 @@
 package com.truve.platform.auth.service.service;
 
+import java.time.LocalDateTime;
 import java.util.UUID;
 import java.util.regex.Pattern;
 
@@ -158,18 +159,39 @@ public class AuthService {
 		// String verifiedAt = emailVerificationRepository.isVerifiedEmail(email);
 		// Preconditions.validate(!(verifiedAt == null || verifiedAt.isBlank()), ErrorCode.NOT_VERIFIED_EMAIL);
 
+		User existingUser = userRepository.findByEmail(email).orElse(null);
+
 		Preconditions.validate(
-			!userRepository.existsByEmail(email),
+			// TODO: 최종 발표 이전에는 탈퇴 유저 즉시 재가입 허용
+			// TODO: 발표 전 1주일 재가입 제한 정책으로 변경
+			// isWithdrawnAfterWeek(existingUser)
+			existingUser == null || existingUser.isWithdrawn(),
 			ErrorCode.ALREADY_EXISTS_EMAIL
 		);
+
 		Preconditions.validate(
 			serviceTermsAgreed && electronicFinanceTermsAgreed && privacyCollectionAgreed && over14Agreed,
 			ErrorCode.REQUIRED_TERMS_NOT_AGREED
 		);
 
-		validateNickname(nickname, null);
+		validateNickname(nickname, existingUser != null ? existingUser.getNickname() : null);
 
 		String encodedPassword = passwordEncoder.encode(password);
+
+		if (existingUser != null && existingUser.isWithdrawn()) {
+			existingUser.reactivate(
+				nickname,
+				encodedPassword,
+				serviceTermsAgreed,
+				electronicFinanceTermsAgreed,
+				privacyCollectionAgreed,
+				marketingInfoAgreed,
+				false,
+				over14Agreed
+			);
+			emailVerificationRepository.deleteVerifiedEmail(email);
+			return;
+		}
 
 		User user = User.createLocalUser(
 			email,
@@ -230,5 +252,20 @@ public class AuthService {
 			ErrorCode.ALREADY_EXISTS_NICKNAME
 		);
 	}
+
+	private boolean isWithdrawnAfterWeek(User user) {
+		if (user == null) {
+			return false;
+		}
+
+		if (!user.isWithdrawn() || user.getWithdrawnAt() == null) {
+			return false;
+		}
+
+		return !user.getWithdrawnAt()
+			.plusWeeks(1)
+			.isAfter(LocalDateTime.now());
+	}
+
 
 }

--- a/auth-server/src/main/java/com/truve/platform/auth/service/service/AuthService.java
+++ b/auth-server/src/main/java/com/truve/platform/auth/service/service/AuthService.java
@@ -26,7 +26,7 @@ import lombok.RequiredArgsConstructor;
 @Service
 @RequiredArgsConstructor
 public class AuthService {
-	private static final Pattern NICKNAME_PATTERN = Pattern.compile("^[a-zA-Z0-9가-힣]{2,10}$");
+	private static final Pattern NICKNAME_PATTERN = Pattern.compile("^(?:[가-힣]{2,10}|[a-zA-Z]{2,16})$");
 
 	private final UserRepository userRepository;
 	private final EmailVerificationRepository emailVerificationRepository;

--- a/auth-server/src/test/java/com/truve/platform/auth/service/service/AuthServiceTest.java
+++ b/auth-server/src/test/java/com/truve/platform/auth/service/service/AuthServiceTest.java
@@ -161,6 +161,25 @@ class AuthServiceTest {
 		}
 
 		@Test
+		@DisplayName("영문 16자 닉네임이면 변경한다.")
+		void 닉네임변경_성공_영문16자() {
+			// given
+			String accessToken = "access-token";
+			String newNickname = "abcdefghijklmnop";
+			User user = createUser(1L, "user@test.com", "encoded");
+
+			given(jwtService.parsePublicId(accessToken)).willReturn(user.getPublicId());
+			given(userRepository.findByPublicId(user.getPublicId())).willReturn(java.util.Optional.of(user));
+			given(userRepository.existsByNickname(newNickname)).willReturn(false);
+
+			// when
+			authService.changeNickname(accessToken, newNickname);
+
+			// then
+			assertThat(user.getNickname()).isEqualTo(newNickname);
+		}
+
+		@Test
 		@DisplayName("현재 닉네임과 같으면 중복 조회 없이 유지한다.")
 		void 닉네임변경_성공_동일닉네임() {
 			// given
@@ -192,6 +211,27 @@ class AuthServiceTest {
 			CustomException exception = assertThrows(
 				CustomException.class,
 				() -> authService.changeNickname(accessToken, "a b")
+			);
+
+			// then
+			assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.INVALID_NICKNAME);
+			verify(userRepository, never()).existsByNickname(anyString());
+		}
+
+		@Test
+		@DisplayName("영문 17자 닉네임이면 예외가 발생한다.")
+		void 닉네임변경_실패_영문17자() {
+			// given
+			String accessToken = "access-token";
+			User user = createUser(1L, "user@test.com", "encoded");
+
+			given(jwtService.parsePublicId(accessToken)).willReturn(user.getPublicId());
+			given(userRepository.findByPublicId(user.getPublicId())).willReturn(java.util.Optional.of(user));
+
+			// when
+			CustomException exception = assertThrows(
+				CustomException.class,
+				() -> authService.changeNickname(accessToken, "abcdefghijklmnopq")
 			);
 
 			// then
@@ -870,6 +910,31 @@ class AuthServiceTest {
 			// then
 			assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.INVALID_NICKNAME);
 			verify(userRepository, never()).save(any(User.class));
+		}
+
+		@Test
+		@DisplayName("영문 16자 닉네임이면 회원가입에 성공한다.")
+		void 회원가입_성공_영문16자_닉네임() {
+			// given
+			String email = "english@test.com";
+			String password = "plain";
+			String englishNickname = "abcdefghijklmnop";
+
+			given(userRepository.findByEmail(email)).willReturn(Optional.empty());
+			given(userRepository.existsByNickname(englishNickname)).willReturn(false);
+			given(passwordEncoder.encode(password)).willReturn("encoded");
+			given(userRepository.save(any(User.class))).willAnswer(invocation -> {
+				User savedUser = invocation.getArgument(0);
+				ReflectionTestUtils.setField(savedUser, "id", 2L);
+				return savedUser;
+			});
+
+			// when
+			authService.signUp(email, englishNickname, password, true, true, true, false, true);
+
+			// then
+			verify(userRepository).save(any(User.class));
+			verify(userSignedUpEventPublisher).publish(anyString(), any());
 		}
 
 		@Test

--- a/auth-server/src/test/java/com/truve/platform/auth/service/service/AuthServiceTest.java
+++ b/auth-server/src/test/java/com/truve/platform/auth/service/service/AuthServiceTest.java
@@ -6,6 +6,7 @@ import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.*;
 
 import java.util.Date;
+import java.util.Optional;
 import java.util.UUID;
 
 import org.junit.jupiter.api.DisplayName;
@@ -702,10 +703,7 @@ class AuthServiceTest {
 			// given
 			String email = "new@test.com";
 			String password = "plain";
-			String verifiedAt = "1700000000000";
-
-			given(emailVerificationRepository.isVerifiedEmail(email)).willReturn(verifiedAt);
-			given(userRepository.existsByEmail(email)).willReturn(false);
+			given(userRepository.findByEmail(email)).willReturn(Optional.empty());
 			given(userRepository.existsByNickname(NICKNAME)).willReturn(false);
 			given(passwordEncoder.encode(password)).willReturn("encoded");
 			given(userRepository.save(any(User.class))).willAnswer(invocation -> {
@@ -746,19 +744,16 @@ class AuthServiceTest {
 			// given
 			String email = "new@test.com";
 			String password = "plain";
-
-			given(emailVerificationRepository.isVerifiedEmail(email)).willReturn("");
+			given(userRepository.findByEmail(email)).willReturn(Optional.empty());
+			given(userRepository.existsByNickname(NICKNAME)).willReturn(false);
+			given(passwordEncoder.encode(password)).willReturn("encoded");
+			given(userRepository.save(any(User.class))).willAnswer(invocation -> invocation.getArgument(0));
 
 			// when
-			CustomException exception = assertThrows(
-				CustomException.class,
-				() -> authService.signUp(email, NICKNAME, password, true, true, true, false, true)
-			);
+			authService.signUp(email, NICKNAME, password, true, true, true, false, true);
 
 			// then
-			assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.NOT_VERIFIED_EMAIL);
-			verify(userRepository, never()).save(any(User.class));
-			verify(userSignedUpEventPublisher, never()).publish(anyString(), any());
+			verify(userRepository).save(any(User.class));
 		}
 
 		@Test
@@ -767,9 +762,18 @@ class AuthServiceTest {
 			// given
 			String email = "dup@test.com";
 			String password = "plain";
-
-			given(emailVerificationRepository.isVerifiedEmail(email)).willReturn("1700000000000");
-			given(userRepository.existsByEmail(email)).willReturn(true);
+			User existingUser = User.createLocalUser(
+				email,
+				"existing",
+				"encoded-old",
+				true,
+				true,
+				true,
+				false,
+				false,
+				true
+			);
+			given(userRepository.findByEmail(email)).willReturn(Optional.of(existingUser));
 
 			// when
 			CustomException exception = assertThrows(
@@ -785,14 +789,54 @@ class AuthServiceTest {
 		}
 
 		@Test
+		@DisplayName("탈퇴한 유저는 즉시 재가입 처리된다.")
+		void 회원가입_성공_탈퇴유저_재가입() {
+			// given
+			String email = "withdrawn@test.com";
+			String password = "plain";
+			User withdrawnUser = User.createLocalUser(
+				email,
+				"oldnick",
+				"old-password",
+				true,
+				true,
+				true,
+				false,
+				false,
+				true
+			);
+			withdrawnUser.withdraw();
+
+			given(userRepository.findByEmail(email)).willReturn(Optional.of(withdrawnUser));
+			given(userRepository.existsByNickname(NICKNAME)).willReturn(false);
+			given(passwordEncoder.encode(password)).willReturn("encoded");
+
+			// when
+			authService.signUp(email, NICKNAME, password, true, true, true, false, true);
+
+			// then
+			assertAll(
+				() -> assertThat(withdrawnUser.isWithdrawn()).isFalse(),
+				() -> assertThat(withdrawnUser.getNickname()).isEqualTo(NICKNAME),
+				() -> assertThat(withdrawnUser.getPassword()).isEqualTo("encoded"),
+				() -> assertThat(withdrawnUser.isServiceTermsAgreed()).isTrue(),
+				() -> assertThat(withdrawnUser.isElectronicFinanceTermsAgreed()).isTrue(),
+				() -> assertThat(withdrawnUser.isPrivacyCollectionAgreed()).isTrue(),
+				() -> assertThat(withdrawnUser.isOver14Agreed()).isTrue()
+			);
+			verify(userRepository, never()).save(any(User.class));
+			verify(emailVerificationRepository).deleteVerifiedEmail(email);
+			verify(userSignedUpEventPublisher, never()).publish(anyString(), any());
+		}
+
+		@Test
 		@DisplayName("필수 약관에 동의하지 않으면 예외가 발생한다.")
 		void 회원가입_실패_필수_약관_미동의() {
 			// given
 			String email = "new@test.com";
 			String password = "plain";
 
-			given(emailVerificationRepository.isVerifiedEmail(email)).willReturn("1700000000000");
-			given(userRepository.existsByEmail(email)).willReturn(false);
+			given(userRepository.findByEmail(email)).willReturn(Optional.empty());
 
 			// when
 			CustomException exception = assertThrows(
@@ -815,8 +859,7 @@ class AuthServiceTest {
 			String email = "new@test.com";
 			String password = "plain";
 
-			given(emailVerificationRepository.isVerifiedEmail(email)).willReturn("1700000000000");
-			given(userRepository.existsByEmail(email)).willReturn(false);
+			given(userRepository.findByEmail(email)).willReturn(Optional.empty());
 
 			// when
 			CustomException exception = assertThrows(
@@ -836,8 +879,7 @@ class AuthServiceTest {
 			String email = "new@test.com";
 			String password = "plain";
 
-			given(emailVerificationRepository.isVerifiedEmail(email)).willReturn("1700000000000");
-			given(userRepository.existsByEmail(email)).willReturn(false);
+			given(userRepository.findByEmail(email)).willReturn(Optional.empty());
 			given(userRepository.existsByNickname(NICKNAME)).willReturn(true);
 
 			// when


### PR DESCRIPTION
## 변경 사항

추가/변경 사항과 사유를 작성해 주세요.

- [x] 전체 테스트 코드 성공 여부

### 탈퇴 유저 검증 이후 회원가입 허용
연동 편의를 위해 검증 주석처리 해놓았습니다.
최종발표 이전에 `Precondtion.validate()` 내부 변경하겠습니다!

### 닉네임 정책 한글 2-10자, 알파벳 2-16자 변경

## 관련 이슈

- Notion Ticket: [#83](https://www.notion.so/32f9e3e335cc80d4a78ff85e96cd851e?source=copy_link)

## 참고사항 (선택)
