### PR TITLE
feat(logging): 로그인할 때 userId 검증 로직 제외 처리

### DIFF
--- a/api-gateway/src/main/java/com/truve/platform/apigateway/logging/LoggingFilter.java
+++ b/api-gateway/src/main/java/com/truve/platform/apigateway/logging/LoggingFilter.java
@@ -112,7 +112,9 @@ public class LoggingFilter implements WebFilter, Ordered {
 			kv("statusCode", ctx.statusCode),
 			kv("requestBody", ctx.requestBody)
 		);
-		if (ctx.getUserId() != null && TARGET_USER_ID.contains(ctx.getUserId())) {
+		if ("/api/auth/login".equals(ctx.path)) {
+			s3LogUploader.enqueue(ctx.toJson(), "BE");
+		} else if (ctx.getUserId() != null && TARGET_USER_ID.contains(ctx.getUserId())) {
 			s3LogUploader.enqueue(ctx.toJson(), "BE");
 		}
 		//sendToKafka(ctx);

--- a/api-gateway/src/main/java/com/truve/platform/apigateway/logging/S3LogUploader.java
+++ b/api-gateway/src/main/java/com/truve/platform/apigateway/logging/S3LogUploader.java
@@ -19,6 +19,8 @@ import java.util.concurrent.locks.ReentrantLock;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
+import lombok.extern.slf4j.Slf4j;
+
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
@@ -30,6 +32,7 @@ import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.S3ClientBuilder;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
+@Slf4j
 @Component
 public class S3LogUploader {
 
@@ -150,6 +153,7 @@ public class S3LogUploader {
 				.build(),
 			RequestBody.fromString(content, StandardCharsets.UTF_8)
 		);
+		log.info("S3 upload complete: bucket={}, key={}, lines={}", bucket, key, lines.size());
 	}
 
 	private S3Client buildS3Client() {


### PR DESCRIPTION
## 변경 사항

---
현재 S3 로그 업로드할 때, 특정 userId의 요청만 업로드를 하고 있는데 로그인의 경우 User ID가 무조건 null이라 기록이 안 되고 있었습니다.
따라서 경로가 `/api/auth/login`일 경우, userId를 체크하는 로직을 건너뛰고 전부 기록하도록 변경합니다. (보안팀 협의 O)

추가적으로, S3에 업로드할 때마다 로그를 남기도록 추가했습니다.

- [X] 전체 테스트 코드 성공 여부

## 관련 이슈

---
- Notion Ticket: #

## 참고사항 (선택)

---