### PR TITLE
feat(membership): 아티스트 멤버십 결제 완료 조회 API 구현

### DIFF
--- a/common/src/main/java/com/truve/platform/common/exception/ErrorCode.java
+++ b/common/src/main/java/com/truve/platform/common/exception/ErrorCode.java
@@ -62,6 +62,8 @@ public enum ErrorCode {
 	NOT_FOUND_ARTIST(HttpStatus.NOT_FOUND, "존재하지 않는 배우입니다.", "M02"),
 	ALREADY_LIKED_ARTIST(HttpStatus.BAD_REQUEST, "이미 좋아요한 배우입니다.", "M03"),
 	ALREADY_JOINED_ARTIST_MEMBERSHIP(HttpStatus.BAD_REQUEST, "이미 해당 아티스트의 멤버십에 가입되어 있습니다.", "M04"),
+	NOT_FOUND_ARTIST_MEMBERSHIP(HttpStatus.NOT_FOUND, "가입된 아티스트 멤버십이 없습니다.", "M05"),
+	MEMBERSHIP_PAYMENT_NOT_COMPLETED(HttpStatus.BAD_REQUEST, "멤버십 결제가 아직 완료되지 않았습니다.", "M06"),
 
 	ALREADY_EXIST_REVIEW(HttpStatus.BAD_REQUEST, "이미 유저가 리뷰를 작성했습니다.", "MR01"),
 	NOT_CHARM_POINT(HttpStatus.BAD_REQUEST, "매력 포인트가 아닙니다.", "MR02"),

--- a/musical/src/main/java/com/truve/platform/musical/show/controller/MembershipController.java
+++ b/musical/src/main/java/com/truve/platform/musical/show/controller/MembershipController.java
@@ -2,6 +2,7 @@ package com.truve.platform.musical.show.controller;
 
 import java.util.UUID;
 
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -35,5 +36,14 @@ public class MembershipController {
 		@RequestBody @Valid MembershipRequest.CreatePayment request
 	) {
 		return ApiResult.ok(membershipService.createPayment(artistId, userId, request));
+	}
+
+	@Operation(summary = "아티스트 멤버십 가입 완료 정보 조회", description = "결제가 완료된 멤버십의 가입 완료 정보를 조회합니다.")
+	@GetMapping("/{artistId}/membership/complete")
+	public ApiResult<MembershipResponse.Complete> complete(
+		@PathVariable Long artistId,
+		@RequestHeader(name = "X-User-Id") UUID userId
+	) {
+		return ApiResult.ok(membershipService.complete(artistId, userId));
 	}
 }

--- a/musical/src/main/java/com/truve/platform/musical/show/domain/entity/ArtistMembership.java
+++ b/musical/src/main/java/com/truve/platform/musical/show/domain/entity/ArtistMembership.java
@@ -1,5 +1,6 @@
 package com.truve.platform.musical.show.domain.entity;
 
+import java.time.LocalDateTime;
 import java.util.UUID;
 
 import com.truve.platform.common.support.BaseEntity;
@@ -55,6 +56,12 @@ public class ArtistMembership extends BaseEntity {
 	@Column(name = "payment_method", nullable = false)
 	private MembershipPaymentMethod paymentMethod;
 
+	@Column(name = "joined_at")
+	private LocalDateTime joinedAt;
+
+	@Column(name = "next_billing_at")
+	private LocalDateTime nextBillingAt;
+
 	@Builder
 	private ArtistMembership(
 		UUID userId,
@@ -62,7 +69,9 @@ public class ArtistMembership extends BaseEntity {
 		ArtistMembershipStatus status,
 		String orderId,
 		Long monthlyAmount,
-		MembershipPaymentMethod paymentMethod
+		MembershipPaymentMethod paymentMethod,
+		LocalDateTime joinedAt,
+		LocalDateTime nextBillingAt
 	) {
 		this.userId = userId;
 		this.artist = artist;
@@ -70,6 +79,8 @@ public class ArtistMembership extends BaseEntity {
 		this.orderId = orderId;
 		this.monthlyAmount = monthlyAmount;
 		this.paymentMethod = paymentMethod;
+		this.joinedAt = joinedAt;
+		this.nextBillingAt = nextBillingAt;
 	}
 
 	public static ArtistMembership preparePayment(
@@ -86,6 +97,8 @@ public class ArtistMembership extends BaseEntity {
 			.orderId(orderId)
 			.monthlyAmount(monthlyAmount)
 			.paymentMethod(paymentMethod)
+			.joinedAt(null)
+			.nextBillingAt(null)
 			.build();
 	}
 
@@ -102,5 +115,15 @@ public class ArtistMembership extends BaseEntity {
 		this.orderId = orderId;
 		this.monthlyAmount = monthlyAmount;
 		this.paymentMethod = paymentMethod;
+		this.joinedAt = null;
+		this.nextBillingAt = null;
+	}
+
+	public void confirm() {
+		if (this.status == ArtistMembershipStatus.PAYMENT_PENDING) {
+			this.status = ArtistMembershipStatus.ACTIVE;
+			this.joinedAt = LocalDateTime.now();
+			this.nextBillingAt = this.joinedAt.plusMonths(1);
+		}
 	}
 }

--- a/musical/src/main/java/com/truve/platform/musical/show/dto/MembershipResponse.java
+++ b/musical/src/main/java/com/truve/platform/musical/show/dto/MembershipResponse.java
@@ -1,5 +1,7 @@
 package com.truve.platform.musical.show.dto;
 
+import java.time.LocalDateTime;
+
 import com.truve.platform.musical.show.domain.entity.ArtistMembership;
 
 public class MembershipResponse {
@@ -61,6 +63,66 @@ public class MembershipResponse {
 
 		public String getPaymentMethod() {
 			return paymentMethod;
+		}
+	}
+
+	public static class Complete {
+		private Long artistId;
+		private String artistName;
+		private String planName;
+		private Long amount;
+		private LocalDateTime joinedAt;
+		private LocalDateTime nextBillingAt;
+
+		public Complete(
+			Long artistId,
+			String artistName,
+			String planName,
+			Long amount,
+			LocalDateTime joinedAt,
+			LocalDateTime nextBillingAt
+		) {
+			this.artistId = artistId;
+			this.artistName = artistName;
+			this.planName = planName;
+			this.amount = amount;
+			this.joinedAt = joinedAt;
+			this.nextBillingAt = nextBillingAt;
+		}
+
+		public static Complete of(Long artistId, String artistName, ArtistMembership membership) {
+			return new Complete(
+				artistId,
+				artistName,
+				"월간 멤버십",
+				membership.getMonthlyAmount(),
+				membership.getJoinedAt(),
+				membership.getNextBillingAt()
+			);
+		}
+
+		public Long getArtistId() {
+			return artistId;
+		}
+
+		public String getArtistName() {
+			return artistName;
+		}
+
+		public String getPlanName() {
+			return planName;
+		}
+
+		public Long getAmount() {
+			return amount;
+		}
+
+		public LocalDateTime getJoinedAt() {
+			return joinedAt;
+		}
+
+		public LocalDateTime getNextBillingAt() {
+			return nextBillingAt;
 		}
 	}
 }

--- a/musical/src/main/java/com/truve/platform/musical/show/dto/MembershipResponse.java
+++ b/musical/src/main/java/com/truve/platform/musical/show/dto/MembershipResponse.java
@@ -1,9 +1,5 @@
 package com.truve.platform.musical.show.dto;
 
-import java.time.LocalDateTime;
-
-import com.truve.platform.musical.show.domain.entity.ArtistMembership;
-
 public class MembershipResponse {
 
 	public static class CreatePayment {
@@ -30,14 +26,14 @@ public class MembershipResponse {
 			this.paymentMethod = paymentMethod;
 		}
 
-		public static CreatePayment of(Long artistId, String artistName, ArtistMembership membership) {
+		public static CreatePayment of(Long artistId, String artistName, Long amount, String orderId, String paymentMethod) {
 			return new CreatePayment(
 				artistId,
 				artistName,
 				"월간 멤버십",
-				membership.getMonthlyAmount(),
-				membership.getOrderId(),
-				membership.getPaymentMethod().getDisplayName()
+				amount,
+				orderId,
+				paymentMethod
 			);
 		}
 
@@ -71,16 +67,16 @@ public class MembershipResponse {
 		private String artistName;
 		private String planName;
 		private Long amount;
-		private LocalDateTime joinedAt;
-		private LocalDateTime nextBillingAt;
+		private String joinedAt;
+		private String nextBillingAt;
 
 		public Complete(
 			Long artistId,
 			String artistName,
 			String planName,
 			Long amount,
-			LocalDateTime joinedAt,
-			LocalDateTime nextBillingAt
+			String joinedAt,
+			String nextBillingAt
 		) {
 			this.artistId = artistId;
 			this.artistName = artistName;
@@ -90,14 +86,20 @@ public class MembershipResponse {
 			this.nextBillingAt = nextBillingAt;
 		}
 
-		public static Complete of(Long artistId, String artistName, ArtistMembership membership) {
+		public static Complete of(
+			Long artistId,
+			String artistName,
+			Long amount,
+			String joinedAt,
+			String nextBillingAt
+		) {
 			return new Complete(
 				artistId,
 				artistName,
 				"월간 멤버십",
-				membership.getMonthlyAmount(),
-				membership.getJoinedAt(),
-				membership.getNextBillingAt()
+				amount,
+				joinedAt,
+				nextBillingAt
 			);
 		}
 
@@ -117,11 +119,11 @@ public class MembershipResponse {
 			return amount;
 		}
 
-		public LocalDateTime getJoinedAt() {
+		public String getJoinedAt() {
 			return joinedAt;
 		}
 
-		public LocalDateTime getNextBillingAt() {
+		public String getNextBillingAt() {
 			return nextBillingAt;
 		}
 	}

--- a/musical/src/main/java/com/truve/platform/musical/show/external/kafka/MembershipEventCommand.java
+++ b/musical/src/main/java/com/truve/platform/musical/show/external/kafka/MembershipEventCommand.java
@@ -1,0 +1,30 @@
+package com.truve.platform.musical.show.external.kafka;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+public class MembershipEventCommand {
+
+	@JsonIgnoreProperties(ignoreUnknown = true)
+	public static class Confirmed {
+		private String orderId;
+
+		public Confirmed() {
+		}
+
+		public String getOrderId() {
+			return orderId;
+		}
+	}
+
+	@JsonIgnoreProperties(ignoreUnknown = true)
+	public static class DepositReceived {
+		private String orderId;
+
+		public DepositReceived() {
+		}
+
+		public String getOrderId() {
+			return orderId;
+		}
+	}
+}

--- a/musical/src/main/java/com/truve/platform/musical/show/external/kafka/PaymentConsumer.java
+++ b/musical/src/main/java/com/truve/platform/musical/show/external/kafka/PaymentConsumer.java
@@ -1,0 +1,35 @@
+package com.truve.platform.musical.show.external.kafka;
+
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.messaging.handler.annotation.Header;
+import org.springframework.stereotype.Component;
+
+import com.truve.platform.common.support.JsonConverter;
+import com.truve.platform.musical.show.service.MembershipService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class PaymentConsumer {
+	public static final String TOPIC = "payment.membership";
+	public static final String GROUP = "payment-membership-group";
+
+	private final JsonConverter jsonConverter;
+	private final MembershipService membershipService;
+
+	@KafkaListener(topics = TOPIC, groupId = GROUP)
+	public void consume(String payload, @Header("event-type") String type) {
+		switch (type) {
+			case "CONFIRMED" -> membershipService.confirm(
+				jsonConverter.convert(payload, MembershipEventCommand.Confirmed.class).getOrderId()
+			);
+			case "DEPOSIT_RECEIVED" -> membershipService.depositReceive(
+				jsonConverter.convert(payload, MembershipEventCommand.DepositReceived.class).getOrderId()
+			);
+			default -> log.warn("[Kafka Consumer] Unknown event type: {}", type);
+		}
+	}
+}

--- a/musical/src/main/java/com/truve/platform/musical/show/service/MembershipService.java
+++ b/musical/src/main/java/com/truve/platform/musical/show/service/MembershipService.java
@@ -68,4 +68,32 @@ public class MembershipService {
 
 		return MembershipResponse.CreatePayment.of(artistId, artistDetail.getArtistName(), savedMembership);
 	}
+
+	@Transactional(readOnly = true)
+	public MembershipResponse.Complete complete(Long artistId, UUID userId) {
+		ArtistRepository.ArtistDetailProjection artistDetail = artistRepository.findDetailById(artistId)
+			.orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_ARTIST));
+
+		ArtistMembership membership = artistMembershipRepository.findByUserIdAndArtistId(userId, artistId)
+			.orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_ARTIST_MEMBERSHIP));
+
+		Preconditions.validate(membership.hasActiveEntitlement(), ErrorCode.MEMBERSHIP_PAYMENT_NOT_COMPLETED);
+
+		return MembershipResponse.Complete.of(artistId, artistDetail.getArtistName(), membership);
+	}
+
+	@Transactional
+	public void confirm(String orderId) {
+		activate(orderId);
+	}
+
+	@Transactional
+	public void depositReceive(String orderId) {
+		activate(orderId);
+	}
+
+	private void activate(String orderId) {
+		artistMembershipRepository.findByOrderId(orderId)
+			.ifPresent(ArtistMembership::confirm);
+	}
 }

--- a/musical/src/main/java/com/truve/platform/musical/show/service/MembershipService.java
+++ b/musical/src/main/java/com/truve/platform/musical/show/service/MembershipService.java
@@ -1,5 +1,7 @@
 package com.truve.platform.musical.show.service;
 
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.UUID;
 
 import org.springframework.dao.DataIntegrityViolationException;
@@ -22,6 +24,7 @@ import com.truve.platform.musical.show.util.MembershipOrderIdGenerator;
 @Service
 public class MembershipService {
 	private static final long MONTHLY_MEMBERSHIP_AMOUNT = 5_000L;
+	private static final DateTimeFormatter COMPLETE_DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy.MM.dd.");
 
 	private final ArtistRepository artistRepository;
 	private final ArtistMembershipRepository artistMembershipRepository;
@@ -66,7 +69,13 @@ public class MembershipService {
 
 		paymentPublisher.publish(PaymentEventCommand.Create.of(savedMembership));
 
-		return MembershipResponse.CreatePayment.of(artistId, artistDetail.getArtistName(), savedMembership);
+		return MembershipResponse.CreatePayment.of(
+			artistId,
+			artistDetail.getArtistName(),
+			savedMembership.getMonthlyAmount(),
+			savedMembership.getOrderId(),
+			savedMembership.getPaymentMethod().getDisplayName()
+		);
 	}
 
 	@Transactional(readOnly = true)
@@ -79,7 +88,13 @@ public class MembershipService {
 
 		Preconditions.validate(membership.hasActiveEntitlement(), ErrorCode.MEMBERSHIP_PAYMENT_NOT_COMPLETED);
 
-		return MembershipResponse.Complete.of(artistId, artistDetail.getArtistName(), membership);
+		return MembershipResponse.Complete.of(
+			artistId,
+			artistDetail.getArtistName(),
+			membership.getMonthlyAmount(),
+			formatCompleteDate(membership.getJoinedAt()),
+			formatCompleteDate(membership.getNextBillingAt())
+		);
 	}
 
 	@Transactional
@@ -95,5 +110,9 @@ public class MembershipService {
 	private void activate(String orderId) {
 		artistMembershipRepository.findByOrderId(orderId)
 			.ifPresent(ArtistMembership::confirm);
+	}
+
+	private String formatCompleteDate(LocalDateTime value) {
+		return value == null ? null : value.format(COMPLETE_DATE_FORMATTER);
 	}
 }

--- a/musical/src/test/java/com/truve/platform/musical/show/controller/MembershipControllerTest.java
+++ b/musical/src/test/java/com/truve/platform/musical/show/controller/MembershipControllerTest.java
@@ -159,8 +159,8 @@ class MembershipControllerTest {
 			"고은성",
 			"월간 멤버십",
 			5_000L,
-			java.time.LocalDateTime.of(2026, 4, 3, 10, 0),
-			java.time.LocalDateTime.of(2026, 5, 3, 10, 0)
+			"2026. 4. 3.",
+			"2026. 5. 3."
 		);
 
 		given(membershipService.complete(101L, userId)).willReturn(response);
@@ -172,7 +172,9 @@ class MembershipControllerTest {
 			.andExpect(jsonPath("$.data.artistId").value(101L))
 			.andExpect(jsonPath("$.data.artistName").value("고은성"))
 			.andExpect(jsonPath("$.data.planName").value("월간 멤버십"))
-			.andExpect(jsonPath("$.data.amount").value(5000L));
+			.andExpect(jsonPath("$.data.amount").value(5000L))
+			.andExpect(jsonPath("$.data.joinedAt").value("2026. 4. 3."))
+			.andExpect(jsonPath("$.data.nextBillingAt").value("2026. 5. 3."));
 	}
 
 	@Test

--- a/musical/src/test/java/com/truve/platform/musical/show/controller/MembershipControllerTest.java
+++ b/musical/src/test/java/com/truve/platform/musical/show/controller/MembershipControllerTest.java
@@ -5,6 +5,7 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willThrow;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -147,5 +148,46 @@ class MembershipControllerTest {
 			.andExpect(status().isBadRequest())
 			.andExpect(jsonPath("$.errorType").value("CLIENT_ERROR"))
 			.andExpect(jsonPath("$.code").value("C02"));
+	}
+
+	@Test
+	@DisplayName("아티스트 멤버십 가입 완료 정보 조회에 성공하면 200 OK와 완료 정보를 응답한다.")
+	void 아티스트_멤버십_가입완료_조회_성공() throws Exception {
+		UUID userId = UUID.fromString("11111111-1111-1111-1111-111111111111");
+		MembershipResponse.Complete response = new MembershipResponse.Complete(
+			101L,
+			"고은성",
+			"월간 멤버십",
+			5_000L,
+			java.time.LocalDateTime.of(2026, 4, 3, 10, 0),
+			java.time.LocalDateTime.of(2026, 5, 3, 10, 0)
+		);
+
+		given(membershipService.complete(101L, userId)).willReturn(response);
+
+		mockMvc.perform(get("/api/musical/artists/{artistId}/membership/complete", 101L)
+				.header("X-User-Id", userId))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.code").value("ok"))
+			.andExpect(jsonPath("$.data.artistId").value(101L))
+			.andExpect(jsonPath("$.data.artistName").value("고은성"))
+			.andExpect(jsonPath("$.data.planName").value("월간 멤버십"))
+			.andExpect(jsonPath("$.data.amount").value(5000L));
+	}
+
+	@Test
+	@DisplayName("결제가 아직 완료되지 않은 멤버십의 완료 정보 조회는 400을 응답한다.")
+	void 결제미완료_멤버십_가입완료_조회_실패() throws Exception {
+		UUID userId = UUID.fromString("11111111-1111-1111-1111-111111111111");
+
+		willThrow(new CustomException(ErrorCode.MEMBERSHIP_PAYMENT_NOT_COMPLETED))
+			.given(membershipService)
+			.complete(101L, userId);
+
+		mockMvc.perform(get("/api/musical/artists/{artistId}/membership/complete", 101L)
+				.header("X-User-Id", userId))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.errorType").value("CLIENT_ERROR"))
+			.andExpect(jsonPath("$.code").value("M06"));
 	}
 }

--- a/musical/src/test/java/com/truve/platform/musical/show/domain/entity/ArtistMembershipTest.java
+++ b/musical/src/test/java/com/truve/platform/musical/show/domain/entity/ArtistMembershipTest.java
@@ -1,0 +1,30 @@
+package com.truve.platform.musical.show.domain.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.UUID;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.truve.platform.musical.show.domain.constant.ArtistMembershipStatus;
+import com.truve.platform.musical.show.domain.constant.MembershipPaymentMethod;
+
+class ArtistMembershipTest {
+
+	@Test
+	@DisplayName("PAYMENT_PENDING 멤버십은 결제 완료 시 ACTIVE로 전환된다.")
+	void 결제완료시_ACTIVE_전환() {
+		ArtistMembership membership = ArtistMembership.preparePayment(
+			UUID.fromString("11111111-1111-1111-1111-111111111111"),
+			null,
+			"M20260402123456",
+			5_000L,
+			MembershipPaymentMethod.TOSS_PAY
+		);
+
+		membership.confirm();
+
+		assertThat(membership.getStatus()).isEqualTo(ArtistMembershipStatus.ACTIVE);
+	}
+}

--- a/musical/src/test/java/com/truve/platform/musical/show/external/kafka/PaymentConsumerTest.java
+++ b/musical/src/test/java/com/truve/platform/musical/show/external/kafka/PaymentConsumerTest.java
@@ -1,0 +1,54 @@
+package com.truve.platform.musical.show.external.kafka;
+
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.truve.platform.common.support.JsonConverter;
+import com.truve.platform.musical.show.service.MembershipService;
+
+@ExtendWith(MockitoExtension.class)
+class PaymentConsumerTest {
+
+	@Mock
+	private MembershipService membershipService;
+
+	private PaymentConsumer paymentConsumer;
+
+	@BeforeEach
+	void setUp() {
+		paymentConsumer = new PaymentConsumer(new JsonConverter(new ObjectMapper()), membershipService);
+	}
+
+	@Test
+	@DisplayName("CONFIRMED 이벤트를 수신하면 멤버십 결제 완료를 처리한다.")
+	void confirmed_이벤트_처리() {
+		paymentConsumer.consume("{\"orderId\":\"M20260402123456\"}", "CONFIRMED");
+
+		verify(membershipService).confirm("M20260402123456");
+	}
+
+	@Test
+	@DisplayName("DEPOSIT_RECEIVED 이벤트를 수신하면 멤버십 입금 완료를 처리한다.")
+	void depositReceived_이벤트_처리() {
+		paymentConsumer.consume("{\"orderId\":\"M20260402123456\"}", "DEPOSIT_RECEIVED");
+
+		verify(membershipService).depositReceive("M20260402123456");
+	}
+
+	@Test
+	@DisplayName("알 수 없는 이벤트는 무시한다.")
+	void unknown_이벤트_무시() {
+		paymentConsumer.consume("{\"orderId\":\"M20260402123456\"}", "UNKNOWN");
+
+		verify(membershipService, never()).confirm(org.mockito.Mockito.anyString());
+		verify(membershipService, never()).depositReceive(org.mockito.Mockito.anyString());
+	}
+}

--- a/musical/src/test/java/com/truve/platform/musical/show/service/MembershipServiceTest.java
+++ b/musical/src/test/java/com/truve/platform/musical/show/service/MembershipServiceTest.java
@@ -251,8 +251,8 @@ class MembershipServiceTest {
 		assertThat(response.getArtistName()).isEqualTo("고은성");
 		assertThat(response.getPlanName()).isEqualTo("월간 멤버십");
 		assertThat(response.getAmount()).isEqualTo(5_000L);
-		assertNotNull(response.getJoinedAt());
-		assertNotNull(response.getNextBillingAt());
+		assertThat(response.getJoinedAt()).matches("\\d{4}\\. \\d{1,2}\\. \\d{1,2}\\.");
+		assertThat(response.getNextBillingAt()).matches("\\d{4}\\. \\d{1,2}\\. \\d{1,2}\\.");
 	}
 
 	@Test

--- a/musical/src/test/java/com/truve/platform/musical/show/service/MembershipServiceTest.java
+++ b/musical/src/test/java/com/truve/platform/musical/show/service/MembershipServiceTest.java
@@ -251,8 +251,8 @@ class MembershipServiceTest {
 		assertThat(response.getArtistName()).isEqualTo("고은성");
 		assertThat(response.getPlanName()).isEqualTo("월간 멤버십");
 		assertThat(response.getAmount()).isEqualTo(5_000L);
-		assertThat(response.getJoinedAt()).matches("\\d{4}\\. \\d{1,2}\\. \\d{1,2}\\.");
-		assertThat(response.getNextBillingAt()).matches("\\d{4}\\. \\d{1,2}\\. \\d{1,2}\\.");
+		assertThat(response.getJoinedAt()).matches("\\d{4}\\.\\d{2}\\.\\d{2}\\.");
+		assertThat(response.getNextBillingAt()).matches("\\d{4}\\.\\d{2}\\.\\d{2}\\.");
 	}
 
 	@Test

--- a/musical/src/test/java/com/truve/platform/musical/show/service/MembershipServiceTest.java
+++ b/musical/src/test/java/com/truve/platform/musical/show/service/MembershipServiceTest.java
@@ -2,6 +2,7 @@ package com.truve.platform.musical.show.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
@@ -183,5 +184,99 @@ class MembershipServiceTest {
 		assertThat(existingMembership.getStatus()).isEqualTo(ArtistMembershipStatus.PAYMENT_PENDING);
 		assertThat(paymentCaptor.getValue().getOrderId()).isEqualTo(response.getOrderId());
 		assertThat(paymentCaptor.getValue().getAmount()).isEqualTo(5_000L);
+	}
+
+	@Test
+	@DisplayName("결제 완료 이벤트를 받으면 해당 주문의 멤버십을 ACTIVE로 전환한다.")
+	void 결제완료시_ACTIVE_전환() {
+		Artist artist = org.mockito.Mockito.mock(Artist.class);
+		ArtistMembership membership = ArtistMembership.preparePayment(
+			UUID.fromString("11111111-1111-1111-1111-111111111111"),
+			artist,
+			"M20260402123456",
+			5_000L,
+			MembershipPaymentMethod.TOSS_PAY
+		);
+
+		when(artistMembershipRepository.findByOrderId("M20260402123456")).thenReturn(java.util.Optional.of(membership));
+
+		membershipService.confirm("M20260402123456");
+
+		assertThat(membership.getStatus()).isEqualTo(ArtistMembershipStatus.ACTIVE);
+		assertNotNull(membership.getJoinedAt());
+		assertNotNull(membership.getNextBillingAt());
+	}
+
+	@Test
+	@DisplayName("입금 완료 이벤트를 받으면 해당 주문의 멤버십을 ACTIVE로 전환한다.")
+	void 입금완료시_ACTIVE_전환() {
+		Artist artist = org.mockito.Mockito.mock(Artist.class);
+		ArtistMembership membership = ArtistMembership.preparePayment(
+			UUID.fromString("11111111-1111-1111-1111-111111111111"),
+			artist,
+			"M20260402123457",
+			5_000L,
+			MembershipPaymentMethod.BANK_TRANSFER
+		);
+
+		when(artistMembershipRepository.findByOrderId("M20260402123457")).thenReturn(java.util.Optional.of(membership));
+
+		membershipService.depositReceive("M20260402123457");
+
+		assertThat(membership.getStatus()).isEqualTo(ArtistMembershipStatus.ACTIVE);
+	}
+
+	@Test
+	@DisplayName("활성 멤버십이 있으면 가입 완료 응답을 반환한다.")
+	void 멤버십_가입완료_조회_성공() {
+		UUID userId = UUID.fromString("11111111-1111-1111-1111-111111111111");
+		Artist artist = org.mockito.Mockito.mock(Artist.class);
+		ArtistRepository.ArtistDetailProjection artistDetail = org.mockito.Mockito.mock(ArtistRepository.ArtistDetailProjection.class);
+		ArtistMembership membership = ArtistMembership.preparePayment(
+			userId,
+			artist,
+			"M20260402123458",
+			5_000L,
+			MembershipPaymentMethod.TOSS_PAY
+		);
+		membership.confirm();
+
+		when(artistRepository.findDetailById(101L)).thenReturn(java.util.Optional.of(artistDetail));
+		when(artistDetail.getArtistName()).thenReturn("고은성");
+		when(artistMembershipRepository.findByUserIdAndArtistId(userId, 101L)).thenReturn(java.util.Optional.of(membership));
+
+		MembershipResponse.Complete response = membershipService.complete(101L, userId);
+
+		assertThat(response.getArtistId()).isEqualTo(101L);
+		assertThat(response.getArtistName()).isEqualTo("고은성");
+		assertThat(response.getPlanName()).isEqualTo("월간 멤버십");
+		assertThat(response.getAmount()).isEqualTo(5_000L);
+		assertNotNull(response.getJoinedAt());
+		assertNotNull(response.getNextBillingAt());
+	}
+
+	@Test
+	@DisplayName("아직 결제가 완료되지 않은 멤버십이면 가입 완료 조회에 실패한다.")
+	void 멤버십_가입완료_조회_실패() {
+		UUID userId = UUID.fromString("11111111-1111-1111-1111-111111111111");
+		Artist artist = org.mockito.Mockito.mock(Artist.class);
+		ArtistRepository.ArtistDetailProjection artistDetail = org.mockito.Mockito.mock(ArtistRepository.ArtistDetailProjection.class);
+		ArtistMembership membership = ArtistMembership.preparePayment(
+			userId,
+			artist,
+			"M20260402123459",
+			5_000L,
+			MembershipPaymentMethod.TOSS_PAY
+		);
+
+		when(artistRepository.findDetailById(101L)).thenReturn(java.util.Optional.of(artistDetail));
+		when(artistMembershipRepository.findByUserIdAndArtistId(userId, 101L)).thenReturn(java.util.Optional.of(membership));
+
+		CustomException exception = assertThrows(
+			CustomException.class,
+			() -> membershipService.complete(101L, userId)
+		);
+
+		assertEquals(ErrorCode.MEMBERSHIP_PAYMENT_NOT_COMPLETED, exception.getErrorCode());
 	}
 }

--- a/payment/src/main/java/com/truve/platform/payment/service/event/PaymentUpdatedListener.java
+++ b/payment/src/main/java/com/truve/platform/payment/service/event/PaymentUpdatedListener.java
@@ -6,17 +6,28 @@ import org.springframework.transaction.event.TransactionalEventListener;
 
 import com.truve.platform.payment.service.external.kafka.BookingEventCommand;
 import com.truve.platform.payment.service.external.kafka.BookingPublisher;
+import com.truve.platform.payment.service.external.kafka.MembershipEventCommand;
+import com.truve.platform.payment.service.external.kafka.MembershipPublisher;
 
 import lombok.RequiredArgsConstructor;
 
 @Component
 @RequiredArgsConstructor
 public class PaymentUpdatedListener {
+	private static final String MEMBERSHIP_ORDER_PREFIX = "M";
 
 	private final BookingPublisher bookingPublisher;
+	private final MembershipPublisher membershipPublisher;
 
 	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
 	public void onConfirmed(PaymentUpdated.Confirmed event) {
+		if (isMembershipOrder(event.getOrderId())) {
+			if (event.getStatus() == com.truve.platform.payment.service.domain.constant.PaymentStatus.DONE) {
+				membershipPublisher.publish(new MembershipEventCommand.Confirmed(event.getOrderId()));
+			}
+			return;
+		}
+
 		bookingPublisher.publish(
 			new BookingEventCommand.Confirmed(
 				event.getOrderId(),
@@ -35,11 +46,20 @@ public class PaymentUpdatedListener {
 
 	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
 	public void onDepositReceived(PaymentUpdated.DepositReceived event) {
+		if (isMembershipOrder(event.getOrderId())) {
+			membershipPublisher.publish(new MembershipEventCommand.DepositReceived(event.getOrderId()));
+			return;
+		}
+
 		bookingPublisher.publish(
 			new BookingEventCommand.DepositReceived(
 				event.getOrderId(),
 				event.getApprovedAt()
 			)
 		);
+	}
+
+	private boolean isMembershipOrder(String orderId) {
+		return orderId != null && orderId.startsWith(MEMBERSHIP_ORDER_PREFIX);
 	}
 }

--- a/payment/src/main/java/com/truve/platform/payment/service/external/kafka/MembershipEventCommand.java
+++ b/payment/src/main/java/com/truve/platform/payment/service/external/kafka/MembershipEventCommand.java
@@ -1,0 +1,41 @@
+package com.truve.platform.payment.service.external.kafka;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class MembershipEventCommand {
+
+	@JsonIgnoreProperties(value = {"eventType"})
+	public interface MembershipEvent {
+		String getOrderId();
+
+		String getEventType();
+	}
+
+	@Getter
+	@AllArgsConstructor
+	@NoArgsConstructor
+	public static class Confirmed implements MembershipEvent {
+		private String orderId;
+
+		@Override
+		public String getEventType() {
+			return "CONFIRMED";
+		}
+	}
+
+	@Getter
+	@AllArgsConstructor
+	@NoArgsConstructor
+	public static class DepositReceived implements MembershipEvent {
+		private String orderId;
+
+		@Override
+		public String getEventType() {
+			return "DEPOSIT_RECEIVED";
+		}
+	}
+}

--- a/payment/src/main/java/com/truve/platform/payment/service/external/kafka/MembershipPublisher.java
+++ b/payment/src/main/java/com/truve/platform/payment/service/external/kafka/MembershipPublisher.java
@@ -1,0 +1,19 @@
+package com.truve.platform.payment.service.external.kafka;
+
+import org.springframework.stereotype.Component;
+
+import com.truve.platform.common.event.EventPublisher;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class MembershipPublisher {
+	private static final String TOPIC = "payment.membership";
+
+	private final EventPublisher eventPublisher;
+
+	public void publish(MembershipEventCommand.MembershipEvent command) {
+		eventPublisher.publish(TOPIC, command.getOrderId(), command.getEventType(), command);
+	}
+}

--- a/payment/src/test/java/com/truve/platform/payment/service/event/PaymentUpdatedListenerTest.java
+++ b/payment/src/test/java/com/truve/platform/payment/service/event/PaymentUpdatedListenerTest.java
@@ -1,0 +1,88 @@
+package com.truve.platform.payment.service.event;
+
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.ArgumentMatchers.argThat;
+
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.truve.platform.payment.service.domain.constant.PaymentMethod;
+import com.truve.platform.payment.service.domain.constant.PaymentStatus;
+import com.truve.platform.payment.service.external.kafka.BookingPublisher;
+import com.truve.platform.payment.service.external.kafka.MembershipEventCommand;
+import com.truve.platform.payment.service.external.kafka.MembershipPublisher;
+
+@ExtendWith(MockitoExtension.class)
+class PaymentUpdatedListenerTest {
+
+	@Mock
+	private BookingPublisher bookingPublisher;
+	@Mock
+	private MembershipPublisher membershipPublisher;
+
+	@InjectMocks
+	private PaymentUpdatedListener paymentUpdatedListener;
+
+	@Test
+	@DisplayName("멤버십 결제가 DONE으로 확정되면 membership completion 이벤트를 발행한다.")
+	void 멤버십_결제확정_이벤트_발행() {
+		PaymentUpdated.Confirmed event = new PaymentUpdated.Confirmed(
+			"M20260402123456",
+			LocalDateTime.now(),
+			LocalDateTime.now(),
+			PaymentMethod.EASY_PAY,
+			null,
+			PaymentStatus.DONE
+		);
+
+		paymentUpdatedListener.onConfirmed(event);
+
+		verify(membershipPublisher).publish(argThat(command ->
+			command instanceof MembershipEventCommand.Confirmed
+				&& command.getOrderId().equals("M20260402123456")
+		));
+		verify(bookingPublisher, never()).publish(org.mockito.Mockito.any());
+	}
+
+	@Test
+	@DisplayName("멤버십 가상계좌 결제가 WAITING_FOR_DEPOSIT면 confirm 단계에서 completion 이벤트를 발행하지 않는다.")
+	void 멤버십_가상계좌_confirm_미발행() {
+		PaymentUpdated.Confirmed event = new PaymentUpdated.Confirmed(
+			"M20260402123456",
+			LocalDateTime.now(),
+			null,
+			PaymentMethod.VIRTUAL_ACCOUNT,
+			null,
+			PaymentStatus.WAITING_FOR_DEPOSIT
+		);
+
+		paymentUpdatedListener.onConfirmed(event);
+
+		verify(membershipPublisher, never()).publish(org.mockito.Mockito.any());
+		verify(bookingPublisher, never()).publish(org.mockito.Mockito.any());
+	}
+
+	@Test
+	@DisplayName("멤버십 입금 완료 이벤트가 오면 membership deposit 이벤트를 발행한다.")
+	void 멤버십_입금완료_이벤트_발행() {
+		PaymentUpdated.DepositReceived event = new PaymentUpdated.DepositReceived(
+			"M20260402123456",
+			LocalDateTime.now()
+		);
+
+		paymentUpdatedListener.onDepositReceived(event);
+
+		verify(membershipPublisher).publish(argThat(command ->
+			command instanceof MembershipEventCommand.DepositReceived
+				&& command.getOrderId().equals("M20260402123456")
+		));
+		verify(bookingPublisher, never()).publish(org.mockito.Mockito.any());
+	}
+}


### PR DESCRIPTION
## 변경 사항

---
musical
- GET /api/musical/artists/{artistId}/membership/complete 추가
- payment 완료 이벤트를 수신하면 membership를 ACTIVE로 전이하도록 구현
- ArtistMembership에 완료 시점 관리 필드 추가
  - joinedAt
  - nextBillingAt
- payment 완료 시 membership 도메인으로 완료 이벤트 발행
  - payment.membership
- 일반 결제 완료 / 무통장입금 입금 완료 이벤트를 membership 쪽으로 전달하도록 구현
- 멤버십 완료 관련 에러코드 추가
  - NOT_FOUND_ARTIST_MEMBERSHIP (M05)
  - MEMBERSHIP_PAYMENT_NOT_COMPLETED (M06)
 
- [x] 전체 테스트 코드 성공 여부

---
- Notion Ticket: # 85

## 참고사항 (선택)

---