### PR TITLE
feat(gateway): LoggingFilter 추가 및 로그 Kafka 전송 구현

### DIFF
--- a/api-gateway/build.gradle
+++ b/api-gateway/build.gradle
@@ -14,6 +14,9 @@ dependencies {
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.13.0'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.13.0'
 
+    // [Kafka]
+    implementation 'org.springframework.boot:spring-boot-starter-kafka'
+
     // [DB - Redis]
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     testImplementation 'org.springframework.boot:spring-boot-starter-data-redis-test'

--- a/api-gateway/src/main/java/com/truve/platform/apigateway/logging/LoggingFilter.java
+++ b/api-gateway/src/main/java/com/truve/platform/apigateway/logging/LoggingFilter.java
@@ -25,7 +25,7 @@ import reactor.core.publisher.Mono;
 @RequiredArgsConstructor
 public class LoggingFilter implements WebFilter, Ordered {
 
-	private static final String TOPIC = "gateway-log";
+	private static final String TOPIC = "raw.gateway";
 	private final KafkaTemplate<String, String> kafkaTemplate;
 
 	private static final List<String> EXCLUDE_PATHS = List.of(

--- a/api-gateway/src/main/java/com/truve/platform/apigateway/logging/LoggingFilter.java
+++ b/api-gateway/src/main/java/com/truve/platform/apigateway/logging/LoggingFilter.java
@@ -30,7 +30,6 @@ public class LoggingFilter implements WebFilter, Ordered {
 
 	private static final List<String> EXCLUDE_PATHS = List.of(
 		"/api/auth",
-		"/api/musical",
 		"/swagger-ui",
 		"/v3/api-docs",
 		"/api/auth/v3/api-docs",

--- a/api-gateway/src/main/java/com/truve/platform/apigateway/logging/LoggingFilter.java
+++ b/api-gateway/src/main/java/com/truve/platform/apigateway/logging/LoggingFilter.java
@@ -9,22 +9,30 @@ import org.springframework.core.io.buffer.DataBuffer;
 import org.springframework.core.io.buffer.DataBufferUtils;
 import org.springframework.http.server.reactive.ServerHttpRequest;
 import org.springframework.http.server.reactive.ServerHttpRequestDecorator;
+import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Component;
 import org.springframework.web.server.ServerWebExchange;
 import org.springframework.web.server.WebFilter;
 import org.springframework.web.server.WebFilterChain;
 
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 @Slf4j
 @Component
+@RequiredArgsConstructor
 public class LoggingFilter implements WebFilter, Ordered {
+
+	private static final String TOPIC = "gateway-log";
+	private final KafkaTemplate<String, String> kafkaTemplate;
+
 	private static final List<String> EXCLUDE_PATHS = List.of(
 		"/api/auth",
 		"/api/musical",
 		"/swagger-ui",
+		"/v3/api-docs",
 		"/api/auth/v3/api-docs",
 		"/api/payments/v3/api-docs",
 		"/api/queue/v3/api-docs",
@@ -76,15 +84,18 @@ public class LoggingFilter implements WebFilter, Ordered {
 
 	private void saveLog(RequestContext ctx) {
 		if (ctx.path.startsWith("/telemetry")) {
-			log.info("[TELEMETRY]",
+			log.info("",
+				kv("type", "TELEMETRY"),
 				kv("tsServer", ctx.tsServer),
 				kv("userId", ctx.userId),
 				raw("requestBody", ctx.requestBody)
 			);
+			sendToKafka(ctx);
 			return;
 		}
 
-		log.info("[REQUEST]",
+		log.info("",
+			kv("type", "REQUEST"),
 			kv("tsServer", ctx.tsServer),
 			kv("method", ctx.method),
 			kv("path", ctx.path),
@@ -94,6 +105,11 @@ public class LoggingFilter implements WebFilter, Ordered {
 			kv("statusCode", ctx.statusCode),
 			raw("requestBody", ctx.requestBody)
 		);
+		sendToKafka(ctx);
+	}
+
+	private void sendToKafka(RequestContext ctx) {
+		kafkaTemplate.send(TOPIC, ctx.toJson());
 	}
 
 	@Override

--- a/api-gateway/src/main/java/com/truve/platform/apigateway/logging/LoggingFilter.java
+++ b/api-gateway/src/main/java/com/truve/platform/apigateway/logging/LoggingFilter.java
@@ -1,0 +1,103 @@
+package com.truve.platform.apigateway.logging;
+
+import static net.logstash.logback.argument.StructuredArguments.*;
+
+import java.util.List;
+
+import org.springframework.core.Ordered;
+import org.springframework.core.io.buffer.DataBuffer;
+import org.springframework.core.io.buffer.DataBufferUtils;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.http.server.reactive.ServerHttpRequestDecorator;
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ServerWebExchange;
+import org.springframework.web.server.WebFilter;
+import org.springframework.web.server.WebFilterChain;
+
+import lombok.extern.slf4j.Slf4j;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+@Slf4j
+@Component
+public class LoggingFilter implements WebFilter, Ordered {
+	private static final List<String> EXCLUDE_PATHS = List.of(
+		"/api/auth",
+		"/api/musical",
+		"/swagger-ui",
+		"/api/auth/v3/api-docs",
+		"/api/payments/v3/api-docs",
+		"/api/queue/v3/api-docs",
+		"/api/ticketing/v3/api-docs",
+		"/api/musical/v3/api-docs"
+	);
+
+	@Override
+	public Mono<Void> filter(ServerWebExchange exchange, WebFilterChain chain) {
+		String path = exchange.getRequest().getPath().value();
+
+		if (EXCLUDE_PATHS.stream().anyMatch(path::startsWith)) {
+			return chain.filter(exchange);
+		}
+
+		return readBody(exchange)
+			.flatMap(body -> {
+				RequestContext ctx = RequestContext.from(exchange, body);
+				return chain.filter(rebuildExchange(exchange, body))
+					.then(Mono.fromRunnable(() -> {
+						Integer status = exchange.getResponse().getStatusCode() != null
+							? exchange.getResponse().getStatusCode().value()
+							: null;
+						saveLog(ctx.toBuilder().statusCode(status).build());
+					}));
+			});
+	}
+
+	private Mono<byte[]> readBody(ServerWebExchange exchange) {
+		return DataBufferUtils.join(exchange.getRequest().getBody())
+			.defaultIfEmpty(exchange.getResponse().bufferFactory().wrap(new byte[0]))
+			.map(dataBuffer -> {
+				byte[] bytes = new byte[dataBuffer.readableByteCount()];
+				dataBuffer.read(bytes);
+				DataBufferUtils.release(dataBuffer);
+				return bytes;
+			});
+	}
+
+	private ServerWebExchange rebuildExchange(ServerWebExchange exchange, byte[] body) {
+		ServerHttpRequest mutatedRequest = new ServerHttpRequestDecorator(exchange.getRequest()) {
+			@Override
+			public Flux<DataBuffer> getBody() {
+				return Flux.just(exchange.getResponse().bufferFactory().wrap(body));
+			}
+		};
+		return exchange.mutate().request(mutatedRequest).build();
+	}
+
+	private void saveLog(RequestContext ctx) {
+		if (ctx.path.startsWith("/telemetry")) {
+			log.info("[TELEMETRY]",
+				kv("tsServer", ctx.tsServer),
+				kv("userId", ctx.userId),
+				raw("requestBody", ctx.requestBody)
+			);
+			return;
+		}
+
+		log.info("[REQUEST]",
+			kv("tsServer", ctx.tsServer),
+			kv("method", ctx.method),
+			kv("path", ctx.path),
+			kv("userId", ctx.userId),
+			kv("sessionTicket", ctx.sessionTicket),
+			kv("queryParams", ctx.queryParams),
+			kv("statusCode", ctx.statusCode),
+			raw("requestBody", ctx.requestBody)
+		);
+	}
+
+	@Override
+	public int getOrder() {
+		return Ordered.HIGHEST_PRECEDENCE;
+	}
+}

--- a/api-gateway/src/main/java/com/truve/platform/apigateway/logging/LoggingFilter.java
+++ b/api-gateway/src/main/java/com/truve/platform/apigateway/logging/LoggingFilter.java
@@ -88,7 +88,7 @@ public class LoggingFilter implements WebFilter, Ordered {
 				kv("type", "TELEMETRY"),
 				kv("tsServer", ctx.tsServer),
 				kv("userId", ctx.userId),
-				raw("requestBody", ctx.requestBody)
+				kv("requestBody", ctx.requestBody)
 			);
 			sendToKafka(ctx);
 			return;
@@ -103,7 +103,7 @@ public class LoggingFilter implements WebFilter, Ordered {
 			kv("sessionTicket", ctx.sessionTicket),
 			kv("queryParams", ctx.queryParams),
 			kv("statusCode", ctx.statusCode),
-			raw("requestBody", ctx.requestBody)
+			kv("requestBody", ctx.requestBody)
 		);
 		sendToKafka(ctx);
 	}

--- a/api-gateway/src/main/java/com/truve/platform/apigateway/logging/LoggingFilter.java
+++ b/api-gateway/src/main/java/com/truve/platform/apigateway/logging/LoggingFilter.java
@@ -89,7 +89,7 @@ public class LoggingFilter implements WebFilter, Ordered {
 				kv("userId", ctx.userId),
 				kv("requestBody", ctx.requestBody)
 			);
-			sendToKafka(ctx);
+			//sendToKafka(ctx);
 			return;
 		}
 
@@ -104,9 +104,10 @@ public class LoggingFilter implements WebFilter, Ordered {
 			kv("statusCode", ctx.statusCode),
 			kv("requestBody", ctx.requestBody)
 		);
-		sendToKafka(ctx);
+		//sendToKafka(ctx);
 	}
 
+	@Deprecated
 	private void sendToKafka(RequestContext ctx) {
 		kafkaTemplate.send(TOPIC, ctx.toJson());
 	}

--- a/api-gateway/src/main/java/com/truve/platform/apigateway/logging/RequestContext.java
+++ b/api-gateway/src/main/java/com/truve/platform/apigateway/logging/RequestContext.java
@@ -5,18 +5,25 @@ import java.util.Map;
 
 import org.springframework.web.server.ServerWebExchange;
 
+import com.fasterxml.jackson.annotation.JsonRawValue;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import lombok.Builder;
 import lombok.Getter;
 
 @Getter
 @Builder(toBuilder = true)
 public class RequestContext {
+
+	private static final ObjectMapper MAPPER = new ObjectMapper();
+
 	long tsServer;
 	String method;
 	String path;
 	String userId;
 	String sessionTicket;
 	Map<String, String> queryParams;
+	@JsonRawValue
 	String requestBody;
 	Integer statusCode;
 
@@ -30,6 +37,14 @@ public class RequestContext {
 			.queryParams(exchange.getRequest().getQueryParams().toSingleValueMap())
 			.requestBody(parseBody(body))
 			.build();
+	}
+
+	public String toJson() {
+		try {
+			return MAPPER.writeValueAsString(this);
+		} catch (Exception e) {
+			return "{}";
+		}
 	}
 
 	private static String parseBody(byte[] body) {

--- a/api-gateway/src/main/java/com/truve/platform/apigateway/logging/RequestContext.java
+++ b/api-gateway/src/main/java/com/truve/platform/apigateway/logging/RequestContext.java
@@ -1,11 +1,10 @@
 package com.truve.platform.apigateway.logging;
 
-import java.nio.charset.StandardCharsets;
 import java.util.Map;
 
 import org.springframework.web.server.ServerWebExchange;
 
-import com.fasterxml.jackson.annotation.JsonRawValue;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import lombok.Builder;
@@ -23,8 +22,7 @@ public class RequestContext {
 	String userId;
 	String sessionTicket;
 	Map<String, String> queryParams;
-	@JsonRawValue
-	String requestBody;
+	JsonNode requestBody;
 	Integer statusCode;
 
 	public static RequestContext from(ServerWebExchange exchange, byte[] body) {
@@ -47,11 +45,12 @@ public class RequestContext {
 		}
 	}
 
-	private static String parseBody(byte[] body) {
-		if (body.length == 0)
-			return "{}";
-		return new String(body, StandardCharsets.UTF_8)
-			.replaceAll("\\s+", " ")
-			.trim();
+	private static JsonNode parseBody(byte[] body) {
+		try {
+			if (body.length == 0) return MAPPER.createObjectNode();
+			return MAPPER.readTree(body);
+		} catch (Exception e) {
+			return MAPPER.createObjectNode();
+		}
 	}
 }

--- a/api-gateway/src/main/java/com/truve/platform/apigateway/logging/RequestContext.java
+++ b/api-gateway/src/main/java/com/truve/platform/apigateway/logging/RequestContext.java
@@ -1,0 +1,42 @@
+package com.truve.platform.apigateway.logging;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+import org.springframework.web.server.ServerWebExchange;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder(toBuilder = true)
+public class RequestContext {
+	long tsServer;
+	String method;
+	String path;
+	String userId;
+	String sessionTicket;
+	Map<String, String> queryParams;
+	String requestBody;
+	Integer statusCode;
+
+	public static RequestContext from(ServerWebExchange exchange, byte[] body) {
+		return RequestContext.builder()
+			.tsServer(System.currentTimeMillis())
+			.method(exchange.getRequest().getMethod().name())
+			.path(exchange.getRequest().getPath().value())
+			.userId(exchange.getRequest().getHeaders().getFirst("X-User-Id"))
+			.sessionTicket(exchange.getRequest().getHeaders().getFirst("X-Session-Ticket"))
+			.queryParams(exchange.getRequest().getQueryParams().toSingleValueMap())
+			.requestBody(parseBody(body))
+			.build();
+	}
+
+	private static String parseBody(byte[] body) {
+		if (body.length == 0)
+			return "{}";
+		return new String(body, StandardCharsets.UTF_8)
+			.replaceAll("\\s+", " ")
+			.trim();
+	}
+}

--- a/api-gateway/src/main/java/com/truve/platform/apigateway/logging/TelemetryController.java
+++ b/api-gateway/src/main/java/com/truve/platform/apigateway/logging/TelemetryController.java
@@ -1,0 +1,16 @@
+package com.truve.platform.apigateway.logging;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/telemetry")
+public class TelemetryController {
+
+	@PostMapping
+	public ResponseEntity<Void> receive() {
+		return ResponseEntity.ok().build();
+	}
+}


### PR DESCRIPTION
## 변경 사항

---
### API Gateway 로깅 추가

- auth, musical 서버의 요청은 로그를 남기지 않습니다. (비밀번호 노출 방지 및 단순 조회 요청 제외)
- 프론트에서 수집한 변수를 전송하는 API `/telemetry`를 추가했습니다. 

<img width="923" height="235" alt="image" src="https://github.com/user-attachments/assets/b26b3790-6ed2-4c28-ae77-c394c39c4b71" />

요청의 경우 `"type":"REQUEST"`, 프론트 변수의 경우 `"type":"TELEMETRY"`으로 전송됩니다.
 

- [X] 전체 테스트 코드 성공 여부

## 관련 이슈

---
- Notion Ticket: #

## 참고사항 (선택)

---