### PR TITLE
feat(gateway):JWT 정보 추출 필터 추가

### DIFF
--- a/api-gateway/src/main/java/com/truve/platform/apigateway/authentication/JwtAuthenticationFilter.java
+++ b/api-gateway/src/main/java/com/truve/platform/apigateway/authentication/JwtAuthenticationFilter.java
@@ -55,6 +55,8 @@ public class JwtAuthenticationFilter extends AbstractGatewayFilterFactory {
 				return exchange.getResponse().setComplete();
 			}
 
+			exchange.getAttributes().put("userId", userId);
+
 			return chain.filter(
 				exchange.mutate()
 					.request(

--- a/api-gateway/src/main/java/com/truve/platform/apigateway/authentication/JwtExtractionFilter.java
+++ b/api-gateway/src/main/java/com/truve/platform/apigateway/authentication/JwtExtractionFilter.java
@@ -1,0 +1,72 @@
+package com.truve.platform.apigateway.authentication;
+
+import javax.crypto.SecretKey;
+
+import org.springframework.cloud.gateway.filter.GatewayFilter;
+import org.springframework.cloud.gateway.filter.factory.AbstractGatewayFilterFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Component
+public class JwtExtractionFilter extends AbstractGatewayFilterFactory {
+
+	private final JwtProperties jwtProperties;
+
+	@Override
+	public GatewayFilter apply(Object config) {
+		return (exchange, chain) -> {
+			String token = exchange.getRequest()
+				.getHeaders()
+				.getFirst("Authorization");
+
+			if (token == null || !token.startsWith("Bearer ")) {
+				return chain.filter(exchange);
+			}
+
+			try {
+				String accessToken = token.substring(7);
+				SecretKey secretKey = jwtProperties.getSecretKey();
+				Claims claims = Jwts.parser()
+					.verifyWith(secretKey)
+					.build()
+					.parseSignedClaims(accessToken)
+					.getPayload();
+
+				String userId = claims.get("user_public_id", String.class);
+				String role = claims.get("role", String.class);
+				String tokenType = claims.get("token_type", String.class);
+
+				if (!"access".equals(tokenType) || !StringUtils.hasText(tokenType)) {
+					return chain.filter(exchange);
+				}
+
+				exchange.getAttributes().put("userId", userId);
+
+				return chain.filter(
+					exchange.mutate()
+						.request(
+							exchange.getRequest()
+								.mutate()
+								.headers(headers -> {
+									headers.remove("X-User-Id");
+									headers.remove("X-User-Role");
+
+									headers.set("X-User-Id", userId);
+									headers.set("X-User-Role", role);
+									headers.set("X-Token", accessToken);
+								})
+								.build()
+						)
+						.build()
+				);
+			} catch (Exception e) {
+				return chain.filter(exchange);
+			}
+		};
+	}
+}

--- a/api-gateway/src/main/java/com/truve/platform/apigateway/logging/LoggingFilter.java
+++ b/api-gateway/src/main/java/com/truve/platform/apigateway/logging/LoggingFilter.java
@@ -55,7 +55,8 @@ public class LoggingFilter implements WebFilter, Ordered {
 						Integer status = exchange.getResponse().getStatusCode() != null
 							? exchange.getResponse().getStatusCode().value()
 							: null;
-						saveLog(ctx.toBuilder().statusCode(status).build());
+						String userId = exchange.getAttribute("userId");
+						saveLog(ctx.toBuilder().statusCode(status).userId(userId).build());
 					}));
 			});
 	}

--- a/api-gateway/src/main/java/com/truve/platform/apigateway/logging/RequestContext.java
+++ b/api-gateway/src/main/java/com/truve/platform/apigateway/logging/RequestContext.java
@@ -30,7 +30,6 @@ public class RequestContext {
 			.tsServer(System.currentTimeMillis())
 			.method(exchange.getRequest().getMethod().name())
 			.path(exchange.getRequest().getPath().value())
-			.userId(exchange.getRequest().getHeaders().getFirst("X-User-Id"))
 			.sessionTicket(exchange.getRequest().getHeaders().getFirst("X-Session-Ticket"))
 			.queryParams(exchange.getRequest().getQueryParams().toSingleValueMap())
 			.requestBody(parseBody(body))

--- a/api-gateway/src/main/resources/application.yml
+++ b/api-gateway/src/main/resources/application.yml
@@ -76,12 +76,16 @@ spring:
               uri: ${AUTH_SERVER_URI:http://localhost:8081}
               predicates:
                 - Path=/api/auth/**
+              filters:
+                - JwtExtractionFilter
 
             # 2. payment
             - id: payment
               uri: ${PAYMENT_SERVER_URI:http://localhost:8082}
               predicates:
                 - Path=/api/payments/**
+              filters:
+                - JwtAuthenticationFilter
             - id: payment-webhook
               uri: ${PAYMENT_SERVER_URI:http://localhost:8082}
               predicates:
@@ -108,6 +112,8 @@ spring:
               uri: ${TICKETING_SERVER_URI:http://localhost:8084}
               predicates:
                 - Path=/api/bookings/**
+              filters:
+                - JwtExtractionFilter
 
             # 6. review
             - id: review-protected
@@ -121,6 +127,8 @@ spring:
               uri: ${MUSICAL_SERVER_URI:http://localhost:8085}
               predicates:
                 - Path=/api/musical/reviews/**
+              filters:
+                - JwtExtractionFilter
 
             # 7. artist
             - id: artist-protected
@@ -134,12 +142,16 @@ spring:
               uri: ${MUSICAL_SERVER_URI:http://localhost:8085}
               predicates:
                 - Path=/api/musical/artists/**
+              filters:
+                - JwtExtractionFilter
 
             # 8. musical
             - id: musical
               uri: ${MUSICAL_SERVER_URI:http://localhost:8085}
               predicates:
                 - Path=/api/musical/**
+              filters:
+                - JwtExtractionFilter
 
 
 


### PR DESCRIPTION
## 변경 사항

---
- 헤더에 인증 정보가 존재하는 요청일 경우, 유저 정보를 추출하는 필터 `JwtExtractionFilter`를 추가했습니다 (인증인가 X 추출만 합니다)

- `api-gateway/application.yml`에서 인증이 필요한 경로인 경우 `JwtAuthenticationFilter`를, 그 외엔 `JwtExtractionFilter`를 적용하도록 변경했습니다.

- `LoggingFilter`에서 userId를 추출하기 위해 각 필터에서 요청 attribute에 userId를 저장하는 과정을 추가했습니다.
: 원래 요청 헤더 X-User-Id에서 추출했는데, 이게 JwtFilter 동작 전에 수행되어 항상 null값이라 의미가 없다는 점을 알아버려서 개선했습니다..

- [X] 전체 테스트 코드 성공 여부

## 관련 이슈

---
- Notion Ticket: #

## 참고사항 (선택)

---
`api-gateway/application.yml`에서 라우팅할 때 필터가 적절히 적용되었는지 검토 부탁드립니다!
로그인한 사용자만 접근해야 하는 경우엔 `JwtAuthenticationFilter`, 로그인하지 않아도 접근 가능한 경우엔 `JwtExtractionFilter`입니다!!