### PR TITLE
feat(auth): 소셜로그인 전략패턴 추상화 및 고도화

### DIFF
--- a/auth-server/src/main/java/com/truve/platform/auth/service/controller/AuthController.java
+++ b/auth-server/src/main/java/com/truve/platform/auth/service/controller/AuthController.java
@@ -13,6 +13,7 @@ import com.truve.platform.auth.service.domain.dto.request.AuthRequest;
 import com.truve.platform.auth.service.domain.dto.response.AuthResponse;
 import com.truve.platform.auth.service.security.AuthCookieManager;
 import com.truve.platform.auth.service.service.AuthService;
+import com.truve.platform.auth.service.service.SocialLoginService;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -30,6 +31,7 @@ import lombok.RequiredArgsConstructor;
 @Tag(name = "Auth", description = "인증/인가 API")
 public class AuthController {
 	private final AuthService authService;
+	private final SocialLoginService socialLoginService;
 	private final AuthCookieManager authCookieManager;
 
 	@PostMapping("/sign-up")
@@ -79,6 +81,25 @@ public class AuthController {
 			);
 
 		return ResponseEntity.ok(response);
+	}
+
+	@PostMapping("/social/sign-up/complete")
+	public ResponseEntity<AuthResponse.Login> completeSocialSignUp(
+		HttpServletResponse httpServletResponse,
+		@RequestBody @Valid AuthRequest.CompleteSocialSignUp request
+	) {
+		Pair<String, String> tokens = socialLoginService.completeSignUp(request);
+
+		String accessToken = tokens.getFirst();
+		String refreshToken = tokens.getSecond();
+
+		authCookieManager.setRefreshToken(
+			httpServletResponse,
+			refreshToken,
+			60L * 60 * 24 * 14
+		);
+
+		return ResponseEntity.ok(new AuthResponse.Login(accessToken));
 	}
 
 	@Operation(summary = "토큰 재발급")

--- a/auth-server/src/main/java/com/truve/platform/auth/service/controller/KakaoOAuthController.java
+++ b/auth-server/src/main/java/com/truve/platform/auth/service/controller/KakaoOAuthController.java
@@ -1,8 +1,9 @@
 package com.truve.platform.auth.service.controller;
 
 import java.net.URI;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 
-import org.springframework.data.util.Pair;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -13,7 +14,9 @@ import org.springframework.web.bind.annotation.RestController;
 import com.truve.platform.auth.service.security.AuthCookieManager;
 import com.truve.platform.auth.service.security.properties.FrontOAuthProperties;
 import com.truve.platform.auth.service.security.properties.KakaoOAuthProperties;
-import com.truve.platform.auth.service.service.KakaoOAuthService;
+import com.truve.platform.auth.service.service.SocialLoginService;
+import com.truve.platform.auth.service.service.social.SocialLoginResult;
+import com.truve.platform.common.constants.AuthProvider;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.headers.Header;
@@ -29,7 +32,7 @@ import lombok.RequiredArgsConstructor;
 public class KakaoOAuthController {
 	private final FrontOAuthProperties frontOAuthProperties;
 	private final KakaoOAuthProperties kakaoOAuthProperties;
-	private final KakaoOAuthService kakaoOAuthService;
+	private final SocialLoginService socialLoginService;
 	private final AuthCookieManager authCookieManager;
 
 	@Operation(
@@ -74,18 +77,28 @@ public class KakaoOAuthController {
 		@RequestParam(required = false) String state,
 		HttpServletResponse httpServletResponse
 	) {
-		Pair<String, String> tokens = kakaoOAuthService.login(code, error, error_description, state);
+		SocialLoginResult result = socialLoginService.start(AuthProvider.KAKAO, code, state);
 
-		String refreshToken = tokens.getSecond();
+		if (result.getStatus() == SocialLoginResult.Status.LOGIN_SUCCESS) {
+			authCookieManager.setRefreshToken(
+				httpServletResponse,
+				result.getRefreshToken(),
+				60L * 60 * 24 * 14
+			);
 
-		authCookieManager.setRefreshToken(
-			httpServletResponse,
-			refreshToken,
-			60L * 60 * 24 * 14
-		);
+			return ResponseEntity.status(HttpStatus.FOUND)
+				.location(URI.create(frontOAuthProperties.getCallback() + "?status=login-success"))
+				.build();
+		}
+
+		String redirectUri = frontOAuthProperties.getCallback()
+			+ "?status=sign-up-required"
+			+ "&provider=" + result.getProvider().name()
+			+ "&email=" + URLEncoder.encode(result.getEmail(), StandardCharsets.UTF_8)
+			+ "&registrationToken=" + URLEncoder.encode(result.getRegistrationToken(), StandardCharsets.UTF_8);
 
 		return ResponseEntity.status(HttpStatus.FOUND)
-			.location(URI.create(frontOAuthProperties.getCallback()))
+			.location(URI.create(redirectUri))
 			.build();
 	}
 

--- a/auth-server/src/main/java/com/truve/platform/auth/service/controller/NaverOAuthController.java
+++ b/auth-server/src/main/java/com/truve/platform/auth/service/controller/NaverOAuthController.java
@@ -1,9 +1,10 @@
 package com.truve.platform.auth.service.controller;
 
 import java.net.URI;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.UUID;
 
-import org.springframework.data.util.Pair;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -14,7 +15,9 @@ import org.springframework.web.bind.annotation.RestController;
 import com.truve.platform.auth.service.security.AuthCookieManager;
 import com.truve.platform.auth.service.security.properties.FrontOAuthProperties;
 import com.truve.platform.auth.service.security.properties.NaverOAuthProperties;
-import com.truve.platform.auth.service.service.NaverOAuthService;
+import com.truve.platform.auth.service.service.SocialLoginService;
+import com.truve.platform.auth.service.service.social.SocialLoginResult;
+import com.truve.platform.common.constants.AuthProvider;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.headers.Header;
@@ -30,7 +33,7 @@ import lombok.RequiredArgsConstructor;
 public class NaverOAuthController {
 	private final FrontOAuthProperties frontOAuthProperties;
 	private final NaverOAuthProperties naverOAuthProperties;
-	private final NaverOAuthService naverOAuthService;
+	private final SocialLoginService socialLoginService;
 	private final AuthCookieManager authCookieManager;
 
 	@Operation(
@@ -76,17 +79,28 @@ public class NaverOAuthController {
 		@RequestParam(required = false) String state,
 		HttpServletResponse httpServletResponse
 	) {
-		Pair<String, String> tokens = naverOAuthService.login(code, error, error_description, state);
-		String refreshToken = tokens.getSecond();
+		SocialLoginResult result = socialLoginService.start(AuthProvider.NAVER, code, state);
 
-		authCookieManager.setRefreshToken(
-			httpServletResponse,
-			refreshToken,
-			60L * 60 * 24 * 14
-		);
+		if (result.getStatus() == SocialLoginResult.Status.LOGIN_SUCCESS) {
+			authCookieManager.setRefreshToken(
+				httpServletResponse,
+				result.getRefreshToken(),
+				60L * 60 * 24 * 14
+			);
+
+			return ResponseEntity.status(HttpStatus.FOUND)
+				.location(URI.create(frontOAuthProperties.getCallback() + "?status=login-success"))
+				.build();
+		}
+
+		String redirectUri = frontOAuthProperties.getCallback()
+			+ "?status=sign-up-required"
+			+ "&provider=" + result.getProvider().name()
+			+ "&email=" + URLEncoder.encode(result.getEmail(), StandardCharsets.UTF_8)
+			+ "&registrationToken=" + URLEncoder.encode(result.getRegistrationToken(), StandardCharsets.UTF_8);
 
 		return ResponseEntity.status(HttpStatus.FOUND)
-			.location(URI.create(frontOAuthProperties.getCallback()))
+			.location(URI.create(redirectUri))
 			.build();
 	}
 }

--- a/auth-server/src/main/java/com/truve/platform/auth/service/domain/dto/request/AuthRequest.java
+++ b/auth-server/src/main/java/com/truve/platform/auth/service/domain/dto/request/AuthRequest.java
@@ -69,4 +69,29 @@ public class AuthRequest {
 	public static class UpdateEmailNotificationConsent {
 		private boolean emailNotificationAgreed;
 	}
+
+	@Getter
+	@AllArgsConstructor
+	@NoArgsConstructor
+	@Schema(name = "AuthRequestCompleteSocialSignUp", description = "소셜 회원가입 완료 요청")
+	public static class CompleteSocialSignUp {
+		@NotBlank
+		private String registrationToken;
+
+		@NotBlank
+		private String email;
+
+		@NotBlank
+		private String nickname;
+
+		private boolean serviceTermsAgreed;
+
+		private boolean electronicFinanceTermsAgreed;
+
+		private boolean privacyCollectionAgreed;
+
+		private boolean marketingInfoAgreed;
+
+		private boolean over14Agreed;
+	}
 }

--- a/auth-server/src/main/java/com/truve/platform/auth/service/domain/entity/User.java
+++ b/auth-server/src/main/java/com/truve/platform/auth/service/domain/entity/User.java
@@ -159,6 +159,38 @@ public class User extends BaseEntity {
 			.build();
 	}
 
+	public static User createOAuthUser(
+		String email,
+		String nickname,
+		AuthProvider provider,
+		String oAuthUserId,
+		String oAuthAccessToken,
+		String oAuthRefreshToken,
+		boolean serviceTermsAgreed,
+		boolean electronicFinanceTermsAgreed,
+		boolean privacyCollectionAgreed,
+		boolean marketingInfoAgreed,
+		boolean emailNotificationAgreed,
+		boolean over14Agreed
+	) {
+		return User.builder()
+			.publicId(UUID.randomUUID())
+			.email(email)
+			.nickname(nickname)
+			.provider(provider)
+			.role(UserRole.MEMBER)
+			.oAuthUserId(oAuthUserId)
+			.oAuthAccessToken(oAuthAccessToken)
+			.oAuthRefreshToken(oAuthRefreshToken)
+			.serviceTermsAgreed(serviceTermsAgreed)
+			.electronicFinanceTermsAgreed(electronicFinanceTermsAgreed)
+			.privacyCollectionAgreed(privacyCollectionAgreed)
+			.marketingInfoAgreed(marketingInfoAgreed)
+			.emailNotificationAgreed(emailNotificationAgreed)
+			.over14Agreed(over14Agreed)
+			.build();
+	}
+
 	public void updateNickname(String nickname) {
 		this.nickname = nickname;
 	}

--- a/auth-server/src/main/java/com/truve/platform/auth/service/repository/SocialRegistrationRepository.java
+++ b/auth-server/src/main/java/com/truve/platform/auth/service/repository/SocialRegistrationRepository.java
@@ -1,0 +1,53 @@
+package com.truve.platform.auth.service.repository;
+
+import java.time.Duration;
+
+import org.springframework.stereotype.Repository;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.truve.platform.auth.service.service.social.SocialRegistrationInfo;
+import com.truve.platform.common.exception.CustomException;
+import com.truve.platform.common.exception.ErrorCode;
+import com.truve.platform.auth.service.support.RedisSupport;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class SocialRegistrationRepository {
+
+	private static final String SOCIAL_REGISTRATION_PREFIX = "social:registration:";
+	private static final Duration SOCIAL_REGISTRATION_TTL = Duration.ofMinutes(30);
+
+	private final RedisSupport redisSupport;
+	private final ObjectMapper objectMapper;
+
+	public void save(String registrationToken, SocialRegistrationInfo info) {
+		try {
+			String key = SOCIAL_REGISTRATION_PREFIX + registrationToken;
+			String value = objectMapper.writeValueAsString(info);
+			redisSupport.setValueWithTtl(key, value, SOCIAL_REGISTRATION_TTL);
+		} catch (JsonProcessingException e) {
+			throw new CustomException(ErrorCode.EVENT_SERIALIZATION_FAILED);
+		}
+	}
+
+	public SocialRegistrationInfo find(String registrationToken) {
+		try {
+			String key = SOCIAL_REGISTRATION_PREFIX + registrationToken;
+			String value = redisSupport.getValue(key);
+			if (value == null || value.isBlank()) {
+				return null;
+			}
+			return objectMapper.readValue(value, SocialRegistrationInfo.class);
+		} catch (JsonProcessingException e) {
+			throw new CustomException(ErrorCode.EVENT_DESERIALIZATION_FAILED);
+		}
+	}
+
+	public void delete(String registrationToken) {
+		String key = SOCIAL_REGISTRATION_PREFIX + registrationToken;
+		redisSupport.delete(key);
+	}
+}

--- a/auth-server/src/main/java/com/truve/platform/auth/service/repository/SocialRegistrationRepository.java
+++ b/auth-server/src/main/java/com/truve/platform/auth/service/repository/SocialRegistrationRepository.java
@@ -3,6 +3,7 @@ package com.truve.platform.auth.service.repository;
 import java.time.Duration;
 
 import org.springframework.stereotype.Repository;
+import org.springframework.util.StringUtils;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -37,7 +38,7 @@ public class SocialRegistrationRepository {
 		try {
 			String key = SOCIAL_REGISTRATION_PREFIX + registrationToken;
 			String value = redisSupport.getValue(key);
-			if (value == null || value.isBlank()) {
+			if (!StringUtils.hasText(value)) {
 				return null;
 			}
 			return objectMapper.readValue(value, SocialRegistrationInfo.class);

--- a/auth-server/src/main/java/com/truve/platform/auth/service/service/KakaoOAuthService.java
+++ b/auth-server/src/main/java/com/truve/platform/auth/service/service/KakaoOAuthService.java
@@ -1,14 +1,8 @@
 package com.truve.platform.auth.service.service;
 
-import static com.truve.platform.auth.service.domain.dto.response.OAuthDTO.*;
-
 import org.springframework.data.util.Pair;
-import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.util.LinkedMultiValueMap;
-import org.springframework.util.MultiValueMap;
-import org.springframework.web.client.RestClient;
 
 import com.truve.platform.common.constants.AuthProvider;
 import com.truve.platform.common.exception.ErrorCode;
@@ -17,18 +11,18 @@ import com.truve.platform.auth.service.domain.entity.User;
 import com.truve.platform.auth.service.repository.UserRepository;
 import com.truve.platform.auth.service.security.JwtService;
 import com.truve.platform.auth.service.security.TokenType;
-import com.truve.platform.auth.service.security.properties.KakaoOAuthProperties;
+import com.truve.platform.auth.service.service.social.KakaoOAuthProviderClient;
+import com.truve.platform.auth.service.service.social.OAuthTokenInfo;
+import com.truve.platform.auth.service.service.social.OAuthUserInfo;
 
 import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
 public class KakaoOAuthService {
-	private final KakaoOAuthProperties kakaoOAuthProperties;
 	private final JwtService jwtService;
 	private final RefreshTokenService refreshTokenService;
-	private final RestClient kakaoOAuthRestClient;
-	private final RestClient kakaoApiRestClient;
+	private final KakaoOAuthProviderClient kakaoOAuthProviderClient;
 	private final UserRepository userRepository;
 
 
@@ -37,15 +31,16 @@ public class KakaoOAuthService {
 	@Transactional
 	public Pair<String, String> login(String code, String error, String errorDescription, String state) {
 
-		KakaoLoginResponse kakaoDTO = requestToken(code);
+		OAuthTokenInfo tokenInfo = kakaoOAuthProviderClient.exchangeToken(code, state);
 
-		Preconditions.validate(!(kakaoDTO == null), ErrorCode.NOT_FOUND_EMAIL);
+		Preconditions.validate(tokenInfo != null, ErrorCode.NOT_FOUND_EMAIL);
 
-		String kakaoAccessToken = kakaoDTO.getAccessToken();
-		String kakaoRefreshToken = kakaoDTO.getRefreshToken();
-		KakaoUserInfo info = requestUserInfo(kakaoAccessToken);
-		String kakaoEmail = info.getKakaoAccount().getEmail();
-		String kakaoUserId = info.getId();
+		String kakaoAccessToken = tokenInfo.getAccessToken();
+		String kakaoRefreshToken = tokenInfo.getRefreshToken();
+		OAuthUserInfo userInfo = kakaoOAuthProviderClient.getUserInfo(kakaoAccessToken);
+		Preconditions.validate(userInfo != null && userInfo.getEmail() != null, ErrorCode.NOT_FOUND_EMAIL);
+		String kakaoEmail = userInfo.getEmail();
+		String kakaoUserId = userInfo.getProviderUserId();
 		User user;
 
 		if (!userRepository.existsByEmail(kakaoEmail)) {
@@ -71,32 +66,4 @@ public class KakaoOAuthService {
 
 		return Pair.of(accessToken, refreshToken);
 	}
-
-
-	private KakaoLoginResponse requestToken(String code) {
-		MultiValueMap<String, String> form = new LinkedMultiValueMap<>();
-		form.add("grant_type", "authorization_code");
-		form.add("client_id", kakaoOAuthProperties.getClientId());
-		form.add("redirect_uri", kakaoOAuthProperties.getRedirectUri());
-		form.add("code", code);
-		form.add("client_secret", kakaoOAuthProperties.getClientSecret());
-
-		return kakaoOAuthRestClient.post()
-			.uri("/token")
-			.contentType(MediaType.APPLICATION_FORM_URLENCODED)
-			.body(form)
-			.retrieve()
-			.body(KakaoLoginResponse.class);
-	}
-
-	private KakaoUserInfo requestUserInfo(String accessToken) {
-		return kakaoApiRestClient.post()
-			.uri("/user/me")
-			.contentType(MediaType.APPLICATION_FORM_URLENCODED)
-			.header("Authorization", "Bearer " + accessToken)
-			.body("property_keys=[\"kakao_account.email\"]")
-			.retrieve()
-			.body(KakaoUserInfo.class);
-	}
-
 }

--- a/auth-server/src/main/java/com/truve/platform/auth/service/service/NaverOAuthService.java
+++ b/auth-server/src/main/java/com/truve/platform/auth/service/service/NaverOAuthService.java
@@ -1,14 +1,8 @@
 package com.truve.platform.auth.service.service;
 
-import static com.truve.platform.auth.service.domain.dto.response.OAuthDTO.*;
-
 import org.springframework.data.util.Pair;
-import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.util.LinkedMultiValueMap;
-import org.springframework.util.MultiValueMap;
-import org.springframework.web.client.RestClient;
 
 import com.truve.platform.common.constants.AuthProvider;
 import com.truve.platform.common.exception.ErrorCode;
@@ -17,7 +11,9 @@ import com.truve.platform.auth.service.domain.entity.User;
 import com.truve.platform.auth.service.repository.UserRepository;
 import com.truve.platform.auth.service.security.JwtService;
 import com.truve.platform.auth.service.security.TokenType;
-import com.truve.platform.auth.service.security.properties.NaverOAuthProperties;
+import com.truve.platform.auth.service.service.social.NaverOAuthProviderClient;
+import com.truve.platform.auth.service.service.social.OAuthTokenInfo;
+import com.truve.platform.auth.service.service.social.OAuthUserInfo;
 
 import lombok.RequiredArgsConstructor;
 
@@ -25,9 +21,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class NaverOAuthService {
 	
-	private final NaverOAuthProperties naverOAuthProperties;
-	private final RestClient naverOAuthRestClient;
-	private final RestClient naverApiRestClient;
+	private final NaverOAuthProviderClient naverOAuthProviderClient;
 	private final UserRepository userRepository;
 	private final JwtService jwtService;
 	private final RefreshTokenService refreshTokenService;
@@ -38,15 +32,16 @@ public class NaverOAuthService {
 	@Transactional
 	public Pair<String, String> login(String code, String error, String errorDescription, String state) {
 
-		NaverLoginResponse naverDTO = requestToken(code, state);
+		OAuthTokenInfo tokenInfo = naverOAuthProviderClient.exchangeToken(code, state);
 
-		Preconditions.validate(!(naverDTO == null), ErrorCode.NOT_FOUND_EMAIL);
+		Preconditions.validate(tokenInfo != null, ErrorCode.NOT_FOUND_EMAIL);
 
-		String naverAccessToken = naverDTO.getAccessToken();
-		String naverRefreshToken = naverDTO.getRefreshToken();
-		NaverUserInfo info = requestUserInfo(naverAccessToken);
-		String naverEmail = info.getResponse().getEmail();
-		String naverUserId = info.getResponse().getId();
+		String naverAccessToken = tokenInfo.getAccessToken();
+		String naverRefreshToken = tokenInfo.getRefreshToken();
+		OAuthUserInfo userInfo = naverOAuthProviderClient.getUserInfo(naverAccessToken);
+		Preconditions.validate(userInfo != null && userInfo.getEmail() != null, ErrorCode.NOT_FOUND_EMAIL);
+		String naverEmail = userInfo.getEmail();
+		String naverUserId = userInfo.getProviderUserId();
 		User user;
 
 		if (!userRepository.existsByEmail(naverEmail)) {
@@ -72,29 +67,5 @@ public class NaverOAuthService {
 		refreshTokenService.save(user.getPublicId(), refreshToken, refreshTtlMs);
 
 		return Pair.of(accessToken, refreshToken);
-	}
-
-	private NaverLoginResponse requestToken(String code, String state) {
-		MultiValueMap<String, String> form = new LinkedMultiValueMap<>();
-		form.add("grant_type", "authorization_code");
-		form.add("client_id", naverOAuthProperties.getClientId());
-		form.add("client_secret", naverOAuthProperties.getClientSecret());
-		form.add("code", code);
-		form.add("state", state);
-
-		return naverOAuthRestClient.post()
-			.uri("/token")
-			.contentType(MediaType.APPLICATION_FORM_URLENCODED)
-			.body(form)
-			.retrieve()
-			.body(NaverLoginResponse.class);
-	}
-
-	private NaverUserInfo requestUserInfo(String accessToken) {
-		return naverApiRestClient.get()
-			.uri("/me")
-			.header("Authorization", "Bearer " + accessToken)
-			.retrieve()
-			.body(NaverUserInfo.class);
 	}
 }

--- a/auth-server/src/main/java/com/truve/platform/auth/service/service/SocialLoginService.java
+++ b/auth-server/src/main/java/com/truve/platform/auth/service/service/SocialLoginService.java
@@ -15,6 +15,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.truve.platform.auth.service.domain.dto.request.AuthRequest;
 import com.truve.platform.auth.service.domain.entity.User;
+import com.truve.platform.auth.service.event.UserSignedUpEvent;
 import com.truve.platform.auth.service.repository.EmailVerificationRepository;
 import com.truve.platform.auth.service.repository.SocialRegistrationRepository;
 import com.truve.platform.auth.service.repository.UserRepository;
@@ -43,6 +44,7 @@ public class SocialLoginService {
 	private final JwtService jwtService;
 	private final RefreshTokenService refreshTokenService;
 	private final SocialRegistrationRepository socialRegistrationRepository;
+	private final UserSignedUpEventPublisher userSignedUpEventPublisher;
 	private Map<AuthProvider, OAuthProviderClient> providerClients;
 
 	@PostConstruct
@@ -124,6 +126,8 @@ public class SocialLoginService {
 		);
 
 		userRepository.save(user);
+		UserSignedUpEvent event = UserSignedUpEvent.from(user);
+		userSignedUpEventPublisher.publish(user.getPublicId().toString(), event);
 		emailVerificationRepository.deleteVerifiedEmail(request.getEmail());
 		socialRegistrationRepository.delete(request.getRegistrationToken());
 

--- a/auth-server/src/main/java/com/truve/platform/auth/service/service/SocialLoginService.java
+++ b/auth-server/src/main/java/com/truve/platform/auth/service/service/SocialLoginService.java
@@ -5,13 +5,17 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.function.Function;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import jakarta.annotation.PostConstruct;
+import org.springframework.data.util.Pair;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.truve.platform.auth.service.domain.dto.request.AuthRequest;
 import com.truve.platform.auth.service.domain.entity.User;
+import com.truve.platform.auth.service.repository.EmailVerificationRepository;
 import com.truve.platform.auth.service.repository.SocialRegistrationRepository;
 import com.truve.platform.auth.service.repository.UserRepository;
 import com.truve.platform.auth.service.security.JwtService;
@@ -31,9 +35,11 @@ import lombok.RequiredArgsConstructor;
 @Service
 @RequiredArgsConstructor
 public class SocialLoginService {
+	private static final Pattern NICKNAME_PATTERN = Pattern.compile("^(?:[가-힣]{2,10}|[a-zA-Z]{2,16})$");
 
 	private final List<OAuthProviderClient> oauthProviderClients;
 	private final UserRepository userRepository;
+	private final EmailVerificationRepository emailVerificationRepository;
 	private final JwtService jwtService;
 	private final RefreshTokenService refreshTokenService;
 	private final SocialRegistrationRepository socialRegistrationRepository;
@@ -77,7 +83,59 @@ public class SocialLoginService {
 		return SocialLoginResult.signUpRequired(registrationToken, userInfo.getEmail(), provider);
 	}
 
+	@Transactional
+	public Pair<String, String> completeSignUp(AuthRequest.CompleteSocialSignUp request) {
+		SocialRegistrationInfo registrationInfo = socialRegistrationRepository.find(request.getRegistrationToken());
+
+		Preconditions.validate(registrationInfo != null, ErrorCode.INVALID_SOCIAL_REGISTRATION_TOKEN);
+		Preconditions.validate(
+			request.getEmail().equals(registrationInfo.email()),
+			ErrorCode.INVALID_SOCIAL_REGISTRATION_TOKEN
+		);
+
+		String verifiedAt = emailVerificationRepository.isVerifiedEmail(request.getEmail());
+		Preconditions.validate(!(verifiedAt == null || verifiedAt.isBlank()), ErrorCode.NOT_VERIFIED_EMAIL);
+
+		Preconditions.validate(
+			request.isServiceTermsAgreed()
+				&& request.isElectronicFinanceTermsAgreed()
+				&& request.isPrivacyCollectionAgreed()
+				&& request.isOver14Agreed(),
+			ErrorCode.REQUIRED_TERMS_NOT_AGREED
+		);
+
+		validateNickname(request.getNickname());
+		Preconditions.validate(!userRepository.existsByEmail(request.getEmail()), ErrorCode.ALREADY_EXISTS_EMAIL);
+		Preconditions.validate(!userRepository.existsByNickname(request.getNickname()), ErrorCode.ALREADY_EXISTS_NICKNAME);
+
+		User user = User.createOAuthUser(
+			request.getEmail(),
+			request.getNickname(),
+			registrationInfo.provider(),
+			registrationInfo.providerUserId(),
+			registrationInfo.oAuthAccessToken(),
+			registrationInfo.oAuthRefreshToken(),
+			request.isServiceTermsAgreed(),
+			request.isElectronicFinanceTermsAgreed(),
+			request.isPrivacyCollectionAgreed(),
+			request.isMarketingInfoAgreed(),
+			false,
+			request.isOver14Agreed()
+		);
+
+		userRepository.save(user);
+		emailVerificationRepository.deleteVerifiedEmail(request.getEmail());
+		socialRegistrationRepository.delete(request.getRegistrationToken());
+
+		return issueTokens(user);
+	}
+
 	private SocialLoginResult issueLoginResult(User user) {
+		Pair<String, String> tokens = issueTokens(user);
+		return SocialLoginResult.loginSuccess(tokens.getFirst(), tokens.getSecond(), user.getProvider());
+	}
+
+	private Pair<String, String> issueTokens(User user) {
 		Date accessExp = jwtService.getAccessExpiration();
 		Date refreshExp = jwtService.getRefreshExpiration();
 
@@ -102,12 +160,19 @@ public class SocialLoginService {
 		long refreshTtlMs = refreshExp.getTime() - System.currentTimeMillis();
 		refreshTokenService.save(user.getPublicId(), refreshToken, refreshTtlMs);
 
-		return SocialLoginResult.loginSuccess(accessToken, refreshToken, user.getProvider());
+		return Pair.of(accessToken, refreshToken);
 	}
 
 	private void validateNotWithdrawn(User user) {
 		if (user.isWithdrawn()) {
 			throw new CustomException(ErrorCode.ALREADY_WITHDRAWN_USER);
 		}
+	}
+
+	private void validateNickname(String nickname) {
+		Preconditions.validate(
+			nickname != null && NICKNAME_PATTERN.matcher(nickname).matches(),
+			ErrorCode.INVALID_NICKNAME
+		);
 	}
 }

--- a/auth-server/src/main/java/com/truve/platform/auth/service/service/SocialLoginService.java
+++ b/auth-server/src/main/java/com/truve/platform/auth/service/service/SocialLoginService.java
@@ -1,0 +1,113 @@
+package com.truve.platform.auth.service.service;
+
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import jakarta.annotation.PostConstruct;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.truve.platform.auth.service.domain.entity.User;
+import com.truve.platform.auth.service.repository.SocialRegistrationRepository;
+import com.truve.platform.auth.service.repository.UserRepository;
+import com.truve.platform.auth.service.security.JwtService;
+import com.truve.platform.auth.service.security.TokenType;
+import com.truve.platform.auth.service.service.social.OAuthProviderClient;
+import com.truve.platform.auth.service.service.social.OAuthTokenInfo;
+import com.truve.platform.auth.service.service.social.OAuthUserInfo;
+import com.truve.platform.auth.service.service.social.SocialLoginResult;
+import com.truve.platform.auth.service.service.social.SocialRegistrationInfo;
+import com.truve.platform.common.constants.AuthProvider;
+import com.truve.platform.common.exception.CustomException;
+import com.truve.platform.common.exception.ErrorCode;
+import com.truve.platform.common.support.Preconditions;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class SocialLoginService {
+
+	private final List<OAuthProviderClient> oauthProviderClients;
+	private final UserRepository userRepository;
+	private final JwtService jwtService;
+	private final RefreshTokenService refreshTokenService;
+	private final SocialRegistrationRepository socialRegistrationRepository;
+	private Map<AuthProvider, OAuthProviderClient> providerClients;
+
+	@PostConstruct
+	void initializeProviderClients() {
+		this.providerClients = oauthProviderClients.stream()
+			.collect(Collectors.toMap(OAuthProviderClient::supports, Function.identity()));
+	}
+
+	@Transactional
+	public SocialLoginResult start(AuthProvider provider, String code, String state) {
+		OAuthProviderClient providerClient = providerClients.get(provider);
+		Preconditions.validate(providerClient != null, ErrorCode.INVALID_AUTH_PROVIDER);
+
+		OAuthTokenInfo tokenInfo = providerClient.exchangeToken(code, state);
+		Preconditions.validate(tokenInfo != null, ErrorCode.NOT_FOUND_EMAIL);
+
+		OAuthUserInfo userInfo = providerClient.getUserInfo(tokenInfo.getAccessToken());
+		Preconditions.validate(userInfo != null && userInfo.getEmail() != null, ErrorCode.NOT_FOUND_EMAIL);
+
+		if (userRepository.existsByEmail(userInfo.getEmail())) {
+			User user = userRepository.findByEmailOrThrow(userInfo.getEmail());
+			validateNotWithdrawn(user);
+			return issueLoginResult(user);
+		}
+
+		String registrationToken = UUID.randomUUID().toString();
+		socialRegistrationRepository.save(
+			registrationToken,
+			new SocialRegistrationInfo(
+				provider,
+				userInfo.getProviderUserId(),
+				userInfo.getEmail(),
+				tokenInfo.getAccessToken(),
+				tokenInfo.getRefreshToken()
+			)
+		);
+
+		return SocialLoginResult.signUpRequired(registrationToken, userInfo.getEmail(), provider);
+	}
+
+	private SocialLoginResult issueLoginResult(User user) {
+		Date accessExp = jwtService.getAccessExpiration();
+		Date refreshExp = jwtService.getRefreshExpiration();
+
+		String accessToken = jwtService.issue(
+			user.getPublicId(),
+			user.getId(),
+			user.getEmail(),
+			user.getRole(),
+			accessExp,
+			TokenType.ACCESS_TOKEN.getType()
+		);
+
+		String refreshToken = jwtService.issue(
+			user.getPublicId(),
+			user.getId(),
+			user.getEmail(),
+			user.getRole(),
+			refreshExp,
+			TokenType.REFRESH_TOKEN.getType()
+		);
+
+		long refreshTtlMs = refreshExp.getTime() - System.currentTimeMillis();
+		refreshTokenService.save(user.getPublicId(), refreshToken, refreshTtlMs);
+
+		return SocialLoginResult.loginSuccess(accessToken, refreshToken, user.getProvider());
+	}
+
+	private void validateNotWithdrawn(User user) {
+		if (user.isWithdrawn()) {
+			throw new CustomException(ErrorCode.ALREADY_WITHDRAWN_USER);
+		}
+	}
+}

--- a/auth-server/src/main/java/com/truve/platform/auth/service/service/social/KakaoOAuthProviderClient.java
+++ b/auth-server/src/main/java/com/truve/platform/auth/service/service/social/KakaoOAuthProviderClient.java
@@ -1,0 +1,72 @@
+package com.truve.platform.auth.service.service.social;
+
+import static com.truve.platform.auth.service.domain.dto.response.OAuthDTO.*;
+
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestClient;
+
+import com.truve.platform.auth.service.security.properties.KakaoOAuthProperties;
+import com.truve.platform.common.constants.AuthProvider;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class KakaoOAuthProviderClient implements OAuthProviderClient {
+
+	private final KakaoOAuthProperties kakaoOAuthProperties;
+	private final RestClient kakaoOAuthRestClient;
+	private final RestClient kakaoApiRestClient;
+
+	@Override
+	public AuthProvider supports() {
+		return AuthProvider.KAKAO;
+	}
+
+	@Override
+	public OAuthTokenInfo exchangeToken(String code, String state) {
+		MultiValueMap<String, String> form = new LinkedMultiValueMap<>();
+		form.add("grant_type", "authorization_code");
+		form.add("client_id", kakaoOAuthProperties.getClientId());
+		form.add("redirect_uri", kakaoOAuthProperties.getRedirectUri());
+		form.add("code", code);
+		form.add("client_secret", kakaoOAuthProperties.getClientSecret());
+
+		KakaoLoginResponse response = kakaoOAuthRestClient.post()
+			.uri("/token")
+			.contentType(MediaType.APPLICATION_FORM_URLENCODED)
+			.body(form)
+			.retrieve()
+			.body(KakaoLoginResponse.class);
+
+		if (response == null) {
+			return null;
+		}
+
+		return new OAuthTokenInfo(response.getAccessToken(), response.getRefreshToken());
+	}
+
+	@Override
+	public OAuthUserInfo getUserInfo(String accessToken) {
+		KakaoUserInfo response = kakaoApiRestClient.post()
+			.uri("/user/me")
+			.contentType(MediaType.APPLICATION_FORM_URLENCODED)
+			.header("Authorization", "Bearer " + accessToken)
+			.body("property_keys=[\"kakao_account.email\"]")
+			.retrieve()
+			.body(KakaoUserInfo.class);
+
+		if (response == null || response.getKakaoAccount() == null) {
+			return null;
+		}
+
+		return new OAuthUserInfo(
+			AuthProvider.KAKAO,
+			response.getId(),
+			response.getKakaoAccount().getEmail()
+		);
+	}
+}

--- a/auth-server/src/main/java/com/truve/platform/auth/service/service/social/NaverOAuthProviderClient.java
+++ b/auth-server/src/main/java/com/truve/platform/auth/service/service/social/NaverOAuthProviderClient.java
@@ -1,0 +1,70 @@
+package com.truve.platform.auth.service.service.social;
+
+import static com.truve.platform.auth.service.domain.dto.response.OAuthDTO.*;
+
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestClient;
+
+import com.truve.platform.auth.service.security.properties.NaverOAuthProperties;
+import com.truve.platform.common.constants.AuthProvider;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class NaverOAuthProviderClient implements OAuthProviderClient {
+
+	private final NaverOAuthProperties naverOAuthProperties;
+	private final RestClient naverOAuthRestClient;
+	private final RestClient naverApiRestClient;
+
+	@Override
+	public AuthProvider supports() {
+		return AuthProvider.NAVER;
+	}
+
+	@Override
+	public OAuthTokenInfo exchangeToken(String code, String state) {
+		MultiValueMap<String, String> form = new LinkedMultiValueMap<>();
+		form.add("grant_type", "authorization_code");
+		form.add("client_id", naverOAuthProperties.getClientId());
+		form.add("client_secret", naverOAuthProperties.getClientSecret());
+		form.add("code", code);
+		form.add("state", state);
+
+		NaverLoginResponse response = naverOAuthRestClient.post()
+			.uri("/token")
+			.contentType(MediaType.APPLICATION_FORM_URLENCODED)
+			.body(form)
+			.retrieve()
+			.body(NaverLoginResponse.class);
+
+		if (response == null) {
+			return null;
+		}
+
+		return new OAuthTokenInfo(response.getAccessToken(), response.getRefreshToken());
+	}
+
+	@Override
+	public OAuthUserInfo getUserInfo(String accessToken) {
+		NaverUserInfo response = naverApiRestClient.get()
+			.uri("/me")
+			.header("Authorization", "Bearer " + accessToken)
+			.retrieve()
+			.body(NaverUserInfo.class);
+
+		if (response == null || response.getResponse() == null) {
+			return null;
+		}
+
+		return new OAuthUserInfo(
+			AuthProvider.NAVER,
+			response.getResponse().getId(),
+			response.getResponse().getEmail()
+		);
+	}
+}

--- a/auth-server/src/main/java/com/truve/platform/auth/service/service/social/OAuthProviderClient.java
+++ b/auth-server/src/main/java/com/truve/platform/auth/service/service/social/OAuthProviderClient.java
@@ -1,0 +1,12 @@
+package com.truve.platform.auth.service.service.social;
+
+import com.truve.platform.common.constants.AuthProvider;
+
+public interface OAuthProviderClient {
+
+	AuthProvider supports();
+
+	OAuthTokenInfo exchangeToken(String code, String state);
+
+	OAuthUserInfo getUserInfo(String accessToken);
+}

--- a/auth-server/src/main/java/com/truve/platform/auth/service/service/social/OAuthTokenInfo.java
+++ b/auth-server/src/main/java/com/truve/platform/auth/service/service/social/OAuthTokenInfo.java
@@ -1,0 +1,11 @@
+package com.truve.platform.auth.service.service.social;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class OAuthTokenInfo {
+	private final String accessToken;
+	private final String refreshToken;
+}

--- a/auth-server/src/main/java/com/truve/platform/auth/service/service/social/OAuthUserInfo.java
+++ b/auth-server/src/main/java/com/truve/platform/auth/service/service/social/OAuthUserInfo.java
@@ -1,0 +1,14 @@
+package com.truve.platform.auth.service.service.social;
+
+import com.truve.platform.common.constants.AuthProvider;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class OAuthUserInfo {
+	private final AuthProvider provider;
+	private final String providerUserId;
+	private final String email;
+}

--- a/auth-server/src/main/java/com/truve/platform/auth/service/service/social/SocialLoginResult.java
+++ b/auth-server/src/main/java/com/truve/platform/auth/service/service/social/SocialLoginResult.java
@@ -1,0 +1,31 @@
+package com.truve.platform.auth.service.service.social;
+
+import com.truve.platform.common.constants.AuthProvider;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class SocialLoginResult {
+
+	public enum Status {
+		LOGIN_SUCCESS,
+		SIGN_UP_REQUIRED
+	}
+
+	private final Status status;
+	private final String accessToken;
+	private final String refreshToken;
+	private final String registrationToken;
+	private final String email;
+	private final AuthProvider provider;
+
+	public static SocialLoginResult loginSuccess(String accessToken, String refreshToken, AuthProvider provider) {
+		return new SocialLoginResult(Status.LOGIN_SUCCESS, accessToken, refreshToken, null, null, provider);
+	}
+
+	public static SocialLoginResult signUpRequired(String registrationToken, String email, AuthProvider provider) {
+		return new SocialLoginResult(Status.SIGN_UP_REQUIRED, null, null, registrationToken, email, provider);
+	}
+}

--- a/auth-server/src/main/java/com/truve/platform/auth/service/service/social/SocialRegistrationInfo.java
+++ b/auth-server/src/main/java/com/truve/platform/auth/service/service/social/SocialRegistrationInfo.java
@@ -1,0 +1,18 @@
+package com.truve.platform.auth.service.service.social;
+
+import com.truve.platform.common.constants.AuthProvider;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class SocialRegistrationInfo {
+	private AuthProvider provider;
+	private String providerUserId;
+	private String email;
+	private String oAuthAccessToken;
+	private String oAuthRefreshToken;
+}

--- a/auth-server/src/main/java/com/truve/platform/auth/service/service/social/SocialRegistrationInfo.java
+++ b/auth-server/src/main/java/com/truve/platform/auth/service/service/social/SocialRegistrationInfo.java
@@ -2,17 +2,11 @@ package com.truve.platform.auth.service.service.social;
 
 import com.truve.platform.common.constants.AuthProvider;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-
-@Getter
-@NoArgsConstructor
-@AllArgsConstructor
-public class SocialRegistrationInfo {
-	private AuthProvider provider;
-	private String providerUserId;
-	private String email;
-	private String oAuthAccessToken;
-	private String oAuthRefreshToken;
+public record SocialRegistrationInfo(
+	AuthProvider provider,
+	String providerUserId,
+	String email,
+	String oAuthAccessToken,
+	String oAuthRefreshToken
+) {
 }

--- a/auth-server/src/main/resources/templates/callback.html
+++ b/auth-server/src/main/resources/templates/callback.html
@@ -136,7 +136,12 @@
             <input id="nickname" placeholder="최종 가입 완료 API 붙으면 이 값으로 제출" />
         </div>
     </div>
-    <p class="dim">완료 API가 아직 없어서 지금은 이메일 인증까지 확인하고 닉네임 입력값만 보관하는 테스트용 화면입니다.</p>
+
+    <h4>4. 소셜 회원가입 완료</h4>
+    <div class="row">
+        <button onclick="completeSocialSignUp()">회원가입 완료</button>
+    </div>
+    <p class="dim">이 버튼은 registrationToken, email, nickname, 기본 약관 동의값을 묶어서 최종 가입 완료 API를 호출합니다.</p>
 </div>
 
 <pre id="result"></pre>
@@ -277,6 +282,46 @@
                 (nickname || "(미입력)");
         } catch (e) {
             document.getElementById("result").innerText = "인증코드 검증 실패";
+        }
+    }
+
+    async function completeSocialSignUp() {
+        try {
+            const res = await fetch("http://localhost:8080/api/auth/social/sign-up/complete", {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json"
+                },
+                credentials: "include",
+                body: JSON.stringify({
+                    registrationToken: document.getElementById("registrationToken").value,
+                    email: document.getElementById("email").value,
+                    nickname: document.getElementById("nickname").value,
+                    serviceTermsAgreed: true,
+                    electronicFinanceTermsAgreed: true,
+                    privacyCollectionAgreed: true,
+                    marketingInfoAgreed: false,
+                    over14Agreed: true
+                })
+            });
+
+            const data = await res.json();
+
+            if (!res.ok) {
+                document.getElementById("result").innerText =
+                    "소셜 회원가입 완료 실패\n\n" +
+                    JSON.stringify(data, null, 2);
+                return;
+            }
+
+            accessToken = data.accessToken;
+
+            document.getElementById("result").innerText =
+                "소셜 회원가입 완료 성공\n\n" +
+                JSON.stringify(data, null, 2) +
+                "\n\nrefreshToken은 HttpOnly 쿠키로 저장되었습니다.";
+        } catch (e) {
+            document.getElementById("result").innerText = "소셜 회원가입 완료 호출 실패";
         }
     }
 </script>

--- a/auth-server/src/main/resources/templates/callback.html
+++ b/auth-server/src/main/resources/templates/callback.html
@@ -2,22 +2,183 @@
 <html xmlns:th="http://www.thymeleaf.org">
 <head>
     <title>OAuth Callback</title>
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+            max-width: 860px;
+            margin: 40px auto;
+            padding: 0 20px 40px;
+            line-height: 1.5;
+        }
+
+        .card {
+            border: 1px solid #ddd;
+            border-radius: 16px;
+            padding: 20px;
+            margin-bottom: 16px;
+        }
+
+        .hidden {
+            display: none;
+        }
+
+        .row {
+            display: flex;
+            gap: 12px;
+            flex-wrap: wrap;
+            margin-bottom: 12px;
+        }
+
+        input {
+            width: 100%;
+            max-width: 360px;
+            padding: 10px 12px;
+            border-radius: 10px;
+            border: 1px solid #ccc;
+        }
+
+        button {
+            border: 0;
+            border-radius: 10px;
+            padding: 10px 16px;
+            cursor: pointer;
+            font-weight: 600;
+        }
+
+        pre {
+            white-space: pre-wrap;
+            word-break: break-word;
+            background: #111;
+            color: #f7f7f7;
+            padding: 16px;
+            border-radius: 12px;
+            min-height: 120px;
+        }
+
+        .dim {
+            color: #666;
+        }
+
+        .success {
+            color: #0a7f38;
+            font-weight: 700;
+        }
+
+        .warn {
+            color: #9a6700;
+            font-weight: 700;
+        }
+    </style>
 </head>
 <body>
 
-<h2>OAuth Callback Success</h2>
+<h2>OAuth Callback 테스트 페이지</h2>
 
-<p>Refresh Token은 HttpOnly 쿠키로 저장되었습니다.</p>
+<div class="card">
+    <h3>콜백 상태</h3>
+    <p id="statusText" class="dim">쿼리 파라미터를 확인 중입니다.</p>
+    <div id="summary"></div>
+</div>
 
-<hr>
+<div id="loginSuccessCard" class="card hidden">
+    <h3>기존 회원 로그인 완료</h3>
+    <p>Refresh Token은 HttpOnly 쿠키로 저장되었습니다.</p>
+    <div class="row">
+        <button onclick="reissue()">Access Token 재발급</button>
+        <button onclick="logout()">로그아웃</button>
+    </div>
+</div>
 
-<button onclick="reissue()">Access Token 재발급</button>
-<button onclick="logout()">로그아웃</button>
+<div id="signUpCard" class="card hidden">
+    <h3>신규 소셜 회원 가입 진행</h3>
+    <p class="warn">지금은 시작 플로우까지만 연결되어 있습니다. 이메일 인증은 테스트 가능하고, 최종 소셜 가입 완료 API는 다음 단계에서 붙일 예정입니다.</p>
+
+    <div class="row">
+        <div>
+            <label>Provider</label><br />
+            <input id="provider" readonly />
+        </div>
+        <div>
+            <label>Email</label><br />
+            <input id="email" readonly />
+        </div>
+    </div>
+
+    <div class="row">
+        <div>
+            <label>Registration Token</label><br />
+            <input id="registrationToken" readonly />
+        </div>
+    </div>
+
+    <hr />
+
+    <h4>1. 이메일 인증코드 발송</h4>
+    <div class="row">
+        <button onclick="sendCode()">인증코드 발송</button>
+    </div>
+
+    <h4>2. 이메일 인증코드 검증</h4>
+    <div class="row">
+        <div>
+            <label>인증코드</label><br />
+            <input id="verificationCode" placeholder="이메일로 받은 인증코드 입력" />
+        </div>
+    </div>
+    <div class="row">
+        <button onclick="verifyCode()">인증코드 검증</button>
+    </div>
+
+    <h4>3. 닉네임 입력</h4>
+    <div class="row">
+        <div>
+            <label>닉네임</label><br />
+            <input id="nickname" placeholder="최종 가입 완료 API 붙으면 이 값으로 제출" />
+        </div>
+    </div>
+    <p class="dim">완료 API가 아직 없어서 지금은 이메일 인증까지 확인하고 닉네임 입력값만 보관하는 테스트용 화면입니다.</p>
+</div>
 
 <pre id="result"></pre>
 
 <script>
     let accessToken = null;
+    const params = new URLSearchParams(window.location.search);
+    const status = params.get("status");
+    const provider = params.get("provider");
+    const email = params.get("email");
+    const registrationToken = params.get("registrationToken");
+
+    initialize();
+
+    function initialize() {
+        const statusText = document.getElementById("statusText");
+        const summary = document.getElementById("summary");
+
+        if (status === "login-success") {
+            document.getElementById("loginSuccessCard").classList.remove("hidden");
+            statusText.innerHTML = '<span class="success">기존 회원 로그인 성공</span>';
+            summary.innerHTML = "<p>이제 reissue로 access token을 발급받고 로그아웃까지 테스트할 수 있습니다.</p>";
+            return;
+        }
+
+        if (status === "sign-up-required") {
+            document.getElementById("signUpCard").classList.remove("hidden");
+            document.getElementById("provider").value = provider || "";
+            document.getElementById("email").value = email || "";
+            document.getElementById("registrationToken").value = registrationToken || "";
+
+            statusText.innerHTML = '<span class="warn">신규 소셜 회원 - 추가 가입 절차 필요</span>';
+            summary.innerHTML =
+                "<p><strong>provider:</strong> " + (provider || "-") + "</p>" +
+                "<p><strong>email:</strong> " + (email || "-") + "</p>" +
+                "<p><strong>registrationToken:</strong> " + (registrationToken || "-") + "</p>";
+            return;
+        }
+
+        statusText.innerText = "알 수 없는 콜백 상태입니다. 직접 콜백 URL로 들어왔거나 쿼리 파라미터가 없습니다.";
+        summary.innerHTML = "<p class='dim'>/api/auth/kakao/login 또는 /api/auth/naver/login 으로 다시 시작해보세요.</p>";
+    }
 
     async function reissue() {
         try {
@@ -68,6 +229,54 @@
         } catch (e) {
             document.getElementById("result").innerText =
                 "로그아웃 중 에러 발생";
+        }
+    }
+
+    async function sendCode() {
+        try {
+            const res = await fetch("http://localhost:8080/api/auth/email/send-code", {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json"
+                },
+                body: JSON.stringify({
+                    email: document.getElementById("email").value
+                })
+            });
+
+            const data = await res.json();
+
+            document.getElementById("result").innerText =
+                "인증코드 발송 응답\n\n" +
+                JSON.stringify(data, null, 2);
+        } catch (e) {
+            document.getElementById("result").innerText = "인증코드 발송 실패";
+        }
+    }
+
+    async function verifyCode() {
+        try {
+            const res = await fetch("http://localhost:8080/api/auth/email/verify", {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json"
+                },
+                body: JSON.stringify({
+                    email: document.getElementById("email").value,
+                    code: document.getElementById("verificationCode").value
+                })
+            });
+
+            const data = await res.json();
+            const nickname = document.getElementById("nickname").value;
+
+            document.getElementById("result").innerText =
+                "인증코드 검증 응답\n\n" +
+                JSON.stringify(data, null, 2) +
+                "\n\n입력한 nickname\n\n" +
+                (nickname || "(미입력)");
+        } catch (e) {
+            document.getElementById("result").innerText = "인증코드 검증 실패";
         }
     }
 </script>

--- a/auth-server/src/main/resources/templates/login.html
+++ b/auth-server/src/main/resources/templates/login.html
@@ -1,15 +1,76 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org">
 <head>
-    <title>Kakao Login Test</title>
+    <title>OAuth Login Test</title>
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+            max-width: 760px;
+            margin: 48px auto;
+            padding: 0 20px;
+            line-height: 1.5;
+        }
+
+        .card {
+            border: 1px solid #ddd;
+            border-radius: 16px;
+            padding: 24px;
+            margin-bottom: 20px;
+        }
+
+        .actions {
+            display: flex;
+            gap: 12px;
+            flex-wrap: wrap;
+            margin-top: 16px;
+        }
+
+        button {
+            border: 0;
+            border-radius: 10px;
+            padding: 12px 18px;
+            cursor: pointer;
+            font-weight: 600;
+        }
+
+        .kakao {
+            background: #fee500;
+            color: #191919;
+        }
+
+        .naver {
+            background: #03c75a;
+            color: white;
+        }
+
+        code {
+            background: #f5f5f5;
+            padding: 2px 6px;
+            border-radius: 6px;
+        }
+    </style>
 </head>
 <body>
 
-<h2>Kakao Login Test Page</h2>
+<h2>소셜 로그인 테스트 페이지</h2>
 
-<a href="/api/auth/kakao/login">
-    <button>카카오 로그인</button>
-</a>
+<div class="card">
+    <h3>테스트 흐름</h3>
+    <p>기존 회원이면 바로 로그인 완료로 이동하고, 신규 회원이면 <code>registrationToken</code>과 함께 회원가입 진행 상태로 이동합니다.</p>
+    <p>콜백 페이지는 <code>/test/callback</code>에서 확인할 수 있습니다.</p>
+</div>
+
+<div class="card">
+    <h3>소셜 로그인 시작</h3>
+    <div class="actions">
+        <a href="/api/auth/kakao/login">
+            <button class="kakao" type="button">카카오 로그인</button>
+        </a>
+        <a href="/api/auth/naver/login">
+            <button class="naver" type="button">네이버 로그인</button>
+        </a>
+    </div>
+</div>
 
 </body>
 </html>

--- a/auth-server/src/test/java/com/truve/platform/auth/service/controller/AuthControllerTest.java
+++ b/auth-server/src/test/java/com/truve/platform/auth/service/controller/AuthControllerTest.java
@@ -1,6 +1,7 @@
 package com.truve.platform.auth.service.controller;
 
 import static org.mockito.BDDMockito.*;
+import static org.mockito.ArgumentMatchers.any;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -19,6 +20,7 @@ import org.springframework.test.web.servlet.ResultActions;
 import com.truve.platform.auth.service.security.AuthCookieManager;
 import com.truve.platform.auth.service.security.config.SecurityConfig;
 import com.truve.platform.auth.service.service.AuthService;
+import com.truve.platform.auth.service.service.SocialLoginService;
 import com.truve.platform.common.exception.CustomException;
 import com.truve.platform.common.exception.ErrorCode;
 
@@ -32,6 +34,8 @@ class AuthControllerTest {
 	private MockMvc mockMvc;
 	@MockitoBean
 	private AuthService authService;
+	@MockitoBean
+	private SocialLoginService socialLoginService;
 	@MockitoBean
 	private AuthCookieManager authCookieManager;
 	@MockitoBean
@@ -170,6 +174,37 @@ class AuthControllerTest {
 
 		// when
 		ResultActions resultActions = mockMvc.perform(post("/api/auth/login")
+			.contentType(MediaType.APPLICATION_JSON)
+			.content(body));
+
+		// then
+		resultActions.andExpect(status().isOk())
+			.andExpect(jsonPath("$.accessToken").value("access-token"));
+		verify(authCookieManager).setRefreshToken(any(HttpServletResponse.class), eq("refresh-token"), eq(1209600L));
+	}
+
+	@Test
+	@DisplayName("소셜 회원가입 완료에 성공하면 accessToken을 반환하고 refreshToken 쿠키를 설정한다.")
+	void 소셜회원가입완료_성공() throws Exception {
+		// given
+		String body = """
+			{
+			  "registrationToken": "registration-token",
+			  "email": "social@test.com",
+			  "nickname": "tester",
+			  "serviceTermsAgreed": true,
+			  "electronicFinanceTermsAgreed": true,
+			  "privacyCollectionAgreed": true,
+			  "marketingInfoAgreed": false,
+			  "over14Agreed": true
+			}
+			""";
+		given(socialLoginService.completeSignUp(
+			any(com.truve.platform.auth.service.domain.dto.request.AuthRequest.CompleteSocialSignUp.class)
+		)).willReturn(Pair.of("access-token", "refresh-token"));
+
+		// when
+		ResultActions resultActions = mockMvc.perform(post("/api/auth/social/sign-up/complete")
 			.contentType(MediaType.APPLICATION_JSON)
 			.content(body));
 

--- a/auth-server/src/test/java/com/truve/platform/auth/service/service/SocialLoginServiceTest.java
+++ b/auth-server/src/test/java/com/truve/platform/auth/service/service/SocialLoginServiceTest.java
@@ -1,0 +1,189 @@
+package com.truve.platform.auth.service.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import java.util.Date;
+import java.util.List;
+import java.util.UUID;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.util.Pair;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.truve.platform.auth.service.domain.dto.request.AuthRequest;
+import com.truve.platform.auth.service.domain.entity.User;
+import com.truve.platform.auth.service.repository.EmailVerificationRepository;
+import com.truve.platform.auth.service.repository.SocialRegistrationRepository;
+import com.truve.platform.auth.service.repository.UserRepository;
+import com.truve.platform.auth.service.security.JwtService;
+import com.truve.platform.auth.service.service.social.OAuthProviderClient;
+import com.truve.platform.auth.service.service.social.SocialRegistrationInfo;
+import com.truve.platform.common.constants.AuthProvider;
+import com.truve.platform.common.constants.UserRole;
+import com.truve.platform.common.exception.CustomException;
+import com.truve.platform.common.exception.ErrorCode;
+
+@ExtendWith(MockitoExtension.class)
+class SocialLoginServiceTest {
+
+	@Mock
+	private OAuthProviderClient naverOAuthProviderClient;
+	@Mock
+	private List<OAuthProviderClient> oauthProviderClients;
+	@Mock
+	private UserRepository userRepository;
+	@Mock
+	private EmailVerificationRepository emailVerificationRepository;
+	@Mock
+	private JwtService jwtService;
+	@Mock
+	private RefreshTokenService refreshTokenService;
+	@Mock
+	private SocialRegistrationRepository socialRegistrationRepository;
+
+	@InjectMocks
+	private SocialLoginService socialLoginService;
+
+	@Test
+	@DisplayName("소셜 가입 완료에 성공하면 회원을 저장하고 로그인 토큰을 발급한다.")
+	void 소셜회원가입완료_성공() {
+		// given
+		String registrationToken = "registration-token";
+		String email = "social@test.com";
+		String nickname = "tester";
+		AuthRequest.CompleteSocialSignUp request = new AuthRequest.CompleteSocialSignUp(
+			registrationToken,
+			email,
+			nickname,
+			true,
+			true,
+			true,
+			false,
+			true
+		);
+		SocialRegistrationInfo registrationInfo = new SocialRegistrationInfo(
+			AuthProvider.KAKAO,
+			"provider-user-id",
+			email,
+			"oauth-access-token",
+			"oauth-refresh-token"
+		);
+		Date accessExp = new Date(System.currentTimeMillis() + 60_000L);
+		Date refreshExp = new Date(System.currentTimeMillis() + 120_000L);
+
+		given(socialRegistrationRepository.find(registrationToken)).willReturn(registrationInfo);
+		given(emailVerificationRepository.isVerifiedEmail(email)).willReturn("verified");
+		given(userRepository.existsByEmail(email)).willReturn(false);
+		given(userRepository.existsByNickname(nickname)).willReturn(false);
+		given(userRepository.save(any(User.class))).willAnswer(invocation -> {
+			User user = invocation.getArgument(0);
+			ReflectionTestUtils.setField(user, "id", 1L);
+			return user;
+		});
+		given(jwtService.getAccessExpiration()).willReturn(accessExp);
+		given(jwtService.getRefreshExpiration()).willReturn(refreshExp);
+		given(jwtService.issue(any(UUID.class), eq(1L), eq(email), eq(UserRole.MEMBER), eq(accessExp), eq("access")))
+			.willReturn("access-token");
+		given(jwtService.issue(any(UUID.class), eq(1L), eq(email), eq(UserRole.MEMBER), eq(refreshExp), eq("refresh")))
+			.willReturn("refresh-token");
+
+		// when
+		Pair<String, String> result = socialLoginService.completeSignUp(request);
+
+		// then
+		ArgumentCaptor<User> userCaptor = ArgumentCaptor.forClass(User.class);
+		verify(userRepository).save(userCaptor.capture());
+
+		User savedUser = userCaptor.getValue();
+		assertAll(
+			() -> assertThat(result.getFirst()).isEqualTo("access-token"),
+			() -> assertThat(result.getSecond()).isEqualTo("refresh-token"),
+			() -> assertThat(savedUser.getEmail()).isEqualTo(email),
+			() -> assertThat(savedUser.getNickname()).isEqualTo(nickname),
+			() -> assertThat(savedUser.getProvider()).isEqualTo(AuthProvider.KAKAO),
+			() -> assertThat(savedUser.getOAuthUserId()).isEqualTo("provider-user-id"),
+			() -> assertThat(savedUser.isServiceTermsAgreed()).isTrue(),
+			() -> assertThat(savedUser.isElectronicFinanceTermsAgreed()).isTrue(),
+			() -> assertThat(savedUser.isPrivacyCollectionAgreed()).isTrue(),
+			() -> assertThat(savedUser.isMarketingInfoAgreed()).isFalse(),
+			() -> assertThat(savedUser.isOver14Agreed()).isTrue()
+		);
+		verify(emailVerificationRepository).deleteVerifiedEmail(email);
+		verify(socialRegistrationRepository).delete(registrationToken);
+		verify(refreshTokenService).save(any(UUID.class), eq("refresh-token"), any(Long.class));
+	}
+
+	@Test
+	@DisplayName("소셜 가입 토큰이 없으면 예외가 발생한다.")
+	void 소셜회원가입완료_실패_토큰없음() {
+		// given
+		given(socialRegistrationRepository.find("registration-token")).willReturn(null);
+
+		// when
+		CustomException exception = assertThrows(
+			CustomException.class,
+			() -> socialLoginService.completeSignUp(
+				new AuthRequest.CompleteSocialSignUp(
+					"registration-token",
+					"social@test.com",
+					"tester",
+					true,
+					true,
+					true,
+					false,
+					true
+				)
+			)
+		);
+
+		// then
+		assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.INVALID_SOCIAL_REGISTRATION_TOKEN);
+		verify(userRepository, never()).save(any());
+	}
+
+	@Test
+	@DisplayName("이메일 인증이 안 되어 있으면 예외가 발생한다.")
+	void 소셜회원가입완료_실패_이메일미인증() {
+		// given
+		String registrationToken = "registration-token";
+		String email = "social@test.com";
+		given(socialRegistrationRepository.find(registrationToken)).willReturn(
+			new SocialRegistrationInfo(AuthProvider.NAVER, "provider-user-id", email, "oauth-access-token", "oauth-refresh-token")
+		);
+		given(emailVerificationRepository.isVerifiedEmail(email)).willReturn(null);
+
+		// when
+		CustomException exception = assertThrows(
+			CustomException.class,
+			() -> socialLoginService.completeSignUp(
+				new AuthRequest.CompleteSocialSignUp(
+					registrationToken,
+					email,
+					"tester",
+					true,
+					true,
+					true,
+					false,
+					true
+				)
+			)
+		);
+
+		// then
+		assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.NOT_VERIFIED_EMAIL);
+		verify(userRepository, never()).save(any());
+	}
+}

--- a/auth-server/src/test/java/com/truve/platform/auth/service/service/SocialLoginServiceTest.java
+++ b/auth-server/src/test/java/com/truve/platform/auth/service/service/SocialLoginServiceTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
@@ -53,6 +54,8 @@ class SocialLoginServiceTest {
 	private RefreshTokenService refreshTokenService;
 	@Mock
 	private SocialRegistrationRepository socialRegistrationRepository;
+	@Mock
+	private UserSignedUpEventPublisher userSignedUpEventPublisher;
 
 	@InjectMocks
 	private SocialLoginService socialLoginService;
@@ -124,6 +127,7 @@ class SocialLoginServiceTest {
 		verify(emailVerificationRepository).deleteVerifiedEmail(email);
 		verify(socialRegistrationRepository).delete(registrationToken);
 		verify(refreshTokenService).save(any(UUID.class), eq("refresh-token"), any(Long.class));
+		verify(userSignedUpEventPublisher).publish(anyString(), any());
 	}
 
 	@Test

--- a/common/src/main/java/com/truve/platform/common/exception/ErrorCode.java
+++ b/common/src/main/java/com/truve/platform/common/exception/ErrorCode.java
@@ -23,6 +23,7 @@ public enum ErrorCode {
 	ALREADY_EXISTS_NICKNAME(HttpStatus.BAD_REQUEST, "중복된 닉네임입니다.", "A12"),
 	ALREADY_WITHDRAWN_USER(HttpStatus.BAD_REQUEST, "이미 탈퇴한 회원입니다.", "A13"),
 	INVALID_AUTH_PROVIDER(HttpStatus.BAD_REQUEST, "유효하지 않은 소셜 로그인 제공자입니다.", "A14"),
+	INVALID_SOCIAL_REGISTRATION_TOKEN(HttpStatus.BAD_REQUEST, "유효하지 않은 소셜 가입 토큰입니다.", "A15"),
 
 	NOT_FOUND_PAYMENT(HttpStatus.BAD_REQUEST, "존재하지 않는 결제입니다.", "P01"),
 	INVALID_PAYMENT_AMOUNT(HttpStatus.BAD_REQUEST, "유효하지 않은 결제 금액입니다.", "P02"),

--- a/common/src/main/java/com/truve/platform/common/exception/ErrorCode.java
+++ b/common/src/main/java/com/truve/platform/common/exception/ErrorCode.java
@@ -22,6 +22,7 @@ public enum ErrorCode {
 	INVALID_NICKNAME(HttpStatus.BAD_REQUEST, "유효하지 않은 닉네임입니다.", "A11"),
 	ALREADY_EXISTS_NICKNAME(HttpStatus.BAD_REQUEST, "중복된 닉네임입니다.", "A12"),
 	ALREADY_WITHDRAWN_USER(HttpStatus.BAD_REQUEST, "이미 탈퇴한 회원입니다.", "A13"),
+	INVALID_AUTH_PROVIDER(HttpStatus.BAD_REQUEST, "유효하지 않은 소셜 로그인 제공자입니다.", "A14"),
 
 	NOT_FOUND_PAYMENT(HttpStatus.BAD_REQUEST, "존재하지 않는 결제입니다.", "P01"),
 	INVALID_PAYMENT_AMOUNT(HttpStatus.BAD_REQUEST, "유효하지 않은 결제 금액입니다.", "P02"),

--- a/musical/src/main/java/com/truve/platform/musical/review/service/ReviewService.java
+++ b/musical/src/main/java/com/truve/platform/musical/review/service/ReviewService.java
@@ -9,7 +9,9 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -110,7 +112,15 @@ public class ReviewService {
 	}
 
 	public Page<ReviewResponse.ReviewItem> getReviews(Long showId, ReviewSortType sort, Paging paging) {
-		Page<Review> reviews = getSortedReviews(showId, sort, paging.toPageable());
+		Pageable pageable = PageRequest.of(
+			paging.getPage() - 1,
+			paging.getSize(),
+			Sort.by(
+				Sort.Order.desc("createdAt"),
+				Sort.Order.desc("id")
+			)
+		);
+		Page<Review> reviews = getSortedReviews(showId, sort, pageable);
 		return reviews.map(this::toReviewItem);
 	}
 

--- a/musical/src/test/java/com/truve/platform/musical/review/service/ReviewServiceTest.java
+++ b/musical/src/test/java/com/truve/platform/musical/review/service/ReviewServiceTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -21,12 +22,17 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import com.truve.platform.common.exception.CustomException;
 import com.truve.platform.common.exception.ErrorCode;
+import com.truve.platform.common.response.Paging;
 import com.truve.platform.musical.review.dao.ReviewPointCountDao;
 import com.truve.platform.musical.review.domain.constant.ReviewPointName;
+import com.truve.platform.musical.review.domain.constant.ReviewSortType;
 import com.truve.platform.musical.review.domain.entity.Review;
 import com.truve.platform.musical.review.domain.entity.ReviewPoint;
 import com.truve.platform.musical.review.domain.entity.ReviewPointType;
@@ -34,6 +40,8 @@ import com.truve.platform.musical.review.dto.ReviewRequest;
 import com.truve.platform.musical.review.repository.ReviewPointRepository;
 import com.truve.platform.musical.review.repository.ReviewPointTypeRepository;
 import com.truve.platform.musical.review.repository.ReviewRepository;
+import com.truve.platform.musical.user.domain.entity.User;
+import com.truve.platform.musical.user.repository.UserRepository;
 
 @ExtendWith(MockitoExtension.class)
 class ReviewServiceTest {
@@ -44,6 +52,8 @@ class ReviewServiceTest {
 	private ReviewPointTypeRepository reviewPointTypeRepository;
 	@Mock
 	private ReviewPointRepository reviewPointRepository;
+	@Mock
+	private UserRepository userRepository;
 
 	@InjectMocks
 	private ReviewService reviewService;
@@ -171,6 +181,47 @@ class ReviewServiceTest {
 			() -> assertThat(response.getTruveScore()).isEqualTo(75L),
 			() -> assertThat(response.getCharmPointScores()).isNotEmpty(),
 			() -> assertThat(response.getEmotionPointScores()).isNotEmpty()
+		);
+	}
+
+	@Test
+	@DisplayName("리뷰 목록 조회는 최신순(createdAt desc, id desc)으로 정렬 요청한다.")
+	void 리뷰목록_최신순_정렬요청() {
+		// given
+		Long showId = 1L;
+		Paging paging = new Paging(1, 10);
+		Review review = Review.builder()
+			.showId(showId)
+			.userId(UUID.fromString("11111111-1111-1111-1111-111111111111"))
+			.title("리뷰 제목")
+			.content("리뷰 내용")
+			.isPositive(true)
+			.watchedAt(java.time.LocalDateTime.now())
+			.build();
+		ReflectionTestUtils.setField(review, "id", 1L);
+		ReflectionTestUtils.setField(review, "createdAt", java.time.LocalDateTime.now());
+
+		User user = mock(User.class);
+		when(user.getNickname()).thenReturn("tester");
+
+		given(reviewRepository.findByShowIdAndDeletedAtIsNull(any(Long.class), any(Pageable.class)))
+			.willReturn(new PageImpl<>(List.of(review)));
+		given(userRepository.findByUserId(review.getUserId())).willReturn(Optional.of(user));
+
+		// when
+		Page<?> result = reviewService.getReviews(showId, ReviewSortType.LATEST, paging);
+
+		// then
+		ArgumentCaptor<Pageable> pageableCaptor = ArgumentCaptor.forClass(Pageable.class);
+		verify(reviewRepository).findByShowIdAndDeletedAtIsNull(eq(showId), pageableCaptor.capture());
+
+		Pageable pageable = pageableCaptor.getValue();
+		assertAll(
+			() -> assertThat(result.getContent()).hasSize(1),
+			() -> assertThat(pageable.getSort().getOrderFor("createdAt")).isNotNull(),
+			() -> assertThat(pageable.getSort().getOrderFor("createdAt").isDescending()).isTrue(),
+			() -> assertThat(pageable.getSort().getOrderFor("id")).isNotNull(),
+			() -> assertThat(pageable.getSort().getOrderFor("id").isDescending()).isTrue()
 		);
 	}
 


### PR DESCRIPTION
## 변경 사항

추가/변경 사항과 사유를 작성해 주세요.

- [x] 전체 테스트 코드 성공 여부

### 소셜로그인 전략패턴 활용하여 추상화
최대한 책임 분리해서 인터페이스 의존하도록 추상화했습니다.
많은 래퍼런스들이 있어서 참고했는데, 막상 하고나서보니 코드 복잡도가 올라간 것 같기는 합니다.
책임은 분리된 것 같아서 좋기는 한 것 같아요

### 소셜로그인 이후 이메일 인증 및 닉네임 입력
미루던 기획측 의도 반영했습니다.
소셜로그인에서 받아온 토큰을 레디스에서 저장하고, 이메일 인증과 닉네임 입력을 받아 최종 회원가입 하는 구조입니다.
이건 프론트측이랑 얘기해보고 반영할 지 결정이 필요합니다!


## 관련 이슈

- Notion Ticket: [#27](https://www.notion.so/OAuth-3049e3e335cc807688cac242d757c15f?source=copy_link)

## 참고사항 (선택)
PR이 꽤 길어졌네요..
redis에 저장되는 소셜로그인 정보 레코드 활용했는데, 클래스 사용하면 자꾸 역직렬화 오류나서 그랬습니다
이거 한번 탐구해보면 좋겠네요..