### PR TITLE
fix: api-gateway 커스텀 헤더 주입 방식 변경

### DIFF
--- a/api-gateway/src/main/java/com/truve/platform/apigateway/authentication/JwtAuthenticationFilter.java
+++ b/api-gateway/src/main/java/com/truve/platform/apigateway/authentication/JwtAuthenticationFilter.java
@@ -31,13 +31,13 @@ public class JwtAuthenticationFilter extends AbstractGatewayFilterFactory {
 				return exchange.getResponse().setComplete();
 			}
 
-			token = token.substring(7);
+			String accessToken = token.substring(7);
 
 			SecretKey secretKey = jwtProperties.getSecretKey();
 			Claims claims = Jwts.parser()
 				.verifyWith(secretKey)
 				.build()
-				.parseSignedClaims(token)
+				.parseSignedClaims(accessToken)
 				.getPayload();
 
 			String jti = claims.getId();
@@ -60,9 +60,14 @@ public class JwtAuthenticationFilter extends AbstractGatewayFilterFactory {
 					.request(
 						exchange.getRequest()
 							.mutate()
-							.header("X-User-Id", userId)
-							.header("X-User-Role", role)
-							.header("X-Token", token)
+							.headers(headers -> {
+								headers.remove("X-User-Id");
+								headers.remove("X-User-Role");
+
+								headers.set("X-User-Id", userId);
+								headers.set("X-User-Role", role);
+								headers.set("X-Token", accessToken);
+							})
 							.build()
 					)
 					.build()


### PR DESCRIPTION
## 변경 사항

추가/변경 사항과 사유를 작성해 주세요.

- [x] 전체 테스트 코드 성공 여부

커스텀 헤더에 userId를 추가하는 방식이어서, 기존에 값이 있으면 헤더 값을 변경하지 않아
<img width="413" height="131" alt="image" src="https://github.com/user-attachments/assets/dbbad39a-da4b-49e9-b148-50dbef9aef68" />

요런 문제가 발생할 수도 있다고 합니다!
기존 헤더를 다시 다 지우고 api-gateway에서 다시 주입하는 방식으로 변경합니다.


## 관련 이슈

- Notion Ticket: #

## 참고사항 (선택)

보안팀 요구사항 해결합니다!
https://pain2value.slack.com/archives/C0A8LPH1Q79/p1774408328714139