### PR TITLE
feat(gateway): S3 로그 업로드 기능 구현

### DIFF
--- a/api-gateway/build.gradle
+++ b/api-gateway/build.gradle
@@ -23,6 +23,9 @@ dependencies {
 
     // [OpenApi]
     implementation 'org.springdoc:springdoc-openapi-starter-webflux-ui'
+
+    // [S3]
+    implementation 'software.amazon.awssdk:s3:2.26.12'
 }
 
 dependencyManagement {

--- a/api-gateway/src/main/java/com/truve/platform/apigateway/authentication/TelemetryAuthFilter.java
+++ b/api-gateway/src/main/java/com/truve/platform/apigateway/authentication/TelemetryAuthFilter.java
@@ -1,0 +1,66 @@
+package com.truve.platform.apigateway.authentication;
+
+import javax.crypto.SecretKey;
+
+import org.springframework.core.Ordered;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.server.ServerWebExchange;
+import org.springframework.web.server.WebFilter;
+import org.springframework.web.server.WebFilterChain;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import lombok.RequiredArgsConstructor;
+import reactor.core.publisher.Mono;
+
+@Component
+@RequiredArgsConstructor
+public class TelemetryAuthFilter implements WebFilter, Ordered {
+
+	private final JwtProperties jwtProperties;
+
+	@Override
+	public Mono<Void> filter(ServerWebExchange exchange, WebFilterChain chain) {
+		if (!exchange.getRequest().getPath().value().startsWith("/telemetry")) {
+			return chain.filter(exchange);
+		}
+
+		String token = exchange.getRequest()
+			.getHeaders()
+			.getFirst("Authorization");
+
+		if (token == null || !token.startsWith("Bearer ")) {
+			return chain.filter(exchange);
+		}
+
+		try {
+			String accessToken = token.substring(7);
+			SecretKey secretKey = jwtProperties.getSecretKey();
+			Claims claims = Jwts.parser()
+				.verifyWith(secretKey)
+				.build()
+				.parseSignedClaims(accessToken)
+				.getPayload();
+
+			String userId = claims.get("user_public_id", String.class);
+			String role = claims.get("role", String.class);
+			String tokenType = claims.get("token_type", String.class);
+
+			if (!"access".equals(tokenType) || !StringUtils.hasText(tokenType)) {
+				return chain.filter(exchange);
+			}
+
+			exchange.getAttributes().put("userId", userId);
+			return chain.filter(exchange);
+		} catch (JwtException e) {
+			return chain.filter(exchange);
+		}
+	}
+
+	@Override
+	public int getOrder() {
+		return Ordered.HIGHEST_PRECEDENCE + 1;
+	}
+}

--- a/api-gateway/src/main/java/com/truve/platform/apigateway/logging/LoggingFilter.java
+++ b/api-gateway/src/main/java/com/truve/platform/apigateway/logging/LoggingFilter.java
@@ -29,10 +29,11 @@ public class LoggingFilter implements WebFilter, Ordered {
 	private final KafkaTemplate<String, String> kafkaTemplate;
 	private final S3LogUploader s3LogUploader;
 
-	private static final String TARGET_USER_ID = "49e7bc75-7bcb-44d9-ab8e-8d71a67df937";
+	private static final List<String> TARGET_USER_ID = List.of(
+		"49e7bc75-7bcb-44d9-ab8e-8d71a67df937",
+		"64683eca-4333-477f-ba2d-c63566162d5a");
 
 	private static final List<String> EXCLUDE_PATHS = List.of(
-		"/api/auth",
 		"/swagger-ui",
 		"/v3/api-docs",
 		"/api/auth/v3/api-docs",
@@ -93,8 +94,8 @@ public class LoggingFilter implements WebFilter, Ordered {
 				kv("userId", ctx.userId),
 				kv("requestBody", ctx.requestBody)
 			);
-			if (TARGET_USER_ID.equals(ctx.getUserId())) {
-				s3LogUploader.enqueue(ctx.toJson(), "client_telemetry_log_FE");
+			if (ctx.getUserId() != null && TARGET_USER_ID.contains(ctx.getUserId())) {
+				s3LogUploader.enqueue(ctx.toJson(), "FE");
 			}
 			//sendToKafka(ctx);
 			return;
@@ -111,7 +112,7 @@ public class LoggingFilter implements WebFilter, Ordered {
 			kv("statusCode", ctx.statusCode),
 			kv("requestBody", ctx.requestBody)
 		);
-		if (TARGET_USER_ID.equals(ctx.getUserId())) {
+		if (ctx.getUserId() != null && TARGET_USER_ID.contains(ctx.getUserId())) {
 			s3LogUploader.enqueue(ctx.toJson(), "BE");
 		}
 		//sendToKafka(ctx);

--- a/api-gateway/src/main/java/com/truve/platform/apigateway/logging/LoggingFilter.java
+++ b/api-gateway/src/main/java/com/truve/platform/apigateway/logging/LoggingFilter.java
@@ -27,6 +27,9 @@ public class LoggingFilter implements WebFilter, Ordered {
 
 	private static final String TOPIC = "raw.gateway";
 	private final KafkaTemplate<String, String> kafkaTemplate;
+	private final S3LogUploader s3LogUploader;
+
+	private static final String TARGET_USER_ID = "49e7bc75-7bcb-44d9-ab8e-8d71a67df937";
 
 	private static final List<String> EXCLUDE_PATHS = List.of(
 		"/api/auth",
@@ -90,6 +93,9 @@ public class LoggingFilter implements WebFilter, Ordered {
 				kv("userId", ctx.userId),
 				kv("requestBody", ctx.requestBody)
 			);
+			if (TARGET_USER_ID.equals(ctx.getUserId())) {
+				s3LogUploader.enqueue(ctx.toJson(), "client_telemetry_log_FE");
+			}
 			//sendToKafka(ctx);
 			return;
 		}
@@ -105,6 +111,9 @@ public class LoggingFilter implements WebFilter, Ordered {
 			kv("statusCode", ctx.statusCode),
 			kv("requestBody", ctx.requestBody)
 		);
+		if (TARGET_USER_ID.equals(ctx.getUserId())) {
+			s3LogUploader.enqueue(ctx.toJson(), "BE");
+		}
 		//sendToKafka(ctx);
 	}
 

--- a/api-gateway/src/main/java/com/truve/platform/apigateway/logging/S3LogUploader.java
+++ b/api-gateway/src/main/java/com/truve/platform/apigateway/logging/S3LogUploader.java
@@ -1,0 +1,189 @@
+package com.truve.platform.apigateway.logging;
+
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.ReentrantLock;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3ClientBuilder;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+@Component
+public class S3LogUploader {
+
+	private static final DateTimeFormatter DATE_FORMATTER =
+		DateTimeFormatter.ofPattern("yyyy-MM-dd", Locale.ROOT).withZone(ZoneOffset.UTC);
+
+	@Value("${log.s3.bucket:}")
+	private String bucket;
+
+	@Value("${log.s3.region:ap-northeast-2}")
+	private String region;
+
+	@Value("${log.s3.endpoint:}")
+	private String endpoint;
+
+	@Value("${log.s3.access-key:}")
+	private String accessKey;
+
+	@Value("${log.s3.secret-key:}")
+	private String secretKey;
+
+	@Value("${log.s3.flush-size:100}")
+	private int flushSize;
+
+	@Value("${log.s3.flush-interval-seconds:5}")
+	private int flushIntervalSeconds;
+
+	private S3Client s3Client;
+	private final Map<String, List<String>> buffers = new HashMap<>();
+	private final ReentrantLock lock = new ReentrantLock();
+	private ScheduledExecutorService flushScheduler;
+	private ExecutorService uploadExecutor;
+
+	@PostConstruct
+	void init() {
+		if (bucket.isBlank()) {
+			return;
+		}
+
+		s3Client = buildS3Client();
+
+		uploadExecutor = Executors.newSingleThreadExecutor(r -> {
+			Thread t = new Thread(r, "s3-log-uploader");
+			t.setDaemon(true);
+			return t;
+		});
+
+		flushScheduler = Executors.newSingleThreadScheduledExecutor(r -> {
+			Thread t = new Thread(r, "s3-log-flush-timer");
+			t.setDaemon(true);
+			return t;
+		});
+		flushScheduler.scheduleWithFixedDelay(
+			this::triggerFlush,
+			flushIntervalSeconds, flushIntervalSeconds, TimeUnit.SECONDS
+		);
+	}
+
+	public void enqueue(String logJson, String s3Prefix) {
+		if (s3Client == null)
+			return;
+
+		List<String> toUpload = null;
+		lock.lock();
+		try {
+			List<String> buf = buffers.computeIfAbsent(s3Prefix, k -> new ArrayList<>());
+			buf.add(logJson + "\n");
+			if (buf.size() >= flushSize) {
+				toUpload = drainPrefix(s3Prefix);
+			}
+		} finally {
+			lock.unlock();
+		}
+
+		if (toUpload != null) {
+			submitUpload(toUpload, s3Prefix);
+		}
+	}
+
+	private void triggerFlush() {
+		Map<String, List<String>> snapshot;
+		lock.lock();
+		try {
+			snapshot = new HashMap<>();
+			buffers.forEach((prefix, buf) -> {
+				if (!buf.isEmpty()) {
+					snapshot.put(prefix, new ArrayList<>(buf));
+					buf.clear();
+				}
+			});
+		} finally {
+			lock.unlock();
+		}
+		snapshot.forEach((prefix, lines) -> submitUpload(lines, prefix));
+	}
+
+	private List<String> drainPrefix(String prefix) {
+		List<String> buf = buffers.getOrDefault(prefix, new ArrayList<>());
+		List<String> snapshot = new ArrayList<>(buf);
+		buf.clear();
+		return snapshot;
+	}
+
+	private void submitUpload(List<String> lines, String prefix) {
+		uploadExecutor.submit(() -> upload(lines, prefix));
+	}
+
+	private void upload(List<String> lines, String prefix) {
+		String content = String.join("", lines);
+		Instant now = Instant.now();
+		String key = prefix + "/" + DATE_FORMATTER.format(now) + "/" + now.toEpochMilli() + ".log";
+
+		s3Client.putObject(
+			PutObjectRequest.builder()
+				.bucket(bucket)
+				.key(key)
+				.contentType("application/json")
+				.build(),
+			RequestBody.fromString(content, StandardCharsets.UTF_8)
+		);
+	}
+
+	private S3Client buildS3Client() {
+		S3ClientBuilder builder = S3Client.builder().region(Region.of(region));
+
+		if (!accessKey.isBlank() && !secretKey.isBlank()) {
+			builder.credentialsProvider(StaticCredentialsProvider.create(
+				AwsBasicCredentials.create(accessKey, secretKey)));
+		} else {
+			builder.credentialsProvider(DefaultCredentialsProvider.create());
+		}
+
+		if (!endpoint.isBlank()) {
+			builder.endpointOverride(URI.create(endpoint)).forcePathStyle(true);
+		}
+
+		return builder.build();
+	}
+
+	@PreDestroy
+	void shutdown() {
+		if (s3Client == null)
+			return;
+		if (flushScheduler != null)
+			flushScheduler.shutdown();
+		triggerFlush();
+		if (uploadExecutor != null) {
+			uploadExecutor.shutdown();
+			try {
+				uploadExecutor.awaitTermination(10, TimeUnit.SECONDS);
+			} catch (InterruptedException e) {
+				Thread.currentThread().interrupt();
+			}
+		}
+		s3Client.close();
+	}
+}

--- a/api-gateway/src/main/resources/application.yml
+++ b/api-gateway/src/main/resources/application.yml
@@ -163,7 +163,7 @@ log:
     access-key: ${LOG_S3_ACCESS_KEY:}
     secret-key: ${LOG_S3_SECRET_KEY:}
     flush-size: 100
-    flush-interval-seconds: 60
+    flush-interval-seconds: 300
 
 jwt:
   secret: ${kt.jwt.secret:kt-cloud-tech-up-final-project-2026020201010101}

--- a/api-gateway/src/main/resources/application.yml
+++ b/api-gateway/src/main/resources/application.yml
@@ -155,6 +155,16 @@ spring:
 
 
 
+log:
+  s3:
+    bucket: ${LOG_S3_BUCKET:}
+    region: ${LOG_S3_REGION:ap-northeast-2}
+    endpoint: ${LOG_S3_ENDPOINT:}
+    access-key: ${LOG_S3_ACCESS_KEY:}
+    secret-key: ${LOG_S3_SECRET_KEY:}
+    flush-size: 100
+    flush-interval-seconds: 60
+
 jwt:
   secret: ${kt.jwt.secret:kt-cloud-tech-up-final-project-2026020201010101}
   access-token-expiration: ${kt.jwt.access-token-expiration:300000} # 5

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -73,10 +73,10 @@ services:
       - TICKETING_SERVER_URI=http://ticketing:8084
       - MUSICAL_SERVER_URI=http://musical:8085
       - KAFKA_SERVERS=kafka:9092
-      - LOG_S3_BUCKET=truve-logs
+      - LOG_S3_BUCKET=truve-dev-raw-data
       - LOG_S3_REGION=ap-northeast-2
-      - LOG_S3_ACCESS_KEY=test
-      - LOG_S3_SECRET_KEY=test
+      - LOG_S3_ACCESS_KEY=${AWS_ACCESS_KEY}
+      - LOG_S3_SECRET_KEY=${AWS_SECRET_KEY}
       - LOG_S3_ENDPOINT=http://localstack:4566
     networks:
       - truve-network

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -73,6 +73,11 @@ services:
       - TICKETING_SERVER_URI=http://ticketing:8084
       - MUSICAL_SERVER_URI=http://musical:8085
       - KAFKA_SERVERS=kafka:9092
+      - LOG_S3_BUCKET=truve-logs
+      - LOG_S3_REGION=ap-northeast-2
+      - LOG_S3_ACCESS_KEY=test
+      - LOG_S3_SECRET_KEY=test
+      - LOG_S3_ENDPOINT=http://localstack:4566
     networks:
       - truve-network
 

--- a/init-s3.sh
+++ b/init-s3.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 awslocal s3 mb s3://truve-media
-awslocal s3 mb s3://truve-logs
+awslocal s3 mb s3://truve-dev-raw-data
 
 awslocal s3api put-public-access-block \
     --bucket truve-media \

--- a/init-s3.sh
+++ b/init-s3.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 awslocal s3 mb s3://truve-media
+awslocal s3 mb s3://truve-logs
 
 awslocal s3api put-public-access-block \
     --bucket truve-media \


### PR DESCRIPTION
## 변경 사항

---
### `TelemetryAuthFilter` 추가

프론트엔드 변수 전달용인 `/telemetry` API는 Spring Cloud 포워딩이 아니기 때문에 JwtFilter를 거치지 않습니다.
따라서 별도의 WebFilter를 추가했습니다. 
이 부분 중복코드 제거하고 개선할 수 있을 거 같은데, 우선 기능 배포하고 천천히 진행하겠습니다 ㅜㅜ

### `LoggingFilter` 특정 User ID의 요청을 S3으로 업로드하는 기능 추가

보안팀 계정과 제 테스트용 계정 User ID 요청에 한해서만 S3에 업로드합니다!

### `S3LogUploader`

버퍼에 로그를 저장하고, yml에 저장된 flush-size 갯수를 초과하거나 flush-interval-seconds초가 지날 때마다 버퍼를 비우고 S3에 로그 파일을 저장합니다.

현재는 flush-size는 100개, flush-interval-seconds는 60초로 설정되어 있는데, 이 부분은 보안팀 매크로 작업 전에 5000개, 600초 정도로 널널하게 늘릴 예정입니다!

- [X] 전체 테스트 코드 성공 여부

## 관련 이슈

---
- Notion Ticket: #

## 참고사항 (선택)

---
배포 전에 개발 서버 docker-compose 환경변수 추가 필요

코드 정말 아쉬운데 천천히 리팩토링해보겠습니다 🥹