### PR TITLE
fix: 연동 편의성을 위해 진행했던 주석처리 원상복구

### DIFF
--- a/auth-server/src/main/java/com/truve/platform/auth/service/service/AuthService.java
+++ b/auth-server/src/main/java/com/truve/platform/auth/service/service/AuthService.java
@@ -154,18 +154,13 @@ public class AuthService {
 		boolean marketingInfoAgreed,
 		boolean over14Agreed
 	) {
-
-		// TODO: 프론트 연동 이후 이메일 인증 검증 로직 주석 해제
-		// String verifiedAt = emailVerificationRepository.isVerifiedEmail(email);
-		// Preconditions.validate(!(verifiedAt == null || verifiedAt.isBlank()), ErrorCode.NOT_VERIFIED_EMAIL);
+		String verifiedAt = emailVerificationRepository.isVerifiedEmail(email);
+		Preconditions.validate(!(verifiedAt == null || verifiedAt.isBlank()), ErrorCode.NOT_VERIFIED_EMAIL);
 
 		User existingUser = userRepository.findByEmail(email).orElse(null);
 
 		Preconditions.validate(
-			// TODO: 최종 발표 이전에는 탈퇴 유저 즉시 재가입 허용
-			// TODO: 발표 전 1주일 재가입 제한 정책으로 변경
-			// isWithdrawnAfterWeek(existingUser)
-			existingUser == null || existingUser.isWithdrawn(),
+			existingUser == null || isWithdrawnAfterWeek(existingUser),
 			ErrorCode.ALREADY_EXISTS_EMAIL
 		);
 

--- a/auth-server/src/test/java/com/truve/platform/auth/service/service/AuthServiceTest.java
+++ b/auth-server/src/test/java/com/truve/platform/auth/service/service/AuthServiceTest.java
@@ -6,6 +6,7 @@ import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.*;
 
 import java.util.Date;
+import java.time.LocalDateTime;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -743,6 +744,7 @@ class AuthServiceTest {
 			// given
 			String email = "new@test.com";
 			String password = "plain";
+			given(emailVerificationRepository.isVerifiedEmail(email)).willReturn("verified");
 			given(userRepository.findByEmail(email)).willReturn(Optional.empty());
 			given(userRepository.existsByNickname(NICKNAME)).willReturn(false);
 			given(passwordEncoder.encode(password)).willReturn("encoded");
@@ -784,16 +786,18 @@ class AuthServiceTest {
 			// given
 			String email = "new@test.com";
 			String password = "plain";
-			given(userRepository.findByEmail(email)).willReturn(Optional.empty());
-			given(userRepository.existsByNickname(NICKNAME)).willReturn(false);
-			given(passwordEncoder.encode(password)).willReturn("encoded");
-			given(userRepository.save(any(User.class))).willAnswer(invocation -> invocation.getArgument(0));
+			given(emailVerificationRepository.isVerifiedEmail(email)).willReturn(null);
 
 			// when
-			authService.signUp(email, NICKNAME, password, true, true, true, false, true);
+			CustomException exception = assertThrows(
+				CustomException.class,
+				() -> authService.signUp(email, NICKNAME, password, true, true, true, false, true)
+			);
 
 			// then
-			verify(userRepository).save(any(User.class));
+			assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.NOT_VERIFIED_EMAIL);
+			verify(userRepository, never()).findByEmail(anyString());
+			verify(userRepository, never()).save(any(User.class));
 		}
 
 		@Test
@@ -813,6 +817,7 @@ class AuthServiceTest {
 				false,
 				true
 			);
+			given(emailVerificationRepository.isVerifiedEmail(email)).willReturn("verified");
 			given(userRepository.findByEmail(email)).willReturn(Optional.of(existingUser));
 
 			// when
@@ -829,7 +834,7 @@ class AuthServiceTest {
 		}
 
 		@Test
-		@DisplayName("탈퇴한 유저는 즉시 재가입 처리된다.")
+		@DisplayName("탈퇴 후 1주가 지난 유저는 재가입 처리된다.")
 		void 회원가입_성공_탈퇴유저_재가입() {
 			// given
 			String email = "withdrawn@test.com";
@@ -846,7 +851,13 @@ class AuthServiceTest {
 				true
 			);
 			withdrawnUser.withdraw();
+			ReflectionTestUtils.setField(
+				withdrawnUser,
+				"withdrawnAt",
+				LocalDateTime.now().minusWeeks(1).minusSeconds(1)
+			);
 
+			given(emailVerificationRepository.isVerifiedEmail(email)).willReturn("verified");
 			given(userRepository.findByEmail(email)).willReturn(Optional.of(withdrawnUser));
 			given(userRepository.existsByNickname(NICKNAME)).willReturn(false);
 			given(passwordEncoder.encode(password)).willReturn("encoded");
@@ -870,12 +881,48 @@ class AuthServiceTest {
 		}
 
 		@Test
+		@DisplayName("탈퇴 후 1주가 지나지 않은 유저면 재가입할 수 없다.")
+		void 회원가입_실패_탈퇴유저_일주일미만() {
+			// given
+			String email = "withdrawn@test.com";
+			String password = "plain";
+			User withdrawnUser = User.createLocalUser(
+				email,
+				"oldnick",
+				"old-password",
+				true,
+				true,
+				true,
+				false,
+				false,
+				true
+			);
+			withdrawnUser.withdraw();
+			ReflectionTestUtils.setField(withdrawnUser, "withdrawnAt", LocalDateTime.now().minusDays(6));
+
+			given(emailVerificationRepository.isVerifiedEmail(email)).willReturn("verified");
+			given(userRepository.findByEmail(email)).willReturn(Optional.of(withdrawnUser));
+
+			// when
+			CustomException exception = assertThrows(
+				CustomException.class,
+				() -> authService.signUp(email, NICKNAME, password, true, true, true, false, true)
+			);
+
+			// then
+			assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.ALREADY_EXISTS_EMAIL);
+			verify(userRepository, never()).save(any(User.class));
+			verify(emailVerificationRepository, never()).deleteVerifiedEmail(anyString());
+		}
+
+		@Test
 		@DisplayName("필수 약관에 동의하지 않으면 예외가 발생한다.")
 		void 회원가입_실패_필수_약관_미동의() {
 			// given
 			String email = "new@test.com";
 			String password = "plain";
 
+			given(emailVerificationRepository.isVerifiedEmail(email)).willReturn("verified");
 			given(userRepository.findByEmail(email)).willReturn(Optional.empty());
 
 			// when
@@ -899,6 +946,7 @@ class AuthServiceTest {
 			String email = "new@test.com";
 			String password = "plain";
 
+			given(emailVerificationRepository.isVerifiedEmail(email)).willReturn("verified");
 			given(userRepository.findByEmail(email)).willReturn(Optional.empty());
 
 			// when
@@ -920,6 +968,7 @@ class AuthServiceTest {
 			String password = "plain";
 			String englishNickname = "abcdefghijklmnop";
 
+			given(emailVerificationRepository.isVerifiedEmail(email)).willReturn("verified");
 			given(userRepository.findByEmail(email)).willReturn(Optional.empty());
 			given(userRepository.existsByNickname(englishNickname)).willReturn(false);
 			given(passwordEncoder.encode(password)).willReturn("encoded");
@@ -944,6 +993,7 @@ class AuthServiceTest {
 			String email = "new@test.com";
 			String password = "plain";
 
+			given(emailVerificationRepository.isVerifiedEmail(email)).willReturn("verified");
 			given(userRepository.findByEmail(email)).willReturn(Optional.empty());
 			given(userRepository.existsByNickname(NICKNAME)).willReturn(true);
 

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/ticketing/service/TicketingService.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/ticketing/service/TicketingService.java
@@ -34,15 +34,15 @@ public class TicketingService {
 	private final ShowScheduledRepository showScheduledRepository;
 
 	public TicketingResponse.Enter enter(Long showScheduleId, UUID userId, String admissionToken) {
-		// TODO: 프론트 연동 이후 입장 토큰 검증 로직 주석 해제
-		// AdmissionTokenClaimsDTO claims = admissionTokenService.parseAdmissionToken(admissionToken, showScheduleId, userId);
-		// boolean consumedAdmissionToken = ticketingRedisRepository.consumeAdmissionToken(claims.getShowId(), claims.getUserId(), admissionToken);
-		// Preconditions.validate(consumedAdmissionToken, ErrorCode.INVALID_ADMISSION_TOKEN);
+		AdmissionTokenClaimsDTO claims = admissionTokenService.parseAdmissionToken(admissionToken, showScheduleId, userId);
+		boolean consumedAdmissionToken = ticketingRedisRepository.consumeAdmissionToken(
+			claims.getShowId(), claims.getUserId(), admissionToken
+		);
+		Preconditions.validate(consumedAdmissionToken, ErrorCode.INVALID_ADMISSION_TOKEN);
 
 		String sessionToken = UUID.randomUUID().toString();
 
-		// TODO: 만료시간 기획측과 논의, 현재 60분으로 연동 편의성 확보
-		ticketingRedisRepository.saveSessionToken(sessionToken, userId, showScheduleId, Duration.ofMinutes(60));
+		ticketingRedisRepository.saveSessionToken(sessionToken, userId, showScheduleId, Duration.ofMinutes(5));
 		ticketingRedisRepository.addActiveTicketingUser(showScheduleId, sessionToken);
 		long sessionTokenTtl = ticketingRedisRepository.getSessionTokenTtl(sessionToken);
 
@@ -58,9 +58,9 @@ public class TicketingService {
 		long activeWindowMs = ticketingProperties.getActiveWindowMs();
 		ticketingRedisRepository.removeInactiveTicketingUsers(showScheduleId, nowMs - activeWindowMs);
 
-		// TODO: 프론트 연동 이후 세션 만료시간 설정값 기반 갱신 로직 주석 해제
-		// boolean extended = ticketingRedisRepository.refreshSessionTokenTtl(sessionToken, ticketingProperties.getSessionTtlSec());
-		boolean extended = ticketingRedisRepository.refreshSessionTokenTtl(sessionToken, Duration.ofMinutes(60).toSeconds());
+		boolean extended = ticketingRedisRepository.refreshSessionTokenTtl(
+			sessionToken, ticketingProperties.getSessionTtlSec()
+		);
 		Preconditions.validate(extended, ErrorCode.INVALID_SESSION_TOKEN);
 	}
 

--- a/ticketing/src/test/java/org/truve/platform/ticketing/service/ticketing/service/TicketingServiceTest.java
+++ b/ticketing/src/test/java/org/truve/platform/ticketing/service/ticketing/service/TicketingServiceTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.*;
+import static org.mockito.Mockito.lenient;
 
 import java.time.Duration;
 import java.time.LocalDateTime;
@@ -12,7 +13,6 @@ import java.util.Optional;
 import java.util.UUID;
 
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -66,6 +66,7 @@ class TicketingServiceTest {
 		userId = UUID.fromString("11111111-1111-1111-1111-111111111111");
 		admissionToken = "admission-token";
 		sessionToken = "session-token";
+		lenient().when(ticketingProperties.getSessionTtlSec()).thenReturn(300L);
 	}
 
 	@Nested
@@ -74,8 +75,6 @@ class TicketingServiceTest {
 
 		@Test
 		@DisplayName("입장 토큰이 유효하면 세션 토큰과 TTL을 반환한다.")
-		// TODO: 검증 주석 해제 후 삭제
-		@Disabled
 		void 입장_성공() {
 			// given
 			AdmissionTokenClaimsDTO claims = AdmissionTokenClaimsDTO.of(userId, showScheduleId, "admission");
@@ -100,8 +99,6 @@ class TicketingServiceTest {
 
 		@Test
 		@DisplayName("입장 토큰 소비에 실패하면 예외가 발생한다.")
-		// TODO: 검증 주석 해제 후 삭제
-		@Disabled
 		void 입장_토큰실패() {
 			// given
 			AdmissionTokenClaimsDTO claims = AdmissionTokenClaimsDTO.of(userId, showScheduleId, "admission");
@@ -132,7 +129,7 @@ class TicketingServiceTest {
 			given(ticketingProperties.getActiveWindowMs()).willReturn(30_000L);
 			given(ticketingRedisRepository.getSessionTokenValue(sessionToken))
 				.willReturn(SessionTicketValueDTO.of(userId, showScheduleId));
-			given(ticketingRedisRepository.refreshSessionTokenTtl(sessionToken, 3600L)).willReturn(true);
+			given(ticketingRedisRepository.refreshSessionTokenTtl(sessionToken, 300L)).willReturn(true);
 
 			// when
 			ticketingService.heartbeat(showScheduleId, userId, sessionToken);
@@ -141,7 +138,7 @@ class TicketingServiceTest {
 			assertAll(
 				() -> verify(ticketingRedisRepository).addActiveTicketingUser(showScheduleId, sessionToken),
 				() -> verify(ticketingRedisRepository).removeInactiveTicketingUsers(eq(showScheduleId), anyLong()),
-				() -> verify(ticketingRedisRepository).refreshSessionTokenTtl(sessionToken, 3600L)
+				() -> verify(ticketingRedisRepository).refreshSessionTokenTtl(sessionToken, 300L)
 			);
 		}
 
@@ -203,7 +200,7 @@ class TicketingServiceTest {
 			given(ticketingProperties.getActiveWindowMs()).willReturn(30_000L);
 			given(ticketingRedisRepository.getSessionTokenValue(sessionToken))
 				.willReturn(SessionTicketValueDTO.of(userId, showScheduleId));
-			given(ticketingRedisRepository.refreshSessionTokenTtl(sessionToken, 3600L)).willReturn(false);
+			given(ticketingRedisRepository.refreshSessionTokenTtl(sessionToken, 300L)).willReturn(false);
 
 			// when
 			CustomException exception = assertThrows(
@@ -229,7 +226,7 @@ class TicketingServiceTest {
 			given(ticketingProperties.getActiveWindowMs()).willReturn(30_000L);
 			given(ticketingRedisRepository.getSessionTokenValue(sessionToken))
 				.willReturn(SessionTicketValueDTO.of(userId, showScheduleId));
-			given(ticketingRedisRepository.refreshSessionTokenTtl(sessionToken, 3600L)).willReturn(true);
+			given(ticketingRedisRepository.refreshSessionTokenTtl(sessionToken, 300L)).willReturn(true);
 
 			showScheduled = ShowScheduled.builder()
 				.title("공연")
@@ -390,7 +387,7 @@ class TicketingServiceTest {
 			given(ticketingProperties.getActiveWindowMs()).willReturn(30_000L);
 			given(ticketingRedisRepository.getSessionTokenValue(sessionToken))
 				.willReturn(SessionTicketValueDTO.of(userId, showScheduleId));
-			given(ticketingRedisRepository.refreshSessionTokenTtl(sessionToken, 3600L)).willReturn(true);
+			given(ticketingRedisRepository.refreshSessionTokenTtl(sessionToken, 300L)).willReturn(true);
 		}
 
 		@Test
@@ -444,7 +441,7 @@ class TicketingServiceTest {
 			given(ticketingProperties.getActiveWindowMs()).willReturn(30_000L);
 			given(ticketingRedisRepository.getSessionTokenValue(sessionToken))
 				.willReturn(SessionTicketValueDTO.of(userId, showScheduleId));
-			given(ticketingRedisRepository.refreshSessionTokenTtl(sessionToken, 3600L)).willReturn(true);
+			given(ticketingRedisRepository.refreshSessionTokenTtl(sessionToken, 300L)).willReturn(true);
 		}
 
 		@Test
@@ -496,7 +493,7 @@ class TicketingServiceTest {
 			given(ticketingProperties.getActiveWindowMs()).willReturn(30_000L);
 			given(ticketingRedisRepository.getSessionTokenValue(sessionToken))
 				.willReturn(SessionTicketValueDTO.of(userId, showScheduleId));
-			given(ticketingRedisRepository.refreshSessionTokenTtl(sessionToken, 3600L)).willReturn(true);
+			given(ticketingRedisRepository.refreshSessionTokenTtl(sessionToken, 300L)).willReturn(true);
 		}
 
 		@Test


### PR DESCRIPTION
## 변경 사항

추가/변경 사항과 사유를 작성해 주세요.

- [x] 전체 테스트 코드 성공 여부

연동 편의를 위해 진행했던 주석처리 제거합니다.

1. 탈퇴 유저 재가입 1주일 이후로 가능하도록 반영
2. 대기열 통과시 AdmissionToken 검증
3. 티켓팅 세션토큰 검증

## 관련 이슈

- Notion Ticket: #

## 참고사항 (선택)

---