### PR TITLE
fix(musical): 공연 상세조회 응답에 회차별 남은 좌석 정보를 반영

### DIFF
--- a/musical/src/main/java/com/truve/platform/musical/show/dto/ShowCastingResponse.java
+++ b/musical/src/main/java/com/truve/platform/musical/show/dto/ShowCastingResponse.java
@@ -76,16 +76,6 @@ public class ShowCastingResponse {
 		private String showDateLabel;
 		private String showTimeLabel;
 		private Map<String, CastArtist> casts;
-		private List<GradeRemaining> remainingSeats;
-	}
-
-	@Getter
-	@AllArgsConstructor
-	@Builder
-	public static class GradeRemaining {
-		private String gradeName;
-		private Long remainingSeatCount;
-		private Long totalCount;
 	}
 
 	@Getter

--- a/musical/src/main/java/com/truve/platform/musical/show/dto/ShowResponse.java
+++ b/musical/src/main/java/com/truve/platform/musical/show/dto/ShowResponse.java
@@ -48,6 +48,7 @@ public class ShowResponse {
 		private Long scheduleId;
 		private LocalDateTime showTime;
 		private String status;
+		private List<RemainingSeat> remainingSeats;
 	}
 
 	@Getter
@@ -81,5 +82,13 @@ public class ShowResponse {
 		private String gradeName;
 		private String colorCode;
 		private Long price;
+	}
+
+	@Getter
+	@AllArgsConstructor
+	@Builder
+	public static class RemainingSeat {
+		private String gradeName;
+		private Long remainingSeatCount;
 	}
 }

--- a/musical/src/main/java/com/truve/platform/musical/show/service/ShowCastingService.java
+++ b/musical/src/main/java/com/truve/platform/musical/show/service/ShowCastingService.java
@@ -16,25 +16,20 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.client.RestClientException;
 
 import com.truve.platform.musical.show.domain.entity.Show;
 import com.truve.platform.musical.show.domain.entity.ShowCasting;
 import com.truve.platform.musical.show.domain.entity.ShowSchedule;
 import com.truve.platform.musical.show.domain.entity.ShowScheduleCasting;
 import com.truve.platform.musical.show.dto.ShowCastingResponse;
-import com.truve.platform.musical.show.external.client.TicketingInternalClient;
-import com.truve.platform.musical.show.external.client.TicketingInternalClientResponse;
 import com.truve.platform.musical.show.repository.ShowCastingRepository;
 import com.truve.platform.musical.show.repository.ShowRepository;
 import com.truve.platform.musical.show.repository.ShowScheduleCastingRepository;
 import com.truve.platform.musical.show.repository.ShowScheduleRepository;
 
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 
 @Service
-@Slf4j
 @RequiredArgsConstructor
 public class ShowCastingService {
 	private static final String DEFAULT_UNASSIGNED_CAST_NAME = "미정";
@@ -47,7 +42,6 @@ public class ShowCastingService {
 	private final ShowScheduleRepository showScheduleRepository;
 	private final ShowCastingRepository showCastingRepository;
 	private final ShowScheduleCastingRepository showScheduleCastingRepository;
-	private final TicketingInternalClient ticketingInternalClient;
 
 	@Transactional(readOnly = true)
 	public ShowCastingResponse.Detail getCastingSchedules(
@@ -97,9 +91,6 @@ public class ShowCastingService {
 		Map<Long, Map<String, ShowCastingResponse.CastArtist>> castsByScheduleId = scheduleIds.isEmpty()
 			? Map.of()
 			: buildCastsByScheduleId(scheduleIds);
-		Map<Long, List<ShowCastingResponse.GradeRemaining>> remainingSeatsByScheduleId = scheduleIds.isEmpty()
-			? Map.of()
-			: buildRemainingSeatsByScheduleId(scheduleIds);
 
 		List<ShowCastingResponse.Row> rows = schedulePage.getContent().stream()
 			.map(schedule -> ShowCastingResponse.Row.builder()
@@ -108,7 +99,6 @@ public class ShowCastingService {
 				.showDateLabel(toShowDateLabel(schedule.getShowTime()))
 				.showTimeLabel(toShowTimeLabel(schedule.getShowTime()))
 				.casts(buildRowCasts(schedule.getId(), roles, castsByScheduleId))
-				.remainingSeats(remainingSeatsByScheduleId.getOrDefault(schedule.getId(), List.of()))
 				.build())
 			.toList();
 
@@ -195,35 +185,6 @@ public class ShowCastingService {
 		roles.forEach(role -> rowCasts.put(role.getRoleName(), createUnassignedCast()));
 		rowCasts.putAll(assignedCasts);
 		return rowCasts;
-	}
-
-	private Map<Long, List<ShowCastingResponse.GradeRemaining>> buildRemainingSeatsByScheduleId(List<Long> scheduleIds) {
-		return scheduleIds.stream()
-			.collect(Collectors.toMap(
-				scheduleId -> scheduleId,
-				this::fetchRemainingSeats,
-				(existing, replacement) -> existing,
-				LinkedHashMap::new
-			));
-	}
-
-	private List<ShowCastingResponse.GradeRemaining> fetchRemainingSeats(Long scheduleId) {
-		try {
-			return ticketingInternalClient.getRemainingSeats(scheduleId).stream()
-				.map(this::toGradeRemaining)
-				.toList();
-		} catch (RestClientException e) {
-			log.warn("Failed to fetch remaining seats from ticketing for scheduleId={}", scheduleId);
-			return List.of();
-		}
-	}
-
-	private ShowCastingResponse.GradeRemaining toGradeRemaining(TicketingInternalClientResponse.GradeRemaining gradeRemaining) {
-		return ShowCastingResponse.GradeRemaining.builder()
-			.gradeName(gradeRemaining.getGradeName())
-			.remainingSeatCount(gradeRemaining.getRemainingSeatCount())
-			.totalCount(gradeRemaining.getTotalCount())
-			.build();
 	}
 
 	private ShowCastingResponse.CastArtist createUnassignedCast() {

--- a/musical/src/main/java/com/truve/platform/musical/show/service/ShowDetailService.java
+++ b/musical/src/main/java/com/truve/platform/musical/show/service/ShowDetailService.java
@@ -13,6 +13,7 @@ import java.util.UUID;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
+import org.springframework.web.client.RestClientException;
 
 import com.truve.platform.musical.s3.S3Service;
 import com.truve.platform.musical.seat.domain.entity.Venue;
@@ -22,6 +23,8 @@ import com.truve.platform.musical.show.domain.entity.ShowCasting;
 import com.truve.platform.musical.show.domain.entity.ShowSchedule;
 import com.truve.platform.musical.show.domain.entity.ShowSectionGrade;
 import com.truve.platform.musical.show.dto.ShowResponse;
+import com.truve.platform.musical.show.external.client.TicketingInternalClient;
+import com.truve.platform.musical.show.external.client.TicketingInternalClientResponse;
 import com.truve.platform.musical.show.repository.ArtistLikeRepository;
 import com.truve.platform.musical.show.repository.ShowCastingRepository;
 import com.truve.platform.musical.show.repository.ShowRepository;
@@ -29,8 +32,10 @@ import com.truve.platform.musical.show.repository.ShowScheduleRepository;
 import com.truve.platform.musical.show.repository.ShowSeatGradeRepository;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Service
+@Slf4j
 @RequiredArgsConstructor
 public class ShowDetailService {
 	private static final DateTimeFormatter DATE_LABEL_FORMATTER = DateTimeFormatter.ofPattern("yyyy.MM.dd");
@@ -43,14 +48,21 @@ public class ShowDetailService {
 	private final ArtistLikeRepository artistLikeRepository;
 	private final ShowSeatGradeRepository showSeatGradeRepository;
 	private final S3Service s3Service;
+	private final TicketingInternalClient ticketingInternalClient;
 
 	@Transactional(readOnly = true)
 	public ShowResponse.Detail getDetail(Long showId, UUID userId) {
 		Show show = showRepository.findByIdOrThrow(showId);
 
 		List<ShowSchedule> schedules = showScheduleRepository.findSchedules(showId);
+		Map<Long, List<ShowResponse.RemainingSeat>> remainingSeatsByScheduleId = schedules.isEmpty()
+			? Map.of()
+			: buildRemainingSeatsByScheduleId(schedules.stream().map(ShowSchedule::getId).toList());
 		List<ShowResponse.SimpleSchedule> scheduleResponses = schedules.stream()
-			.map(this::toSimpleScheduleResponse)
+			.map(schedule -> toSimpleScheduleResponse(
+				schedule,
+				remainingSeatsByScheduleId.getOrDefault(schedule.getId(), List.of())
+			))
 			.toList();
 
 		List<ShowCasting> showCastings = showCastingRepository.findAllByShowId(showId);
@@ -128,11 +140,43 @@ public class ShowDetailService {
 			.build();
 	}
 
-	private ShowResponse.SimpleSchedule toSimpleScheduleResponse(ShowSchedule schedule) {
+	private ShowResponse.SimpleSchedule toSimpleScheduleResponse(
+		ShowSchedule schedule,
+		List<ShowResponse.RemainingSeat> remainingSeats
+	) {
 		return ShowResponse.SimpleSchedule.builder()
 			.scheduleId(schedule.getId())
 			.showTime(schedule.getShowTime())
 			.status(schedule.getStatus().name())
+			.remainingSeats(remainingSeats)
+			.build();
+	}
+
+	private Map<Long, List<ShowResponse.RemainingSeat>> buildRemainingSeatsByScheduleId(List<Long> scheduleIds) {
+		Map<Long, List<ShowResponse.RemainingSeat>> remainingSeatsByScheduleId = new LinkedHashMap<>();
+
+		for (Long scheduleId : scheduleIds) {
+			remainingSeatsByScheduleId.put(scheduleId, fetchRemainingSeats(scheduleId));
+		}
+
+		return remainingSeatsByScheduleId;
+	}
+
+	private List<ShowResponse.RemainingSeat> fetchRemainingSeats(Long scheduleId) {
+		try {
+			return ticketingInternalClient.getRemainingSeats(scheduleId).stream()
+				.map(this::toGradeRemaining)
+				.toList();
+		} catch (RestClientException e) {
+			log.warn("Failed to fetch remaining seats from ticketing for scheduleId={}", scheduleId);
+			return List.of();
+		}
+	}
+
+	private ShowResponse.RemainingSeat toGradeRemaining(TicketingInternalClientResponse.GradeRemaining gradeRemaining) {
+		return ShowResponse.RemainingSeat.builder()
+			.gradeName(gradeRemaining.getGradeName())
+			.remainingSeatCount(gradeRemaining.getRemainingSeatCount())
 			.build();
 	}
 

--- a/musical/src/test/java/com/truve/platform/musical/show/controller/ShowControllerTest.java
+++ b/musical/src/test/java/com/truve/platform/musical/show/controller/ShowControllerTest.java
@@ -84,16 +84,24 @@ class ShowControllerTest {
 					.scheduleId(1L)
 					.showTime(LocalDateTime.of(2026, 3, 2, 19, 30))
 					.status(ShowScheduleStatus.OPEN.name())
+					.remainingSeats(List.of(
+						ShowResponse.RemainingSeat.builder()
+							.gradeName("VIP")
+							.remainingSeatCount(10L)
+							.build()
+					))
 					.build(),
 				ShowResponse.SimpleSchedule.builder()
 					.scheduleId(2L)
 					.showTime(LocalDateTime.of(2026, 3, 3, 19, 30))
 					.status(ShowScheduleStatus.CLOSED.name())
+					.remainingSeats(List.of())
 					.build(),
 				ShowResponse.SimpleSchedule.builder()
 					.scheduleId(3L)
 					.showTime(LocalDateTime.of(2026, 3, 4, 19, 30))
 					.status(ShowScheduleStatus.CANCELLED.name())
+					.remainingSeats(List.of())
 					.build()
 			))
 			.seatGrades(List.of(
@@ -114,6 +122,8 @@ class ShowControllerTest {
 			.andExpect(jsonPath("$.data.showId").value(1))
 			.andExpect(jsonPath("$.data.noticeImgs[0]").value("https://img/notice.jpg"))
 			.andExpect(jsonPath("$.data.detailImgs[0]").value("https://img/detail-1.jpg"))
+			.andExpect(jsonPath("$.data.schedules[0].remainingSeats[0].gradeName").value("VIP"))
+			.andExpect(jsonPath("$.data.schedules[0].remainingSeats[0].remainingSeatCount").value(10))
 			.andExpect(jsonPath("$.data.schedules[1].status").value(ShowScheduleStatus.CLOSED.name()))
 			.andExpect(jsonPath("$.data.schedules[2].status").value(ShowScheduleStatus.CANCELLED.name()))
 			.andExpect(jsonPath("$.data.castings[0].artistName").value("배우A"))
@@ -213,13 +223,6 @@ class ShowControllerTest {
 								.artistName("강홍석")
 								.build()
 						))
-					.remainingSeats(List.of(
-						ShowCastingResponse.GradeRemaining.builder()
-							.gradeName("VIP")
-							.remainingSeatCount(10L)
-							.totalCount(20L)
-							.build()
-					))
 					.build()
 			))
 			.build();
@@ -244,11 +247,9 @@ class ShowControllerTest {
 			.andExpect(jsonPath("$.data.showId").value(1))
 			.andExpect(jsonPath("$.data.range.from").value("2025-12-17"))
 			.andExpect(jsonPath("$.data.roles[0].roleName").value("찰리"))
-				.andExpect(jsonPath("$.data.page.currentPage").value(0))
-				.andExpect(jsonPath("$.data.rows[0].scheduleId").value(101))
-				.andExpect(jsonPath("$.data.rows[0].casts.찰리.artistName").value("김호영"))
-				.andExpect(jsonPath("$.data.rows[0].casts.찰리.profileImageUrl").doesNotExist())
-				.andExpect(jsonPath("$.data.rows[0].remainingSeats[0].gradeName").value("VIP"))
-				.andExpect(jsonPath("$.data.rows[0].remainingSeats[0].remainingSeatCount").value(10));
+			.andExpect(jsonPath("$.data.page.currentPage").value(0))
+			.andExpect(jsonPath("$.data.rows[0].scheduleId").value(101))
+			.andExpect(jsonPath("$.data.rows[0].casts.찰리.artistName").value("김호영"))
+			.andExpect(jsonPath("$.data.rows[0].casts.찰리.profileImageUrl").doesNotExist());
 	}
 }

--- a/musical/src/test/java/com/truve/platform/show/service/service/ShowServiceTest.java
+++ b/musical/src/test/java/com/truve/platform/show/service/service/ShowServiceTest.java
@@ -152,6 +152,10 @@ class ShowServiceTest {
 		when(showScheduleRepository.findSchedules(showId)).thenReturn(List.of(schedule1, schedule2));
 		when(showCastingRepository.findAllByShowId(showId))
 			.thenReturn(List.of(castOrder1, castOrder1Duplicate, castOrder2, castOrderNull));
+		when(ticketingInternalClient.getRemainingSeats(2001L)).thenReturn(List.of(
+			new TicketingInternalClientResponse.GradeRemaining("VIP", 10L, 20L)
+		));
+		when(ticketingInternalClient.getRemainingSeats(2002L)).thenReturn(List.of());
 		when(artistLikeRepository.findLikedArtistIds(userId, List.of(101L, 102L, 103L)))
 			.thenReturn(List.of(101L));
 		when(showSeatGradeRepository.findSeatPrices(showId)).thenReturn(List.of(seat));
@@ -166,6 +170,9 @@ class ShowServiceTest {
 		assertEquals(2, result.getSchedules().size());
 		assertEquals("OPEN", result.getSchedules().get(0).getStatus());
 		assertEquals("CANCELLED", result.getSchedules().get(1).getStatus());
+		assertEquals(1, result.getSchedules().get(0).getRemainingSeats().size());
+		assertEquals("VIP", result.getSchedules().get(0).getRemainingSeats().get(0).getGradeName());
+		assertTrue(result.getSchedules().get(1).getRemainingSeats().isEmpty());
 
 		List<ShowResponse.Casting> castings = result.getCastings();
 		assertEquals(3, castings.size());
@@ -232,11 +239,6 @@ class ShowServiceTest {
 		)).thenReturn(new PageImpl<>(List.of(schedule1), PageRequest.of(0, 50), 1));
 		when(showCastingRepository.findAllByShowId(showId)).thenReturn(List.of(charlieCasting, lolaCasting));
 		when(showScheduleCastingRepository.findAllByScheduleIds(List.of(101L))).thenReturn(List.of(sc1, sc2));
-		when(ticketingInternalClient.getRemainingSeats(101L)).thenReturn(List.of(
-			new TicketingInternalClientResponse.GradeRemaining("VIP", 10L, 20L),
-			new TicketingInternalClientResponse.GradeRemaining("R", 30L, 40L)
-		));
-
 		ShowCastingResponse.Detail result = showCastingService.getCastingSchedules(
 			showId,
 			LocalDate.of(2025, 12, 17),
@@ -258,9 +260,6 @@ class ShowServiceTest {
 		assertEquals("오후 7:00", result.getRows().get(0).getShowTimeLabel());
 		assertEquals("김호영", result.getRows().get(0).getCasts().get("찰리").getArtistName());
 		assertEquals("강홍석", result.getRows().get(0).getCasts().get("롤라").getArtistName());
-		assertEquals(2, result.getRows().get(0).getRemainingSeats().size());
-		assertEquals("VIP", result.getRows().get(0).getRemainingSeats().get(0).getGradeName());
-		assertEquals(10L, result.getRows().get(0).getRemainingSeats().get(0).getRemainingSeatCount());
 		assertEquals(0, result.getPage().getCurrentPage());
 		assertEquals(50, result.getPage().getSize());
 		assertEquals(1, result.getPage().getTotalElements());
@@ -362,8 +361,6 @@ class ShowServiceTest {
 		when(showCastingRepository.findAllByShowId(showId))
 			.thenReturn(List.of(charlieCasting, lolaCasting, laurenCasting));
 		when(showScheduleCastingRepository.findAllByScheduleIds(List.of(101L))).thenReturn(List.of(sc1, sc2));
-		when(ticketingInternalClient.getRemainingSeats(101L)).thenReturn(List.of());
-
 		ShowCastingResponse.Detail result = showCastingService.getCastingSchedules(
 			showId,
 			LocalDate.of(2025, 12, 17),
@@ -423,8 +420,8 @@ class ShowServiceTest {
 	}
 
 	@Test
-	@DisplayName("캐스팅 일정 조회는 ticketing 조회 실패 시 잔여 좌석을 빈 목록으로 응답한다.")
-	void 캐스팅_일정_조회_ticketing_실패시_잔여좌석은_빈목록() {
+	@DisplayName("공연 상세 조회는 ticketing 조회 실패 시 회차별 잔여 좌석을 빈 목록으로 응답한다.")
+	void 공연_상세_조회_ticketing_실패시_잔여좌석은_빈목록() {
 		Long showId = 1L;
 		Show show = org.mockito.Mockito.mock(Show.class);
 		when(show.getId()).thenReturn(showId);
@@ -432,6 +429,7 @@ class ShowServiceTest {
 		ShowSchedule schedule1 = org.mockito.Mockito.mock(ShowSchedule.class);
 		when(schedule1.getId()).thenReturn(101L);
 		when(schedule1.getShowTime()).thenReturn(LocalDateTime.of(2026, 1, 2, 19, 0));
+		when(schedule1.getStatus()).thenReturn(ShowScheduleStatus.OPEN);
 
 		Artist artistCharlie = org.mockito.Mockito.mock(Artist.class);
 		when(artistCharlie.getId()).thenReturn(1L);
@@ -442,33 +440,15 @@ class ShowServiceTest {
 		when(charlieCasting.getCastingOrder()).thenReturn(1);
 		when(charlieCasting.getArtist()).thenReturn(artistCharlie);
 
-		ShowScheduleCasting sc1 = org.mockito.Mockito.mock(ShowScheduleCasting.class);
-		when(sc1.getShowSchedule()).thenReturn(schedule1);
-		when(sc1.getShowCasting()).thenReturn(charlieCasting);
-
 		when(showRepository.findByIdOrThrow(showId)).thenReturn(show);
-		when(showScheduleRepository.findCastingSchedules(
-			org.mockito.ArgumentMatchers.eq(showId),
-			org.mockito.ArgumentMatchers.any(),
-			org.mockito.ArgumentMatchers.any(),
-			org.mockito.ArgumentMatchers.eq(true),
-			org.mockito.ArgumentMatchers.anyList(),
-			org.mockito.ArgumentMatchers.any(PageRequest.class)
-		)).thenReturn(new PageImpl<>(List.of(schedule1), PageRequest.of(0, 50), 1));
+		when(showScheduleRepository.findSchedules(showId)).thenReturn(List.of(schedule1));
 		when(showCastingRepository.findAllByShowId(showId)).thenReturn(List.of(charlieCasting));
-		when(showScheduleCastingRepository.findAllByScheduleIds(List.of(101L))).thenReturn(List.of(sc1));
 		when(ticketingInternalClient.getRemainingSeats(101L))
 			.thenThrow(new RestClientException("ticketing unavailable"));
+		when(showSeatGradeRepository.findSeatPrices(showId)).thenReturn(List.of());
 
-		ShowCastingResponse.Detail result = showCastingService.getCastingSchedules(
-			showId,
-			LocalDate.of(2025, 12, 17),
-			LocalDate.of(2026, 3, 29),
-			List.of(),
-			0,
-			50
-		);
+		ShowResponse.Detail result = showDetailService.getDetail(showId, null);
 
-		assertTrue(result.getRows().get(0).getRemainingSeats().isEmpty());
+		assertTrue(result.getSchedules().get(0).getRemainingSeats().isEmpty());
 	}
 }


### PR DESCRIPTION
## 변경 사항

---
- remainingSeats를 상세조회 schedules[]로 이동하고 캐스팅 일정 조회에서 제거
- remainingSeats 응답에서 totalCount 제거
- ticketing 호출 실패 시 fallback 처리하고 warn로그만 남김

- [x] 전체 테스트 코드 성공 여부

## 관련 이슈

---
- Notion Ticket: #

## 참고사항 (선택)

---