### PR TITLE
feat(ticketing): 좌석 선점 시 매크로 탐지 유저 체크

### DIFF
--- a/common/src/main/java/com/truve/platform/common/exception/ErrorCode.java
+++ b/common/src/main/java/com/truve/platform/common/exception/ErrorCode.java
@@ -51,6 +51,7 @@ public enum ErrorCode {
 	INVALID_SHOW_SCHEDULE(HttpStatus.BAD_REQUEST, "잘못된 공연 정보입니다.", "T09"),
 	EXCEEDED_MAX_TICKET_COUNT(HttpStatus.BAD_REQUEST, "인당 최대 4매까지 예매 가능합니다.", "T10"),
 	INVALID_HOLD_SEAT(HttpStatus.BAD_REQUEST, "타인이 점유한 좌석입니다.", "T11"),
+	SUSPECTED_MACRO_ACTIVITY(HttpStatus.BAD_REQUEST, "매크로 의심 유저입니다.", "T12"),
 
 	INVALID_RESERVATION_STATUS(HttpStatus.BAD_REQUEST, "유효하지 않은 예약 상태입니다.", "B01"),
 	CANCEL_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "관람일 당일에는 취소가 불가능합니다.", "B02"),

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/ticketing/repository/TicketingRedisRepository.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/ticketing/repository/TicketingRedisRepository.java
@@ -4,8 +4,12 @@ import java.time.Duration;
 import java.util.UUID;
 
 import org.springframework.stereotype.Repository;
+import org.springframework.util.StringUtils;
 import org.truve.platform.ticketing.service.ticketing.dto.SessionTicketValueDTO;
 import org.truve.platform.ticketing.service.global.support.RedisSupport;
+
+import com.truve.platform.common.exception.ErrorCode;
+import com.truve.platform.common.support.Preconditions;
 
 import lombok.RequiredArgsConstructor;
 
@@ -17,6 +21,8 @@ public class TicketingRedisRepository {
 	private static final String TICKET_ACTIVE_SHOW_USER_PREFIX = "ticket:active:";
 	private static final String READY_KEY_PREFIX = "queue:ready:";
 	private static final String SEAT_HOLD_KEY_PREFIX = "seat:hold:";
+	private static final String BLOCKED_TICKET_PREFIX = "ticket:blocked:";
+
 
 	private final RedisSupport redisSupport;
 
@@ -62,9 +68,17 @@ public class TicketingRedisRepository {
 	public String getHoldSeatSessionToken(Long showScheduleId, Long seatId) {
 		return redisSupport.getValue(seatHoldKey(showScheduleId, seatId));
 	}
+	public void findMacro(String sessionTicket) {
+		String key = secureKey(sessionTicket);
+		Preconditions.validate(!StringUtils.hasText(redisSupport.getValue(key)), ErrorCode.SUSPECTED_MACRO_ACTIVITY);
+	}
 
 	private String seatHoldKey(Long showScheduleId, Long seatId) {
 		return SEAT_HOLD_KEY_PREFIX + showScheduleId + ":" + seatId;
+	}
+
+	private String secureKey(String sessionTicket) {
+		return BLOCKED_TICKET_PREFIX + sessionTicket;
 	}
 
 	private String sessionTokenKey(String sessionToken) {

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/ticketing/repository/TicketingRedisRepository.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/ticketing/repository/TicketingRedisRepository.java
@@ -68,9 +68,14 @@ public class TicketingRedisRepository {
 	public String getHoldSeatSessionToken(Long showScheduleId, Long seatId) {
 		return redisSupport.getValue(seatHoldKey(showScheduleId, seatId));
 	}
-	public void findMacro(String sessionTicket) {
+	public String validateMacro(String sessionTicket) {
 		String key = secureKey(sessionTicket);
-		Preconditions.validate(!StringUtils.hasText(redisSupport.getValue(key)), ErrorCode.SUSPECTED_MACRO_ACTIVITY);
+		return redisSupport.getValue(key);
+	}
+
+	public void expireSessionToken(String sessionToken) {
+		String key = sessionTokenKey(sessionToken);
+		redisSupport.expireSeconds(key, 0);
 	}
 
 	private String seatHoldKey(Long showScheduleId, Long seatId) {

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/ticketing/service/TicketingSecurityService.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/ticketing/service/TicketingSecurityService.java
@@ -1,0 +1,16 @@
+package org.truve.platform.ticketing.service.ticketing.service;
+
+import org.springframework.stereotype.Service;
+import org.truve.platform.ticketing.service.ticketing.repository.TicketingRedisRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Service
+public class TicketingSecurityService {
+	private final TicketingRedisRepository ticketingRedisRepository;
+
+	public void findMacro(String sessionTicket) {
+		ticketingRedisRepository.findMacro(sessionTicket);
+	}
+}

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/ticketing/service/TicketingSecurityService.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/ticketing/service/TicketingSecurityService.java
@@ -1,7 +1,11 @@
 package org.truve.platform.ticketing.service.ticketing.service;
 
 import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
 import org.truve.platform.ticketing.service.ticketing.repository.TicketingRedisRepository;
+
+import com.truve.platform.common.exception.CustomException;
+import com.truve.platform.common.exception.ErrorCode;
 
 import lombok.RequiredArgsConstructor;
 
@@ -11,6 +15,9 @@ public class TicketingSecurityService {
 	private final TicketingRedisRepository ticketingRedisRepository;
 
 	public void findMacro(String sessionTicket) {
-		ticketingRedisRepository.findMacro(sessionTicket);
+		if(StringUtils.hasText(ticketingRedisRepository.validateMacro(sessionTicket))) {
+			ticketingRedisRepository.expireSessionToken(sessionTicket);
+			throw new CustomException(ErrorCode.SUSPECTED_MACRO_ACTIVITY);
+		}
 	}
 }

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/ticketing/service/TicketingService.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/ticketing/service/TicketingService.java
@@ -74,11 +74,11 @@ public class TicketingService {
 		ShowScheduled showScheduled = showScheduledRepository.findById(showScheduleId)
 			.orElseThrow(() -> new CustomException(ErrorCode.INVALID_SHOW_SCHEDULE));
 
-		List<ScheduledSeat> seats = scheduledSeatRepository.findAllById(scheduledSeatIds);
+		List<ScheduledSeat> scheduledSeats = scheduledSeatRepository.findAllById(scheduledSeatIds);
 
-		Preconditions.validate(scheduledSeatIds.size() == seats.size(), ErrorCode.NOT_CORRECT_SEAT);
+		Preconditions.validate(scheduledSeatIds.size() == scheduledSeats.size(), ErrorCode.NOT_CORRECT_SEAT);
 
-		for(ScheduledSeat seat: seats) {
+		for(ScheduledSeat seat: scheduledSeats) {
 
 			Preconditions.validate(
 				showScheduled.getId().equals(seat.getShowScheduleId()),

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/ticketing/service/TicketingService.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/ticketing/service/TicketingService.java
@@ -32,6 +32,7 @@ public class TicketingService {
 	private final TicketingProperties ticketingProperties;
 	private final ScheduledSeatRepository scheduledSeatRepository;
 	private final ShowScheduledRepository showScheduledRepository;
+	private final TicketingSecurityService  ticketingSecurityService;
 
 	public TicketingResponse.Enter enter(Long showScheduleId, UUID userId, String admissionToken) {
 		AdmissionTokenClaimsDTO claims = admissionTokenService.parseAdmissionToken(admissionToken, showScheduleId, userId);
@@ -65,6 +66,7 @@ public class TicketingService {
 	}
 
 	public void holdSeat(Long showScheduleId, UUID userId, String sessionToken, List<Long> scheduledSeatIds) {
+		ticketingSecurityService.findMacro(sessionToken);
 		heartbeat(showScheduleId, userId, sessionToken);
 
 		Preconditions.validate(scheduledSeatIds.size() <= 4, ErrorCode.EXCEEDED_MAX_TICKET_COUNT);

--- a/ticketing/src/test/java/org/truve/platform/ticketing/service/ticketing/service/TicketingSecurityServiceTest.java
+++ b/ticketing/src/test/java/org/truve/platform/ticketing/service/ticketing/service/TicketingSecurityServiceTest.java
@@ -1,0 +1,61 @@
+package org.truve.platform.ticketing.service.ticketing.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+import static org.mockito.Mockito.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.truve.platform.ticketing.service.ticketing.repository.TicketingRedisRepository;
+
+import com.truve.platform.common.exception.CustomException;
+import com.truve.platform.common.exception.ErrorCode;
+
+@ExtendWith(MockitoExtension.class)
+class TicketingSecurityServiceTest {
+
+	@Mock
+	private TicketingRedisRepository ticketingRedisRepository;
+
+	@InjectMocks
+	private TicketingSecurityService ticketingSecurityService;
+
+	@Test
+	@DisplayName("매크로 차단 키가 있으면 세션 토큰을 만료시키고 SUSPECTED_MACRO_ACTIVITY 예외를 던진다.")
+	void 매크로탐지_차단성공() {
+		// given
+		String sessionToken = "session-token";
+		given(ticketingRedisRepository.validateMacro(sessionToken)).willReturn("blocked");
+
+		// when
+		CustomException exception = assertThrows(
+			CustomException.class,
+			() -> ticketingSecurityService.findMacro(sessionToken)
+		);
+
+		// then
+		assertAll(
+			() -> assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.SUSPECTED_MACRO_ACTIVITY),
+			() -> verify(ticketingRedisRepository).expireSessionToken(sessionToken)
+		);
+	}
+
+	@Test
+	@DisplayName("매크로 차단 키가 없으면 정상 통과하고 세션 토큰을 만료시키지 않는다.")
+	void 매크로탐지_정상통과() {
+		// given
+		String sessionToken = "session-token";
+		given(ticketingRedisRepository.validateMacro(sessionToken)).willReturn(null);
+
+		// when
+		assertDoesNotThrow(() -> ticketingSecurityService.findMacro(sessionToken));
+
+		// then
+		verify(ticketingRedisRepository, never()).expireSessionToken(anyString());
+	}
+}

--- a/ticketing/src/test/java/org/truve/platform/ticketing/service/ticketing/service/TicketingServiceTest.java
+++ b/ticketing/src/test/java/org/truve/platform/ticketing/service/ticketing/service/TicketingServiceTest.java
@@ -51,6 +51,8 @@ class TicketingServiceTest {
 	private ScheduledSeatRepository scheduledSeatRepository;
 	@Mock
 	private ShowScheduledRepository showScheduledRepository;
+	@Mock
+	private TicketingSecurityService ticketingSecurityService;
 
 	@InjectMocks
 	private TicketingService ticketingService;
@@ -227,6 +229,7 @@ class TicketingServiceTest {
 			given(ticketingRedisRepository.getSessionTokenValue(sessionToken))
 				.willReturn(SessionTicketValueDTO.of(userId, showScheduleId));
 			given(ticketingRedisRepository.refreshSessionTokenTtl(sessionToken, 300L)).willReturn(true);
+			willDoNothing().given(ticketingSecurityService).findMacro(sessionToken);
 
 			showScheduled = ShowScheduled.builder()
 				.title("공연")
@@ -253,8 +256,32 @@ class TicketingServiceTest {
 
 			// then
 			assertAll(
+				() -> verify(ticketingSecurityService).findMacro(sessionToken),
 				() -> verify(ticketingRedisRepository).tryHoldSeat(showScheduleId, 10L, sessionToken),
 				() -> verify(ticketingRedisRepository).tryHoldSeat(showScheduleId, 11L, sessionToken)
+			);
+		}
+
+		@Test
+		@DisplayName("매크로 탐지 대상 세션이면 SUSPECTED_MACRO_ACTIVITY 예외가 발생하고 선점 로직은 수행하지 않는다.")
+		void 좌석선점_매크로탐지() {
+			// given
+			willThrow(new CustomException(ErrorCode.SUSPECTED_MACRO_ACTIVITY))
+				.given(ticketingSecurityService).findMacro(sessionToken);
+
+			// when
+			CustomException exception = assertThrows(
+				CustomException.class,
+				() -> ticketingService.holdSeat(showScheduleId, userId, sessionToken, List.of(10L))
+			);
+
+			// then
+			assertAll(
+				() -> assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.SUSPECTED_MACRO_ACTIVITY),
+				() -> verify(ticketingSecurityService).findMacro(sessionToken),
+				() -> verify(showScheduledRepository, never()).findById(anyLong()),
+				() -> verify(scheduledSeatRepository, never()).findAllById(anyIterable()),
+				() -> verify(ticketingRedisRepository, never()).tryHoldSeat(anyLong(), anyLong(), anyString())
 			);
 		}
 


### PR DESCRIPTION
## 변경 사항
추가/변경 사항과 사유를 작성해 주세요.

- [x] 전체 테스트 코드 성공 여부

좌석 선점 시 레디스에 `blokced_ticket:{X-Session-Ticket}` 값 조회 이후 있으면 차단 후 세션토큰 만료합니다.

## 관련 이슈

- Notion Ticket:[#89](https://www.notion.so/FE-33d9e3e335cc80d491e5d4eb4695cd76?source=copy_link)

## 참고사항 (선택)

[보안 문서 참고](https://www.notion.so/0409-33b9e3e335cc80a5b622c9967c03b477?source=copy_link)
