### PR TITLE
feat(queue): 대기열 유저 퇴장 api 구현

### DIFF
--- a/queue/src/main/java/org/truve/platform/queue/service/queue/controller/QueueController.java
+++ b/queue/src/main/java/org/truve/platform/queue/service/queue/controller/QueueController.java
@@ -1,5 +1,6 @@
 package org.truve.platform.queue.service.queue.controller;
 
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -62,4 +63,12 @@ public class QueueController {
 		return ApiResult.ok(response);
 	}
 
+	@DeleteMapping("/{showId}/cancel")
+	public ApiResult<Void> cancel(
+		@PathVariable String showId,
+		@RequestHeader(value = USER_ID_HEADER, required = false) String userId
+	) {
+		queueService.cancel(showId, userId);
+		return ApiResult.ok();
+	}
 }

--- a/queue/src/main/java/org/truve/platform/queue/service/queue/repository/QueueRedisRepository.java
+++ b/queue/src/main/java/org/truve/platform/queue/service/queue/repository/QueueRedisRepository.java
@@ -75,6 +75,10 @@ public class QueueRedisRepository {
 		return redisSupport.zSetCount(key, minScore).orElse(0L);
 	}
 
+	public void removeQueueMember(String showId, String userId) {
+		redisSupport.zRem(showId, userId);
+	}
+
 	private static String waitKey(String showId) {
 		return WAIT_KEY_PREFIX + showId;
 	}
@@ -82,4 +86,5 @@ public class QueueRedisRepository {
 	private static String readyKey(String showId, String userId) {
 		return READY_KEY_PREFIX + showId + ":" + userId;
 	}
+
 }

--- a/queue/src/main/java/org/truve/platform/queue/service/queue/repository/QueueRedisRepository.java
+++ b/queue/src/main/java/org/truve/platform/queue/service/queue/repository/QueueRedisRepository.java
@@ -76,7 +76,7 @@ public class QueueRedisRepository {
 	}
 
 	public void removeQueueMember(String showId, String userId) {
-		redisSupport.zRem(showId, userId);
+		redisSupport.zRem(waitKey(showId), userId);
 	}
 
 	private static String waitKey(String showId) {

--- a/queue/src/main/java/org/truve/platform/queue/service/queue/service/QueueService.java
+++ b/queue/src/main/java/org/truve/platform/queue/service/queue/service/QueueService.java
@@ -25,6 +25,11 @@ public class QueueService {
 	private final JwtService jwtService;
 	private final QueuePollingPolicy queuePollingPolicy;
 
+	public void cancel(String showId, String userId) {
+		validateIds(showId, userId);
+		queueRedisRepository.removeQueueMember(showId, userId);
+	}
+
 	public void enter(String showId, String userId) {
 
 		validateIds(showId, userId);

--- a/queue/src/main/java/org/truve/platform/queue/service/queue/service/QueueService.java
+++ b/queue/src/main/java/org/truve/platform/queue/service/queue/service/QueueService.java
@@ -86,7 +86,7 @@ public class QueueService {
 	}
 
 
-	private void validateIds(String userId, String showId) {
+	private void validateIds(String showId, String userId) {
 		Preconditions.validate(StringUtils.hasText(showId), ErrorCode.INVALID_REQUEST_SHOW_ID);
 		Preconditions.validate(StringUtils.hasText(userId), ErrorCode.INVALID_REQUEST_USER_ID);
 	}

--- a/queue/src/main/java/org/truve/platform/queue/service/queue/service/QueueService.java
+++ b/queue/src/main/java/org/truve/platform/queue/service/queue/service/QueueService.java
@@ -27,8 +27,7 @@ public class QueueService {
 
 	public void enter(String showId, String userId) {
 
-		Preconditions.validate(StringUtils.hasText(showId), ErrorCode.INVALID_REQUEST_SHOW_ID);
-		Preconditions.validate(StringUtils.hasText(userId), ErrorCode.INVALID_REQUEST_USER_ID);
+		validateIds(showId, userId);
 
 		long now = System.currentTimeMillis();
 		queueRedisRepository.registerShow(showId);
@@ -37,8 +36,7 @@ public class QueueService {
 
 	public QueueResponse.Status status(String showId, String userId) {
 
-		Preconditions.validate(StringUtils.hasText(showId), ErrorCode.INVALID_REQUEST_SHOW_ID);
-		Preconditions.validate(StringUtils.hasText(userId), ErrorCode.INVALID_REQUEST_USER_ID);
+		validateIds(showId, userId);
 
 		var readyToken = queueRedisRepository.getReadyToken(showId, userId);
 		Long waitingUserCount = queueRedisRepository.getWaitingUserCount(showId);
@@ -80,6 +78,12 @@ public class QueueService {
 			queueRedisRepository.saveReadyToken(showId, userId, admissionToken, queueProperties.getReadyTtlSec());
 		}
 		return users.size();
+	}
+
+
+	private void validateIds(String userId, String showId) {
+		Preconditions.validate(StringUtils.hasText(showId), ErrorCode.INVALID_REQUEST_SHOW_ID);
+		Preconditions.validate(StringUtils.hasText(userId), ErrorCode.INVALID_REQUEST_USER_ID);
 	}
 
 }

--- a/queue/src/main/java/org/truve/platform/queue/service/queue/support/RedisSupport.java
+++ b/queue/src/main/java/org/truve/platform/queue/service/queue/support/RedisSupport.java
@@ -76,4 +76,8 @@ public class RedisSupport {
 		return Optional.ofNullable(redisTemplate.opsForZSet().count(key, minScore, Double.MAX_VALUE));
 	}
 
+	public void zRem(String key, String member) {
+		redisTemplate.opsForZSet().remove(key, member);
+	}
+
 }

--- a/queue/src/test/java/org/truve/platform/queue/service/queue/controller/QueueControllerTest.java
+++ b/queue/src/test/java/org/truve/platform/queue/service/queue/controller/QueueControllerTest.java
@@ -1,0 +1,72 @@
+package org.truve.platform.queue.service.queue.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.truve.platform.queue.service.common.constants.QueueStatus;
+import org.truve.platform.queue.service.common.response.ApiResult;
+import org.truve.platform.queue.service.queue.dto.QueueResponse;
+import org.truve.platform.queue.service.queue.service.QueueService;
+
+@ExtendWith(MockitoExtension.class)
+class QueueControllerTest {
+
+	@Mock
+	private QueueService queueService;
+
+	@InjectMocks
+	private QueueController queueController;
+
+	@Test
+	@DisplayName("대기열 진입 요청을 서비스에 위임하고 성공 응답을 반환한다.")
+	void 대기열_진입_성공() {
+		String showId = "1";
+		String userId = "user-1";
+
+		ApiResult<Void> response = queueController.enter(showId, userId);
+
+		verify(queueService).enter(showId, userId);
+		assertThat(response.getCode()).isEqualTo("ok");
+		assertThat(response.getMessage()).isEqualTo("성공");
+		assertThat(response.getData()).isNull();
+	}
+
+	@Test
+	@DisplayName("대기열 상태 조회 요청을 서비스에 위임하고 응답을 반환한다.")
+	void 대기열_상태조회_성공() {
+		String showId = "1";
+		String userId = "user-1";
+		QueueResponse.Status status = QueueResponse.Status.wait(5L, 20L, 1500L);
+
+		given(queueService.status(showId, userId)).willReturn(status);
+
+		ApiResult<QueueResponse.Status> response = queueController.status(showId, userId);
+
+		verify(queueService).status(showId, userId);
+		assertThat(response.getCode()).isEqualTo("ok");
+		assertThat(response.getMessage()).isEqualTo("성공");
+		assertThat(response.getData()).isEqualTo(status);
+		assertThat(response.getData().getStatus()).isEqualTo(QueueStatus.WAITING);
+	}
+
+	@Test
+	@DisplayName("대기열 취소 요청을 서비스에 위임하고 성공 응답을 반환한다.")
+	void 대기열_취소_성공() {
+		String showId = "1";
+		String userId = "user-1";
+
+		ApiResult<Void> response = queueController.cancel(showId, userId);
+
+		verify(queueService).cancel(showId, userId);
+		assertThat(response.getCode()).isEqualTo("ok");
+		assertThat(response.getMessage()).isEqualTo("성공");
+		assertThat(response.getData()).isNull();
+	}
+}

--- a/queue/src/test/java/org/truve/platform/queue/service/queue/service/QueueServiceTest.java
+++ b/queue/src/test/java/org/truve/platform/queue/service/queue/service/QueueServiceTest.java
@@ -1,0 +1,139 @@
+package org.truve.platform.queue.service.queue.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.truve.platform.queue.service.common.constants.QueueStatus;
+import org.truve.platform.queue.service.common.exception.CustomException;
+import org.truve.platform.queue.service.common.exception.ErrorCode;
+import org.truve.platform.queue.service.queue.config.QueueProperties;
+import org.truve.platform.queue.service.queue.dto.QueueResponse;
+import org.truve.platform.queue.service.queue.jwt.JwtService;
+import org.truve.platform.queue.service.queue.repository.QueueRedisRepository;
+
+@ExtendWith(MockitoExtension.class)
+class QueueServiceTest {
+
+	@Mock
+	private QueueRedisRepository queueRedisRepository;
+
+	@Mock
+	private QueueProperties queueProperties;
+
+	@Mock
+	private JwtService jwtService;
+
+	@Mock
+	private QueuePollingPolicy queuePollingPolicy;
+
+	@InjectMocks
+	private QueueService queueService;
+
+	@Nested
+	@DisplayName("대기열 퇴장 테스트")
+	class CancelTest {
+
+		@Test
+		@DisplayName("showId와 userId가 유효하면 대기열에서 제거한다.")
+		void 대기열_퇴장_성공() {
+			String showId = "1";
+			String userId = "user-1";
+
+			queueService.cancel(showId, userId);
+
+			verify(queueRedisRepository).removeQueueMember(showId, userId);
+		}
+
+		@Test
+		@DisplayName("showId가 비어 있으면 예외가 발생한다.")
+		void 대기열_퇴장_실패_잘못된_공연() {
+			CustomException exception = assertThrows(CustomException.class,
+				() -> queueService.cancel("", "user-1"));
+
+			assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.INVALID_REQUEST_SHOW_ID);
+			verify(queueRedisRepository, never()).removeQueueMember("","user-1");
+		}
+
+		@Test
+		@DisplayName("userId가 비어 있으면 예외가 발생한다.")
+		void 대기열_퇴장_실패_잘못된_유저() {
+			CustomException exception = assertThrows(CustomException.class,
+				() -> queueService.cancel("1", ""));
+
+			assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.INVALID_REQUEST_USER_ID);
+			verify(queueRedisRepository, never()).removeQueueMember("1","");
+		}
+	}
+
+	@Nested
+	@DisplayName("대기열 상태 조회 테스트")
+	class StatusTest {
+
+		@Test
+		@DisplayName("ready 토큰이 있으면 READY 상태를 반환한다.")
+		void 대기열_상태조회_ready_성공() {
+			String showId = "1";
+			String userId = "user-1";
+
+			given(queueRedisRepository.getReadyToken(showId, userId)).willReturn(Optional.of("ready-token"));
+			given(queueRedisRepository.getWaitingUserCount(showId)).willReturn(10L);
+			given(queueRedisRepository.getReadyTokenTtlSec(showId, userId)).willReturn(Optional.of(30L));
+			given(queuePollingPolicy.forReady()).willReturn(1000L);
+
+			QueueResponse.Status response = queueService.status(showId, userId);
+
+			assertThat(response.getStatus()).isEqualTo(QueueStatus.READY);
+			assertThat(response.getAdmissionToken()).isEqualTo("ready-token");
+			assertThat(response.getExpireTime()).isEqualTo(30L);
+			assertThat(response.getWaitingUserCount()).isEqualTo(10L);
+			assertThat(response.getPollingMs()).isEqualTo(1000L);
+		}
+
+		@Test
+		@DisplayName("대기열 순번이 있으면 WAITING 상태를 반환한다.")
+		void 대기열_상태조회_waiting_성공() {
+			String showId = "1";
+			String userId = "user-1";
+
+			given(queueRedisRepository.getReadyToken(showId, userId)).willReturn(Optional.empty());
+			given(queueRedisRepository.getWaitingUserCount(showId)).willReturn(25L);
+			given(queueRedisRepository.getRank(showId, userId)).willReturn(Optional.of(7L));
+			given(queuePollingPolicy.forWaiting(7L)).willReturn(1500L);
+
+			QueueResponse.Status response = queueService.status(showId, userId);
+
+			assertThat(response.getStatus()).isEqualTo(QueueStatus.WAITING);
+			assertThat(response.getRank()).isEqualTo(7L);
+			assertThat(response.getWaitingUserCount()).isEqualTo(25L);
+			assertThat(response.getPollingMs()).isEqualTo(1500L);
+		}
+
+		@Test
+		@DisplayName("대기열 정보가 없으면 예외가 발생한다.")
+		void 대기열_상태조회_실패_입장정보없음() {
+			String showId = "1";
+			String userId = "user-1";
+
+			given(queueRedisRepository.getReadyToken(showId, userId)).willReturn(Optional.empty());
+			given(queueRedisRepository.getWaitingUserCount(showId)).willReturn(0L);
+			given(queueRedisRepository.getRank(showId, userId)).willReturn(Optional.empty());
+
+			CustomException exception = assertThrows(CustomException.class,
+				() -> queueService.status(showId, userId));
+
+			assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.QUEUE_ENTRY_NOT_FOUND);
+		}
+	}
+}


### PR DESCRIPTION
## 변경 사항

추가/변경 사항과 사유를 작성해 주세요.

대기열에서 진입한 유저 취소 api입니다. 
티켓팅 과정에서 취소한 유저까지 한번에 작업하다 양이 꽤 커져 분리해서 적용합니다.

다음 작업으로 티켓팅 화면에서 나갈 시 
AdmissionToken, SessionToken 만료, `ticket:active:{showId}` 키 만료, `queue:ready:{userId}` 키 만료 
동시에 작업해서 올리겠습니다.

- [x] 전체 테스트 코드 성공 여부

## 관련 이슈

- Notion Ticket: # 86

## 참고사항 (선택)

---