### PR TITLE
feat(membership): 내 멤버십 조회 API 구현

### DIFF
--- a/musical/src/main/java/com/truve/platform/musical/MusicalApplication.java
+++ b/musical/src/main/java/com/truve/platform/musical/MusicalApplication.java
@@ -2,7 +2,9 @@ package com.truve.platform.musical;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @SpringBootApplication(scanBasePackages = "com.truve.platform")
 public class MusicalApplication {
 

--- a/musical/src/main/java/com/truve/platform/musical/show/controller/MembershipController.java
+++ b/musical/src/main/java/com/truve/platform/musical/show/controller/MembershipController.java
@@ -2,6 +2,7 @@ package com.truve.platform.musical.show.controller;
 
 import java.util.UUID;
 
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -18,7 +19,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 
 @RestController
-@RequestMapping("/api/musical/artists")
+@RequestMapping("/api/musical")
 public class MembershipController {
 
 	private final MembershipService membershipService;
@@ -28,12 +29,20 @@ public class MembershipController {
 	}
 
 	@Operation(summary = "아티스트 멤버십 결제 준비", description = "멤버십 가입 결제를 위해 주문을 생성하고 결제를 준비합니다.")
-	@PostMapping("/{artistId}/membership/payment")
+	@PostMapping("/artists/{artistId}/membership/payment")
 	public ApiResult<MembershipResponse.CreatePayment> createPayment(
 		@PathVariable Long artistId,
 		@RequestHeader(name = "X-User-Id") UUID userId,
 		@RequestBody @Valid MembershipRequest.CreatePayment request
 	) {
 		return ApiResult.ok(membershipService.createPayment(artistId, userId, request));
+	}
+
+	@Operation(summary = "내 멤버십 조회", description = "현재 유효한 내 멤버십의 목록을 조회합니다.")
+	@GetMapping("/my/membership")
+	public ApiResult<MembershipResponse.MyMembership> getMyMembership(
+		@RequestHeader(name = "X-User-Id") UUID userId
+	) {
+		return ApiResult.ok(membershipService.getMyMembership(userId));
 	}
 }

--- a/musical/src/main/java/com/truve/platform/musical/show/domain/entity/ArtistMembership.java
+++ b/musical/src/main/java/com/truve/platform/musical/show/domain/entity/ArtistMembership.java
@@ -1,5 +1,6 @@
 package com.truve.platform.musical.show.domain.entity;
 
+import java.time.LocalDateTime;
 import java.util.UUID;
 
 import com.truve.platform.common.support.BaseEntity;
@@ -55,6 +56,12 @@ public class ArtistMembership extends BaseEntity {
 	@Column(name = "payment_method", nullable = false)
 	private MembershipPaymentMethod paymentMethod;
 
+	@Column(name = "joined_at")
+	private LocalDateTime joinedAt;
+
+	@Column(name = "next_billing_at")
+	private LocalDateTime nextBillingAt;
+
 	@Builder
 	private ArtistMembership(
 		UUID userId,
@@ -62,7 +69,9 @@ public class ArtistMembership extends BaseEntity {
 		ArtistMembershipStatus status,
 		String orderId,
 		Long monthlyAmount,
-		MembershipPaymentMethod paymentMethod
+		MembershipPaymentMethod paymentMethod,
+		LocalDateTime joinedAt,
+		LocalDateTime nextBillingAt
 	) {
 		this.userId = userId;
 		this.artist = artist;
@@ -70,6 +79,8 @@ public class ArtistMembership extends BaseEntity {
 		this.orderId = orderId;
 		this.monthlyAmount = monthlyAmount;
 		this.paymentMethod = paymentMethod;
+		this.joinedAt = joinedAt;
+		this.nextBillingAt = nextBillingAt;
 	}
 
 	public static ArtistMembership preparePayment(
@@ -86,6 +97,8 @@ public class ArtistMembership extends BaseEntity {
 			.orderId(orderId)
 			.monthlyAmount(monthlyAmount)
 			.paymentMethod(paymentMethod)
+			.joinedAt(null)
+			.nextBillingAt(null)
 			.build();
 	}
 
@@ -102,5 +115,15 @@ public class ArtistMembership extends BaseEntity {
 		this.orderId = orderId;
 		this.monthlyAmount = monthlyAmount;
 		this.paymentMethod = paymentMethod;
+		this.joinedAt = null;
+		this.nextBillingAt = null;
+	}
+
+	public void expireCancellation(LocalDateTime now) {
+		if (this.status == ArtistMembershipStatus.CANCEL_SCHEDULED
+			&& this.nextBillingAt != null
+			&& !this.nextBillingAt.isAfter(now)) {
+			this.status = ArtistMembershipStatus.CANCELED;
+		}
 	}
 }

--- a/musical/src/main/java/com/truve/platform/musical/show/dto/MembershipResponse.java
+++ b/musical/src/main/java/com/truve/platform/musical/show/dto/MembershipResponse.java
@@ -63,4 +63,160 @@ public class MembershipResponse {
 			return paymentMethod;
 		}
 	}
+
+	public static class MyMembership {
+		private MyMembershipSummary summary;
+		private java.util.List<MyMembershipItem> memberships;
+
+		public MyMembership(MyMembershipSummary summary, java.util.List<MyMembershipItem> memberships) {
+			this.summary = summary;
+			this.memberships = memberships;
+		}
+
+		public static MyMembership of(MyMembershipSummary summary, java.util.List<MyMembershipItem> memberships) {
+			return new MyMembership(summary, memberships);
+		}
+
+		public MyMembershipSummary getSummary() {
+			return summary;
+		}
+
+		public java.util.List<MyMembershipItem> getMemberships() {
+			return memberships;
+		}
+	}
+
+	public static class MyMembershipSummary {
+		private long activeMembershipCount;
+		private long monthlyPaymentAmount;
+
+		public MyMembershipSummary(long activeMembershipCount, long monthlyPaymentAmount) {
+			this.activeMembershipCount = activeMembershipCount;
+			this.monthlyPaymentAmount = monthlyPaymentAmount;
+		}
+
+		public static MyMembershipSummary of(long activeMembershipCount, long monthlyPaymentAmount) {
+			return new MyMembershipSummary(activeMembershipCount, monthlyPaymentAmount);
+		}
+
+		public long getActiveMembershipCount() {
+			return activeMembershipCount;
+		}
+
+		public long getMonthlyPaymentAmount() {
+			return monthlyPaymentAmount;
+		}
+	}
+
+	public static class MyMembershipItem {
+		private Long membershipId;
+		private Long artistId;
+		private String artistName;
+		private String profileImageUrl;
+		private String status;
+		private String statusLabel;
+		private String joinedAt;
+		private String nextBillingAt;
+		private long remainingDays;
+		private long monthlyAmount;
+		private boolean cancelable;
+
+		public MyMembershipItem(
+			Long membershipId,
+			Long artistId,
+			String artistName,
+			String profileImageUrl,
+			String status,
+			String statusLabel,
+			String joinedAt,
+			String nextBillingAt,
+			long remainingDays,
+			long monthlyAmount,
+			boolean cancelable
+		) {
+			this.membershipId = membershipId;
+			this.artistId = artistId;
+			this.artistName = artistName;
+			this.profileImageUrl = profileImageUrl;
+			this.status = status;
+			this.statusLabel = statusLabel;
+			this.joinedAt = joinedAt;
+			this.nextBillingAt = nextBillingAt;
+			this.remainingDays = remainingDays;
+			this.monthlyAmount = monthlyAmount;
+			this.cancelable = cancelable;
+		}
+
+		public static MyMembershipItem of(
+			Long membershipId,
+			Long artistId,
+			String artistName,
+			String profileImageUrl,
+			String status,
+			String statusLabel,
+			String joinedAt,
+			String nextBillingAt,
+			long remainingDays,
+			long monthlyAmount,
+			boolean cancelable
+		) {
+			return new MyMembershipItem(
+				membershipId,
+				artistId,
+				artistName,
+				profileImageUrl,
+				status,
+				statusLabel,
+				joinedAt,
+				nextBillingAt,
+				remainingDays,
+				monthlyAmount,
+				cancelable
+			);
+		}
+
+		public Long getMembershipId() {
+			return membershipId;
+		}
+
+		public Long getArtistId() {
+			return artistId;
+		}
+
+		public String getArtistName() {
+			return artistName;
+		}
+
+		public String getProfileImageUrl() {
+			return profileImageUrl;
+		}
+
+		public String getStatus() {
+			return status;
+		}
+
+		public String getStatusLabel() {
+			return statusLabel;
+		}
+
+		public String getJoinedAt() {
+			return joinedAt;
+		}
+
+		public String getNextBillingAt() {
+			return nextBillingAt;
+		}
+
+		public long getRemainingDays() {
+			return remainingDays;
+		}
+
+		public long getMonthlyAmount() {
+			return monthlyAmount;
+		}
+
+		public boolean isCancelable() {
+			return cancelable;
+		}
+	}
 }

--- a/musical/src/main/java/com/truve/platform/musical/show/repository/ArtistMembershipRepository.java
+++ b/musical/src/main/java/com/truve/platform/musical/show/repository/ArtistMembershipRepository.java
@@ -1,9 +1,15 @@
 package com.truve.platform.musical.show.repository;
 
+import java.time.LocalDateTime;
+import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.truve.platform.musical.show.domain.constant.ArtistMembershipStatus;
 import com.truve.platform.musical.show.domain.entity.ArtistMembership;
@@ -15,4 +21,30 @@ public interface ArtistMembershipRepository extends JpaRepository<ArtistMembersh
 	Optional<ArtistMembership> findByOrderId(String orderId);
 
 	boolean existsByUserIdAndArtistIdAndStatus(UUID userId, Long artistId, ArtistMembershipStatus status);
+
+	@EntityGraph(attributePaths = {"artist"})
+	@Query("""
+		select am
+		from ArtistMembership am
+		where am.userId = :userId
+		and am.status in :statuses
+		and am.nextBillingAt > :now
+		order by am.nextBillingAt asc, am.joinedAt desc, am.id asc
+	""")
+	List<ArtistMembership> findCurrentMemberships(
+		@Param("userId") UUID userId,
+		@Param("statuses") Collection<ArtistMembershipStatus> statuses,
+		@Param("now") LocalDateTime now
+	);
+
+	@Query("""
+		select am
+		from ArtistMembership am
+		where am.status = :status
+		and am.nextBillingAt <= :nextBillingAt
+	""")
+	List<ArtistMembership> findExpiredMemberships(
+		@Param("status") ArtistMembershipStatus status,
+		@Param("nextBillingAt") LocalDateTime nextBillingAt
+	);
 }

--- a/musical/src/main/java/com/truve/platform/musical/show/scheduler/MembershipStatusScheduler.java
+++ b/musical/src/main/java/com/truve/platform/musical/show/scheduler/MembershipStatusScheduler.java
@@ -1,0 +1,33 @@
+package com.truve.platform.musical.show.scheduler;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.truve.platform.musical.show.domain.constant.ArtistMembershipStatus;
+import com.truve.platform.musical.show.domain.entity.ArtistMembership;
+import com.truve.platform.musical.show.repository.ArtistMembershipRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class MembershipStatusScheduler {
+
+	private final ArtistMembershipRepository artistMembershipRepository;
+
+	@Scheduled(fixedDelay = 60000)
+	@Transactional
+	public void expireScheduledMemberships() {
+		LocalDateTime now = LocalDateTime.now();
+		List<ArtistMembership> memberships = artistMembershipRepository.findExpiredMemberships(
+			ArtistMembershipStatus.CANCEL_SCHEDULED,
+			now
+		);
+
+		memberships.forEach(membership -> membership.expireCancellation(now));
+	}
+}

--- a/musical/src/main/java/com/truve/platform/musical/show/service/MembershipService.java
+++ b/musical/src/main/java/com/truve/platform/musical/show/service/MembershipService.java
@@ -1,5 +1,9 @@
 package com.truve.platform.musical.show.service;
 
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
 import java.util.UUID;
 
 import org.springframework.dao.DataIntegrityViolationException;
@@ -9,6 +13,8 @@ import org.springframework.transaction.annotation.Transactional;
 import com.truve.platform.common.exception.CustomException;
 import com.truve.platform.common.exception.ErrorCode;
 import com.truve.platform.common.support.Preconditions;
+import com.truve.platform.musical.s3.S3Service;
+import com.truve.platform.musical.show.domain.constant.ArtistMembershipStatus;
 import com.truve.platform.musical.show.domain.entity.ArtistMembership;
 import com.truve.platform.musical.show.domain.entity.Artist;
 import com.truve.platform.musical.show.dto.MembershipRequest;
@@ -19,23 +25,18 @@ import com.truve.platform.musical.show.repository.ArtistMembershipRepository;
 import com.truve.platform.musical.show.repository.ArtistRepository;
 import com.truve.platform.musical.show.util.MembershipOrderIdGenerator;
 
+import lombok.RequiredArgsConstructor;
+
 @Service
+@RequiredArgsConstructor
 public class MembershipService {
 	private static final long MONTHLY_MEMBERSHIP_AMOUNT = 5_000L;
+	private static final DateTimeFormatter MEMBERSHIP_DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy.MM.dd.");
 
 	private final ArtistRepository artistRepository;
 	private final ArtistMembershipRepository artistMembershipRepository;
 	private final PaymentPublisher paymentPublisher;
-
-	public MembershipService(
-		ArtistRepository artistRepository,
-		ArtistMembershipRepository artistMembershipRepository,
-		PaymentPublisher paymentPublisher
-	) {
-		this.artistRepository = artistRepository;
-		this.artistMembershipRepository = artistMembershipRepository;
-		this.paymentPublisher = paymentPublisher;
-	}
+	private final S3Service s3Service;
 
 	@Transactional
 	public MembershipResponse.CreatePayment createPayment(
@@ -67,5 +68,70 @@ public class MembershipService {
 		paymentPublisher.publish(PaymentEventCommand.Create.of(savedMembership));
 
 		return MembershipResponse.CreatePayment.of(artistId, artistDetail.getArtistName(), savedMembership);
+	}
+
+	@Transactional(readOnly = true)
+	public MembershipResponse.MyMembership getMyMembership(UUID userId) {
+		LocalDateTime now = LocalDateTime.now();
+		List<ArtistMembership> memberships = artistMembershipRepository.findCurrentMemberships(
+			userId,
+			List.of(ArtistMembershipStatus.ACTIVE, ArtistMembershipStatus.CANCEL_SCHEDULED),
+			now
+		);
+
+		List<MembershipResponse.MyMembershipItem> items = memberships.stream()
+			.map(membership -> toMyMembershipItem(membership, now))
+			.toList();
+
+		long monthlyPaymentAmount = memberships.stream()
+			.filter(membership -> membership.getStatus() == ArtistMembershipStatus.ACTIVE)
+			.mapToLong(ArtistMembership::getMonthlyAmount)
+			.sum();
+
+		return MembershipResponse.MyMembership.of(
+			MembershipResponse.MyMembershipSummary.of(items.size(), monthlyPaymentAmount),
+			items
+		);
+	}
+
+	private MembershipResponse.MyMembershipItem toMyMembershipItem(ArtistMembership membership, LocalDateTime now) {
+		return MembershipResponse.MyMembershipItem.of(
+			membership.getId(),
+			membership.getArtist().getId(),
+			membership.getArtist().getName(),
+			toProfileImageUrl(membership.getArtist().getProfileImg()),
+			membership.getStatus().name(),
+			toStatusLabel(membership.getStatus()),
+			formatMembershipDate(membership.getJoinedAt()),
+			formatMembershipDate(membership.getNextBillingAt()),
+			calculateRemainingDays(membership.getNextBillingAt(), now),
+			membership.getMonthlyAmount(),
+			membership.getStatus() == ArtistMembershipStatus.ACTIVE
+		);
+	}
+
+	private String toProfileImageUrl(String profileImg) {
+		return profileImg == null ? null : s3Service.getImageUrl(profileImg);
+	}
+
+	private String toStatusLabel(ArtistMembershipStatus status) {
+		return switch (status) {
+			case ACTIVE -> "멤버십 가입중";
+			case CANCEL_SCHEDULED -> "해지 예정";
+			default -> status.name();
+		};
+	}
+
+	private String formatMembershipDate(LocalDateTime dateTime) {
+		return dateTime == null ? null : dateTime.format(MEMBERSHIP_DATE_FORMATTER);
+	}
+
+	private long calculateRemainingDays(LocalDateTime nextBillingAt, LocalDateTime now) {
+		if (nextBillingAt == null) {
+			return 0L;
+		}
+
+		long remainingDays = ChronoUnit.DAYS.between(now.toLocalDate(), nextBillingAt.toLocalDate());
+		return Math.max(remainingDays, 0L);
 	}
 }

--- a/musical/src/test/java/com/truve/platform/musical/show/controller/MembershipControllerTest.java
+++ b/musical/src/test/java/com/truve/platform/musical/show/controller/MembershipControllerTest.java
@@ -1,10 +1,10 @@
 package com.truve.platform.musical.show.controller;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willThrow;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -34,6 +34,10 @@ import com.truve.platform.musical.show.service.MembershipService;
 @org.springframework.context.annotation.Import(ApiAdvice.class)
 @ContextConfiguration(classes = MusicalApplication.class)
 class MembershipControllerTest {
+	private static final UUID USER_ID = UUID.fromString("11111111-1111-1111-1111-111111111111");
+	private static final Long ARTIST_ID = 101L;
+	private static final String ARTIST_NAME = "고은성";
+	private static final long MONTHLY_AMOUNT = 5_000L;
 
 	@Autowired
 	private MockMvc mockMvc;
@@ -49,34 +53,28 @@ class MembershipControllerTest {
 	@Test
 	@DisplayName("아티스트 멤버십 결제 준비에 성공하면 200 OK와 주문 정보를 응답한다.")
 	void 아티스트_멤버십_결제준비_성공() throws Exception {
-		UUID userId = UUID.fromString("11111111-1111-1111-1111-111111111111");
-		MembershipRequest.CreatePayment request = new MembershipRequest.CreatePayment(
-			MembershipPaymentMethod.TOSS_PAY,
-			true,
-			true,
-			true
-		);
+		MembershipRequest.CreatePayment request = createPaymentRequest(MembershipPaymentMethod.TOSS_PAY);
 		MembershipResponse.CreatePayment response = new MembershipResponse.CreatePayment(
-			101L,
-			"고은성",
+			ARTIST_ID,
+			ARTIST_NAME,
 			"월간 멤버십",
-			5_000L,
+			MONTHLY_AMOUNT,
 			"M20260326ABC123",
 			"토스 결제"
 		);
 
-		given(membershipService.createPayment(eq(101L), eq(userId), any())).willReturn(response);
+		given(membershipService.createPayment(eq(ARTIST_ID), eq(USER_ID), any())).willReturn(response);
 
-		mockMvc.perform(post("/api/musical/artists/{artistId}/membership/payment", 101L)
-				.header("X-User-Id", userId)
+		mockMvc.perform(post("/api/musical/artists/{artistId}/membership/payment", ARTIST_ID)
+				.header("X-User-Id", USER_ID)
 				.contentType("application/json")
 				.content(objectMapper.writeValueAsString(request)))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.code").value("ok"))
-			.andExpect(jsonPath("$.data.artistId").value(101L))
-			.andExpect(jsonPath("$.data.artistName").value("고은성"))
+			.andExpect(jsonPath("$.data.artistId").value(ARTIST_ID))
+			.andExpect(jsonPath("$.data.artistName").value(ARTIST_NAME))
 			.andExpect(jsonPath("$.data.planName").value("월간 멤버십"))
-			.andExpect(jsonPath("$.data.amount").value(5000L))
+			.andExpect(jsonPath("$.data.amount").value(MONTHLY_AMOUNT))
 			.andExpect(jsonPath("$.data.orderId").value("M20260326ABC123"))
 			.andExpect(jsonPath("$.data.paymentMethod").value("토스 결제"));
 	}
@@ -84,20 +82,14 @@ class MembershipControllerTest {
 	@Test
 	@DisplayName("존재하지 않는 아티스트의 멤버십 결제 준비 요청은 404를 응답한다.")
 	void 존재하지않는_아티스트_멤버십_결제준비_실패() throws Exception {
-		UUID userId = UUID.fromString("11111111-1111-1111-1111-111111111111");
-		MembershipRequest.CreatePayment request = new MembershipRequest.CreatePayment(
-			MembershipPaymentMethod.TOSS_PAY,
-			true,
-			true,
-			true
-		);
+		MembershipRequest.CreatePayment request = createPaymentRequest(MembershipPaymentMethod.TOSS_PAY);
 
 		willThrow(new CustomException(ErrorCode.NOT_FOUND_ARTIST))
 			.given(membershipService)
-			.createPayment(eq(999L), eq(userId), any());
+			.createPayment(eq(999L), eq(USER_ID), any());
 
 		mockMvc.perform(post("/api/musical/artists/{artistId}/membership/payment", 999L)
-				.header("X-User-Id", userId)
+				.header("X-User-Id", USER_ID)
 				.contentType("application/json")
 				.content(objectMapper.writeValueAsString(request)))
 			.andExpect(status().isNotFound())
@@ -108,20 +100,14 @@ class MembershipControllerTest {
 	@Test
 	@DisplayName("이미 가입한 아티스트의 멤버십 결제 준비 요청은 400을 응답한다.")
 	void 이미가입한_아티스트_멤버십_결제준비_실패() throws Exception {
-		UUID userId = UUID.fromString("11111111-1111-1111-1111-111111111111");
-		MembershipRequest.CreatePayment request = new MembershipRequest.CreatePayment(
-			MembershipPaymentMethod.BANK_TRANSFER,
-			true,
-			true,
-			true
-		);
+		MembershipRequest.CreatePayment request = createPaymentRequest(MembershipPaymentMethod.BANK_TRANSFER);
 
 		willThrow(new CustomException(ErrorCode.ALREADY_JOINED_ARTIST_MEMBERSHIP))
 			.given(membershipService)
-			.createPayment(eq(101L), eq(userId), any());
+			.createPayment(eq(ARTIST_ID), eq(USER_ID), any());
 
-		mockMvc.perform(post("/api/musical/artists/{artistId}/membership/payment", 101L)
-				.header("X-User-Id", userId)
+		mockMvc.perform(post("/api/musical/artists/{artistId}/membership/payment", ARTIST_ID)
+				.header("X-User-Id", USER_ID)
 				.contentType("application/json")
 				.content(objectMapper.writeValueAsString(request)))
 			.andExpect(status().isBadRequest())
@@ -132,7 +118,6 @@ class MembershipControllerTest {
 	@Test
 	@DisplayName("필수 동의가 누락된 멤버십 결제 준비 요청은 400을 응답한다.")
 	void 필수동의_누락_멤버십_결제준비_실패() throws Exception {
-		UUID userId = UUID.fromString("11111111-1111-1111-1111-111111111111");
 		MembershipRequest.CreatePayment request = new MembershipRequest.CreatePayment(
 			MembershipPaymentMethod.TOSS_PAY,
 			false,
@@ -140,12 +125,53 @@ class MembershipControllerTest {
 			true
 		);
 
-		mockMvc.perform(post("/api/musical/artists/{artistId}/membership/payment", 101L)
-				.header("X-User-Id", userId)
+		mockMvc.perform(post("/api/musical/artists/{artistId}/membership/payment", ARTIST_ID)
+				.header("X-User-Id", USER_ID)
 				.contentType("application/json")
 				.content(objectMapper.writeValueAsString(request)))
 			.andExpect(status().isBadRequest())
 			.andExpect(jsonPath("$.errorType").value("CLIENT_ERROR"))
 			.andExpect(jsonPath("$.code").value("C02"));
+	}
+
+	@Test
+	@DisplayName("내 멤버십 조회에 성공하면 요약과 목록을 함께 응답한다.")
+	void 내_멤버십_조회_성공() throws Exception {
+		MembershipResponse.MyMembership response = MembershipResponse.MyMembership.of(
+			MembershipResponse.MyMembershipSummary.of(2, MONTHLY_AMOUNT),
+			java.util.List.of(
+				MembershipResponse.MyMembershipItem.of(
+					3L,
+					1L,
+					"이재환",
+					"https://cdn/leejaehwan.png",
+					"ACTIVE",
+					"멤버십 가입중",
+					"2026.04.03.",
+					"2026.05.03.",
+					23L,
+					5_000L,
+					true
+				)
+			)
+		);
+
+		given(membershipService.getMyMembership(USER_ID)).willReturn(response);
+
+		mockMvc.perform(get("/api/musical/my/membership")
+				.header("X-User-Id", USER_ID))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.code").value("ok"))
+			.andExpect(jsonPath("$.data.summary.activeMembershipCount").value(2))
+			.andExpect(jsonPath("$.data.summary.monthlyPaymentAmount").value(5000))
+			.andExpect(jsonPath("$.data.memberships[0].membershipId").value(3L))
+			.andExpect(jsonPath("$.data.memberships[0].artistId").value(1L))
+			.andExpect(jsonPath("$.data.memberships[0].artistName").value("이재환"))
+			.andExpect(jsonPath("$.data.memberships[0].status").value("ACTIVE"))
+			.andExpect(jsonPath("$.data.memberships[0].statusLabel").value("멤버십 가입중"));
+	}
+
+	private MembershipRequest.CreatePayment createPaymentRequest(MembershipPaymentMethod paymentMethod) {
+		return new MembershipRequest.CreatePayment(paymentMethod, true, true, true);
 	}
 }

--- a/musical/src/test/java/com/truve/platform/musical/show/domain/entity/MembershipCancelTest.java
+++ b/musical/src/test/java/com/truve/platform/musical/show/domain/entity/MembershipCancelTest.java
@@ -1,0 +1,34 @@
+package com.truve.platform.musical.show.domain.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.truve.platform.musical.show.domain.constant.ArtistMembershipStatus;
+import com.truve.platform.musical.show.domain.constant.MembershipPaymentMethod;
+
+class MembershipCancelTest {
+
+	@Test
+	@DisplayName("해지 예정 멤버십은 다음 결제일이 지나면 CANCELED로 전이된다.")
+	void 해지예정_멤버십_만료() {
+		ArtistMembership membership = ArtistMembership.builder()
+			.userId(UUID.fromString("11111111-1111-1111-1111-111111111111"))
+			.artist(null)
+			.status(ArtistMembershipStatus.CANCEL_SCHEDULED)
+			.orderId("M20260408123456")
+			.monthlyAmount(5_000L)
+			.paymentMethod(MembershipPaymentMethod.TOSS_PAY)
+			.joinedAt(LocalDateTime.of(2026, 4, 1, 10, 0))
+			.nextBillingAt(LocalDateTime.of(2026, 4, 8, 10, 0))
+			.build();
+
+		membership.expireCancellation(LocalDateTime.of(2026, 4, 8, 10, 0));
+
+		assertThat(membership.getStatus()).isEqualTo(ArtistMembershipStatus.CANCELED);
+	}
+}

--- a/musical/src/test/java/com/truve/platform/musical/show/scheduler/MembershipStatusSchedulerTest.java
+++ b/musical/src/test/java/com/truve/platform/musical/show/scheduler/MembershipStatusSchedulerTest.java
@@ -1,0 +1,60 @@
+package com.truve.platform.musical.show.scheduler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.truve.platform.musical.show.domain.constant.ArtistMembershipStatus;
+import com.truve.platform.musical.show.domain.constant.MembershipPaymentMethod;
+import com.truve.platform.musical.show.domain.entity.ArtistMembership;
+import com.truve.platform.musical.show.repository.ArtistMembershipRepository;
+
+@ExtendWith(MockitoExtension.class)
+class MembershipStatusSchedulerTest {
+
+	@Mock
+	private ArtistMembershipRepository artistMembershipRepository;
+
+	@InjectMocks
+	private MembershipStatusScheduler membershipStatusScheduler;
+
+	@Test
+	@DisplayName("스케줄러는 만료된 해지 예정 멤버십을 조회한다.")
+	void 만료된_해지예정_멤버십_조회() {
+		ArtistMembership membership = ArtistMembership.builder()
+			.userId(UUID.fromString("11111111-1111-1111-1111-111111111111"))
+			.artist(null)
+			.status(ArtistMembershipStatus.CANCEL_SCHEDULED)
+			.orderId("M20260408123456")
+			.monthlyAmount(5_000L)
+			.paymentMethod(MembershipPaymentMethod.TOSS_PAY)
+			.joinedAt(LocalDateTime.of(2026, 4, 1, 10, 0))
+			.nextBillingAt(LocalDateTime.of(2026, 4, 8, 10, 0))
+			.build();
+
+		when(artistMembershipRepository.findExpiredMemberships(
+				org.mockito.ArgumentMatchers.eq(ArtistMembershipStatus.CANCEL_SCHEDULED),
+				org.mockito.ArgumentMatchers.any(LocalDateTime.class)
+			))
+			.thenReturn(List.of(membership));
+
+		membershipStatusScheduler.expireScheduledMemberships();
+
+		verify(artistMembershipRepository).findExpiredMemberships(
+			org.mockito.ArgumentMatchers.eq(ArtistMembershipStatus.CANCEL_SCHEDULED),
+			org.mockito.ArgumentMatchers.any(LocalDateTime.class)
+		);
+		assertThat(membership.getStatus()).isEqualTo(ArtistMembershipStatus.CANCELED);
+	}
+}

--- a/musical/src/test/java/com/truve/platform/musical/show/service/MembershipServiceTest.java
+++ b/musical/src/test/java/com/truve/platform/musical/show/service/MembershipServiceTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.time.LocalDateTime;
 import java.util.UUID;
 
 import org.junit.jupiter.api.DisplayName;
@@ -33,6 +34,10 @@ import com.truve.platform.musical.show.repository.ArtistRepository;
 
 @ExtendWith(MockitoExtension.class)
 class MembershipServiceTest {
+	private static final UUID USER_ID = UUID.fromString("11111111-1111-1111-1111-111111111111");
+	private static final Long ARTIST_ID = 101L;
+	private static final String ARTIST_NAME = "고은성";
+	private static final long MONTHLY_AMOUNT = 5_000L;
 
 	@Mock
 	private ArtistRepository artistRepository;
@@ -40,6 +45,8 @@ class MembershipServiceTest {
 	private ArtistMembershipRepository artistMembershipRepository;
 	@Mock
 	private PaymentPublisher paymentPublisher;
+	@Mock
+	private com.truve.platform.musical.s3.S3Service s3Service;
 
 	@InjectMocks
 	private MembershipService membershipService;
@@ -47,43 +54,36 @@ class MembershipServiceTest {
 	@Test
 	@DisplayName("멤버십 결제 준비에 성공하면 unified membership을 저장하고 결제 생성 이벤트를 발행한다.")
 	void 멤버십_결제준비_성공() {
-		UUID userId = UUID.fromString("11111111-1111-1111-1111-111111111111");
 		Artist artist = org.mockito.Mockito.mock(Artist.class);
-		ArtistRepository.ArtistDetailProjection artistDetail = org.mockito.Mockito.mock(ArtistRepository.ArtistDetailProjection.class);
-		MembershipRequest.CreatePayment request = new MembershipRequest.CreatePayment(
-			MembershipPaymentMethod.TOSS_PAY,
-			true,
-			true,
-			true
-		);
+		ArtistRepository.ArtistDetailProjection artistDetail = mockArtistDetailProjection();
+		MembershipRequest.CreatePayment request = createPaymentRequest(MembershipPaymentMethod.TOSS_PAY);
 
-		when(artistRepository.findDetailById(101L)).thenReturn(java.util.Optional.of(artistDetail));
-		when(artistDetail.getArtistName()).thenReturn("고은성");
-		when(artistMembershipRepository.findByUserIdAndArtistId(userId, 101L)).thenReturn(java.util.Optional.empty());
-		when(artistRepository.getReferenceById(101L)).thenReturn(artist);
+		when(artistRepository.findDetailById(ARTIST_ID)).thenReturn(java.util.Optional.of(artistDetail));
+		when(artistMembershipRepository.findByUserIdAndArtistId(USER_ID, ARTIST_ID)).thenReturn(java.util.Optional.empty());
+		when(artistRepository.getReferenceById(ARTIST_ID)).thenReturn(artist);
 		when(artistMembershipRepository.save(any(ArtistMembership.class)))
 			.thenAnswer(invocation -> invocation.getArgument(0));
 
-		MembershipResponse.CreatePayment response = membershipService.createPayment(101L, userId, request);
+		MembershipResponse.CreatePayment response = membershipService.createPayment(ARTIST_ID, USER_ID, request);
 
 		ArgumentCaptor<ArtistMembership> membershipCaptor = ArgumentCaptor.forClass(ArtistMembership.class);
 		verify(artistMembershipRepository).save(membershipCaptor.capture());
 
 		ArtistMembership savedMembership = membershipCaptor.getValue();
 		assertThat(savedMembership.getOrderId()).startsWith("M");
-		assertThat(savedMembership.getMonthlyAmount()).isEqualTo(5_000L);
+		assertThat(savedMembership.getMonthlyAmount()).isEqualTo(MONTHLY_AMOUNT);
 		assertThat(savedMembership.getPaymentMethod()).isEqualTo(MembershipPaymentMethod.TOSS_PAY);
 		assertThat(savedMembership.getStatus()).isEqualTo(ArtistMembershipStatus.PAYMENT_PENDING);
 
 		ArgumentCaptor<PaymentEventCommand.Create> paymentCaptor = ArgumentCaptor.forClass(PaymentEventCommand.Create.class);
 		verify(paymentPublisher).publish(paymentCaptor.capture());
 		assertThat(paymentCaptor.getValue().getOrderId()).isEqualTo(savedMembership.getOrderId());
-		assertThat(paymentCaptor.getValue().getAmount()).isEqualTo(5_000L);
+		assertThat(paymentCaptor.getValue().getAmount()).isEqualTo(MONTHLY_AMOUNT);
 
-		assertThat(response.getArtistId()).isEqualTo(101L);
-		assertThat(response.getArtistName()).isEqualTo("고은성");
+		assertThat(response.getArtistId()).isEqualTo(ARTIST_ID);
+		assertThat(response.getArtistName()).isEqualTo(ARTIST_NAME);
 		assertThat(response.getPlanName()).isEqualTo("월간 멤버십");
-		assertThat(response.getAmount()).isEqualTo(5_000L);
+		assertThat(response.getAmount()).isEqualTo(MONTHLY_AMOUNT);
 		assertThat(response.getPaymentMethod()).isEqualTo("토스 결제");
 		assertThat(response.getOrderId()).isEqualTo(savedMembership.getOrderId());
 	}
@@ -91,18 +91,12 @@ class MembershipServiceTest {
 	@Test
 	@DisplayName("존재하지 않는 아티스트의 멤버십 결제 준비 요청은 예외를 발생시킨다.")
 	void 존재하지않는_아티스트_멤버십_결제준비_실패() {
-		UUID userId = UUID.fromString("11111111-1111-1111-1111-111111111111");
-		MembershipRequest.CreatePayment request = new MembershipRequest.CreatePayment(
-			MembershipPaymentMethod.TOSS_PAY,
-			true,
-			true,
-			true
-		);
+		MembershipRequest.CreatePayment request = createPaymentRequest(MembershipPaymentMethod.TOSS_PAY);
 		when(artistRepository.findDetailById(999L)).thenReturn(java.util.Optional.empty());
 
 		CustomException exception = assertThrows(
 			CustomException.class,
-			() -> membershipService.createPayment(999L, userId, request)
+			() -> membershipService.createPayment(999L, USER_ID, request)
 		);
 
 		assertEquals(ErrorCode.NOT_FOUND_ARTIST, exception.getErrorCode());
@@ -113,23 +107,17 @@ class MembershipServiceTest {
 	@Test
 	@DisplayName("이미 가입한 아티스트의 멤버십 결제 준비 요청은 예외를 발생시킨다.")
 	void 이미가입한_아티스트_멤버십_결제준비_실패() {
-		UUID userId = UUID.fromString("11111111-1111-1111-1111-111111111111");
 		ArtistRepository.ArtistDetailProjection artistDetail = org.mockito.Mockito.mock(ArtistRepository.ArtistDetailProjection.class);
 		Artist artist = org.mockito.Mockito.mock(Artist.class);
-		MembershipRequest.CreatePayment request = new MembershipRequest.CreatePayment(
-			MembershipPaymentMethod.BANK_TRANSFER,
-			true,
-			true,
-			true
-		);
-		when(artistRepository.findDetailById(101L)).thenReturn(java.util.Optional.of(artistDetail));
-		when(artistMembershipRepository.findByUserIdAndArtistId(userId, 101L)).thenReturn(
+		MembershipRequest.CreatePayment request = createPaymentRequest(MembershipPaymentMethod.BANK_TRANSFER);
+		when(artistRepository.findDetailById(ARTIST_ID)).thenReturn(java.util.Optional.of(artistDetail));
+		when(artistMembershipRepository.findByUserIdAndArtistId(USER_ID, ARTIST_ID)).thenReturn(
 			java.util.Optional.of(
 				ArtistMembership.builder()
-					.userId(userId)
+					.userId(USER_ID)
 					.artist(artist)
 					.status(ArtistMembershipStatus.ACTIVE)
-					.monthlyAmount(5_000L)
+					.monthlyAmount(MONTHLY_AMOUNT)
 					.paymentMethod(MembershipPaymentMethod.BANK_TRANSFER)
 					.build()
 			)
@@ -137,7 +125,7 @@ class MembershipServiceTest {
 
 		CustomException exception = assertThrows(
 			CustomException.class,
-			() -> membershipService.createPayment(101L, userId, request)
+			() -> membershipService.createPayment(ARTIST_ID, USER_ID, request)
 		);
 
 		assertEquals(ErrorCode.ALREADY_JOINED_ARTIST_MEMBERSHIP, exception.getErrorCode());
@@ -148,31 +136,24 @@ class MembershipServiceTest {
 	@Test
 	@DisplayName("이미 PAYMENT_PENDING 상태의 멤버십이 있으면 새 주문번호와 결제수단으로 갱신하고 이벤트를 다시 발행한다.")
 	void 기존_PENDING_멤버십_주문_갱신() {
-		UUID userId = UUID.fromString("11111111-1111-1111-1111-111111111111");
-		ArtistRepository.ArtistDetailProjection artistDetail = org.mockito.Mockito.mock(ArtistRepository.ArtistDetailProjection.class);
+		ArtistRepository.ArtistDetailProjection artistDetail = mockArtistDetailProjection();
 		Artist artist = org.mockito.Mockito.mock(Artist.class);
 		ArtistMembership existingMembership = ArtistMembership.preparePayment(
-			userId,
+			USER_ID,
 			artist,
 			"M20260331999999",
-			5_000L,
+			MONTHLY_AMOUNT,
 			MembershipPaymentMethod.TOSS_PAY
 		);
-		MembershipRequest.CreatePayment request = new MembershipRequest.CreatePayment(
-			MembershipPaymentMethod.BANK_TRANSFER,
-			true,
-			true,
-			true
-		);
+		MembershipRequest.CreatePayment request = createPaymentRequest(MembershipPaymentMethod.BANK_TRANSFER);
 
-		when(artistRepository.findDetailById(101L)).thenReturn(java.util.Optional.of(artistDetail));
-		when(artistDetail.getArtistName()).thenReturn("고은성");
-		when(artistMembershipRepository.findByUserIdAndArtistId(userId, 101L)).thenReturn(java.util.Optional.of(existingMembership));
-		when(artistRepository.getReferenceById(101L)).thenReturn(artist);
+		when(artistRepository.findDetailById(ARTIST_ID)).thenReturn(java.util.Optional.of(artistDetail));
+		when(artistMembershipRepository.findByUserIdAndArtistId(USER_ID, ARTIST_ID)).thenReturn(java.util.Optional.of(existingMembership));
+		when(artistRepository.getReferenceById(ARTIST_ID)).thenReturn(artist);
 		when(artistMembershipRepository.save(any(ArtistMembership.class)))
 			.thenAnswer(invocation -> invocation.getArgument(0));
 
-		MembershipResponse.CreatePayment response = membershipService.createPayment(101L, userId, request);
+		MembershipResponse.CreatePayment response = membershipService.createPayment(ARTIST_ID, USER_ID, request);
 
 		verify(artistMembershipRepository).save(existingMembership);
 		ArgumentCaptor<PaymentEventCommand.Create> paymentCaptor = ArgumentCaptor.forClass(PaymentEventCommand.Create.class);
@@ -182,6 +163,89 @@ class MembershipServiceTest {
 		assertThat(existingMembership.getPaymentMethod()).isEqualTo(MembershipPaymentMethod.BANK_TRANSFER);
 		assertThat(existingMembership.getStatus()).isEqualTo(ArtistMembershipStatus.PAYMENT_PENDING);
 		assertThat(paymentCaptor.getValue().getOrderId()).isEqualTo(response.getOrderId());
-		assertThat(paymentCaptor.getValue().getAmount()).isEqualTo(5_000L);
+		assertThat(paymentCaptor.getValue().getAmount()).isEqualTo(MONTHLY_AMOUNT);
+	}
+
+	@Test
+	@DisplayName("내 멤버십이 없으면 빈 목록과 0 summary를 반환한다.")
+	void 내_멤버십_빈_응답() {
+		when(artistMembershipRepository.findCurrentMemberships(
+			org.mockito.ArgumentMatchers.eq(USER_ID),
+			org.mockito.ArgumentMatchers.anyCollection(),
+			org.mockito.ArgumentMatchers.any(LocalDateTime.class)
+		)).thenReturn(java.util.List.of());
+
+		MembershipResponse.MyMembership response = membershipService.getMyMembership(USER_ID);
+
+		assertThat(response.getSummary().getActiveMembershipCount()).isEqualTo(0);
+		assertThat(response.getSummary().getMonthlyPaymentAmount()).isEqualTo(0);
+		assertThat(response.getMemberships()).isEmpty();
+	}
+
+	@Test
+	@DisplayName("내 멤버십 조회는 ACTIVE와 CANCEL_SCHEDULED를 함께 보여주고 월 결제 총액은 ACTIVE만 합산한다.")
+	void 내_멤버십_조회_성공() {
+		Artist activeArtist = org.mockito.Mockito.mock(Artist.class);
+		Artist cancelScheduledArtist = org.mockito.Mockito.mock(Artist.class);
+
+		ArtistMembership activeMembership = ArtistMembership.builder()
+			.userId(USER_ID)
+			.artist(activeArtist)
+			.status(ArtistMembershipStatus.ACTIVE)
+			.orderId("M20260408111111")
+			.monthlyAmount(MONTHLY_AMOUNT)
+			.paymentMethod(MembershipPaymentMethod.TOSS_PAY)
+			.joinedAt(LocalDateTime.now().minusDays(5))
+			.nextBillingAt(LocalDateTime.now().plusDays(20))
+			.build();
+		ArtistMembership cancelScheduledMembership = ArtistMembership.builder()
+			.userId(USER_ID)
+			.artist(cancelScheduledArtist)
+			.status(ArtistMembershipStatus.CANCEL_SCHEDULED)
+			.orderId("M20260408222222")
+			.monthlyAmount(7_000L)
+			.paymentMethod(MembershipPaymentMethod.BANK_TRANSFER)
+			.joinedAt(LocalDateTime.now().minusDays(10))
+			.nextBillingAt(LocalDateTime.now().plusDays(3))
+			.build();
+
+		when(activeArtist.getId()).thenReturn(1L);
+		when(activeArtist.getName()).thenReturn("이재환");
+		when(activeArtist.getProfileImg()).thenReturn("leejaehwan.png");
+		when(cancelScheduledArtist.getId()).thenReturn(2L);
+		when(cancelScheduledArtist.getName()).thenReturn("고은성");
+		when(cancelScheduledArtist.getProfileImg()).thenReturn("goeunsung.png");
+		when(s3Service.getImageUrl("leejaehwan.png")).thenReturn("https://cdn/leejaehwan.png");
+		when(s3Service.getImageUrl("goeunsung.png")).thenReturn("https://cdn/goeunsung.png");
+		when(artistMembershipRepository.findCurrentMemberships(
+			org.mockito.ArgumentMatchers.eq(USER_ID),
+			org.mockito.ArgumentMatchers.anyCollection(),
+			org.mockito.ArgumentMatchers.any(LocalDateTime.class)
+		)).thenReturn(java.util.List.of(activeMembership, cancelScheduledMembership));
+
+		MembershipResponse.MyMembership response = membershipService.getMyMembership(USER_ID);
+
+		assertThat(response.getSummary().getActiveMembershipCount()).isEqualTo(2);
+		assertThat(response.getSummary().getMonthlyPaymentAmount()).isEqualTo(5_000L);
+		assertThat(response.getMemberships()).hasSize(2);
+		assertThat(response.getMemberships().get(0).getMembershipId()).isEqualTo(activeMembership.getId());
+		assertThat(response.getMemberships().get(0).getArtistId()).isEqualTo(1L);
+		assertThat(response.getMemberships().get(0).getProfileImageUrl()).isEqualTo("https://cdn/leejaehwan.png");
+		assertThat(response.getMemberships().get(0).getStatus()).isEqualTo("ACTIVE");
+		assertThat(response.getMemberships().get(0).getStatusLabel()).isEqualTo("멤버십 가입중");
+		assertThat(response.getMemberships().get(0).isCancelable()).isTrue();
+		assertThat(response.getMemberships().get(1).getStatus()).isEqualTo("CANCEL_SCHEDULED");
+		assertThat(response.getMemberships().get(1).getStatusLabel()).isEqualTo("해지 예정");
+		assertThat(response.getMemberships().get(1).isCancelable()).isFalse();
+	}
+
+	private ArtistRepository.ArtistDetailProjection mockArtistDetailProjection() {
+		ArtistRepository.ArtistDetailProjection artistDetail = org.mockito.Mockito.mock(ArtistRepository.ArtistDetailProjection.class);
+		when(artistDetail.getArtistName()).thenReturn(ARTIST_NAME);
+		return artistDetail;
+	}
+
+	private MembershipRequest.CreatePayment createPaymentRequest(MembershipPaymentMethod paymentMethod) {
+		return new MembershipRequest.CreatePayment(paymentMethod, true, true, true);
 	}
 }


### PR DESCRIPTION
## 변경 사항

---
구현 내용
- GET /api/musical/my/membership 추가
- MembershipService.getMyMembership(userId) 구현
  - 현재 유효한 멤버십 목록 조회
  - summary 계산
  - 상태 라벨 / 잔여일 / 날짜 문자열 포맷팅
  - membershipId 포함 응답 조립
- MembershipResponse에 내 멤버십 조회용 DTO 추가
  - MyMembership
  - MyMembershipSummary
  - MyMembershipItem
- ArtistMembershipRepository에 조회/만료용 메서드 추가
  - findCurrentMemberships(...)
  - findExpiredMemberships(...)
- MembershipStatusScheduler 추가
  - 만료된 CANCEL_SCHEDULED 멤버십을 CANCELED로 전이
- MusicalApplication에 scheduling 활성화 추가

조회 정책
- 목록 포함
  - ACTIVE
  - CANCEL_SCHEDULED 중 nextBillingAt > now
- 목록 제외
  - PAYMENT_PENDING
  - CANCELED
  - 만료된 CANCEL_SCHEDULED
- activeMembershipCount
  - 현재 목록에 노출되는 멤버십 수
- monthlyPaymentAmount
  - ACTIVE 상태 멤버십만 합산
- 상태 라벨
  - ACTIVE → 멤버십 가입중
  - CANCEL_SCHEDULED → 해지 예정

- [x] 전체 테스트 코드 성공 여부

## 관련 이슈

---
- Notion Ticket: # 90

## 참고사항 (선택)

---