### PR TITLE
feat(booking): 예약 create 시 좌석 HOLD 상태로 변경

### DIFF
--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/domain/entity/Ticket.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/domain/entity/Ticket.java
@@ -44,6 +44,9 @@ public class Ticket extends BaseEntity {
 	private String seatDetail;
 
 	@Column(nullable = false)
+	private Long scheduledSeatId;
+
+	@Column(nullable = false)
 	@Enumerated(EnumType.STRING)
 	private TicketStatus status;
 
@@ -54,12 +57,20 @@ public class Ticket extends BaseEntity {
 	private LocalDateTime usedAt;
 
 	@Builder
-	private Ticket(Reservation reservation, String number, String grade, Long priceSnapshot, String seatDetail) {
+	private Ticket(
+		Reservation reservation,
+		String number,
+		String grade,
+		Long priceSnapshot,
+		String seatDetail,
+		Long scheduledSeatId
+	) {
 		this.reservation = reservation;
 		this.number = number;
 		this.grade = grade;
 		this.priceSnapshot = priceSnapshot;
 		this.seatDetail = seatDetail;
+		this.scheduledSeatId = scheduledSeatId;
 		this.status = TicketStatus.ISSUED;
 	}
 
@@ -68,13 +79,16 @@ public class Ticket extends BaseEntity {
 		String number,
 		String grade,
 		Long priceSnapshot,
-		String seatDetail) {
+		String seatDetail,
+		Long scheduledSeatId
+	) {
 		return Ticket.builder()
 			.reservation(reservation)
 			.number(number)
 			.grade(grade)
 			.priceSnapshot(priceSnapshot)
 			.seatDetail(seatDetail)
+			.scheduledSeatId(scheduledSeatId)
 			.build();
 	}
 

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/external/client/ticketing/TicketingResponse.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/external/client/ticketing/TicketingResponse.java
@@ -30,6 +30,8 @@ public class TicketingResponse {
 		Long getSeatNumber();
 
 		Long getPrice();
+
+		Long getScheduledSeatId();
 	}
 
 	@Getter
@@ -55,21 +57,23 @@ public class TicketingResponse {
 	}
 
 	@Getter
-	@AllArgsConstructor
-	public static class Seat {
-		private final String sectionName;
-		private final Long floor;
-		private final String gradeName;
-		private final String seatRow;
-		private final Long seatNumber;
+		@AllArgsConstructor
+		public static class Seat {
+			private final Long scheduledSeatId;
+			private final String sectionName;
+			private final Long floor;
+			private final String gradeName;
+			private final String seatRow;
+			private final Long seatNumber;
 		private final Long price;
 
-		public static Seat from(FlatSeatInfo flat) {
-			return new Seat(
-				flat.getSectionName(),
-				flat.getFloor(),
-				flat.getGradeName(),
-				flat.getSeatRow(),
+			public static Seat from(FlatSeatInfo flat) {
+				return new Seat(
+					flat.getScheduledSeatId(),
+					flat.getSectionName(),
+					flat.getFloor(),
+					flat.getGradeName(),
+					flat.getSeatRow(),
 				flat.getSeatNumber(),
 				flat.getPrice()
 			);

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/external/kafka/TicketingEventCommand.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/external/kafka/TicketingEventCommand.java
@@ -66,4 +66,27 @@ public class TicketingEventCommand {
 			return "HOLD_RELEASED";
 		}
 	}
+
+	@Getter
+	@Builder
+	@AllArgsConstructor
+	@NoArgsConstructor
+	public static class SoldConfirmed implements TicketingEvent {
+		private String reservationNumber;
+		private UUID userId;
+		private List<Long> scheduledSeatIds;
+
+		public static SoldConfirmed of(Reservation reservation, List<Long> scheduledSeatIds) {
+			return SoldConfirmed.builder()
+				.reservationNumber(reservation.getNumber())
+				.userId(reservation.getUserId())
+				.scheduledSeatIds(List.copyOf(scheduledSeatIds))
+				.build();
+		}
+
+		@Override
+		public String getEventType() {
+			return "SOLD_CONFIRMED";
+		}
+	}
 }

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/external/kafka/TicketingEventCommand.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/external/kafka/TicketingEventCommand.java
@@ -1,0 +1,46 @@
+package org.truve.platform.ticketing.service.booking.external.kafka;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.truve.platform.ticketing.service.booking.domain.entity.Reservation;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class TicketingEventCommand {
+
+	@JsonIgnoreProperties(value = {"eventType"})
+	public interface TicketingEvent {
+		String getReservationNumber();
+
+		String getEventType();
+	}
+
+	@Getter
+	@Builder
+	@AllArgsConstructor
+	@NoArgsConstructor
+	public static class HoldRequested implements TicketingEvent {
+		private String reservationNumber;
+		private UUID userId;
+		private List<Long> scheduledSeatIds;
+
+		public static HoldRequested of(Reservation reservation, List<Long> scheduledSeatIds) {
+			return HoldRequested.builder()
+				.reservationNumber(reservation.getNumber())
+				.userId(reservation.getUserId())
+				.scheduledSeatIds(List.copyOf(scheduledSeatIds))
+				.build();
+		}
+
+		@Override
+		public String getEventType() {
+			return "HOLD_REQUESTED";
+		}
+	}
+}

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/external/kafka/TicketingEventCommand.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/external/kafka/TicketingEventCommand.java
@@ -43,4 +43,27 @@ public class TicketingEventCommand {
 			return "HOLD_REQUESTED";
 		}
 	}
+
+	@Getter
+	@Builder
+	@AllArgsConstructor
+	@NoArgsConstructor
+	public static class HoldReleased implements TicketingEvent {
+		private String reservationNumber;
+		private UUID userId;
+		private List<Long> scheduledSeatIds;
+
+		public static HoldReleased of(Reservation reservation, List<Long> scheduledSeatIds) {
+			return HoldReleased.builder()
+				.reservationNumber(reservation.getNumber())
+				.userId(reservation.getUserId())
+				.scheduledSeatIds(List.copyOf(scheduledSeatIds))
+				.build();
+		}
+
+		@Override
+		public String getEventType() {
+			return "HOLD_RELEASED";
+		}
+	}
 }

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/external/kafka/TicketingPublisher.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/external/kafka/TicketingPublisher.java
@@ -1,0 +1,19 @@
+package org.truve.platform.ticketing.service.booking.external.kafka;
+
+import org.springframework.stereotype.Component;
+
+import com.truve.platform.common.event.EventPublisher;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class TicketingPublisher {
+	private static final String TOPIC = "booking.ticketing";
+
+	private final EventPublisher eventPublisher;
+
+	public void publish(TicketingEventCommand.TicketingEvent command) {
+		eventPublisher.publish(TOPIC, command.getReservationNumber(), command.getEventType(), command);
+	}
+}

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/service/BookingService.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/service/BookingService.java
@@ -150,6 +150,11 @@ public class BookingService {
 			event.getMethod(),
 			VirtualAccount.from(event.getVirtualAccount())
 		);
+
+		List<Long> scheduledSeatIds = reservation.getTickets().stream()
+			.map(Ticket::getScheduledSeatId)
+			.toList();
+		ticketingPublisher.publish(TicketingEventCommand.SoldConfirmed.of(reservation, scheduledSeatIds));
 	}
 
 	@Transactional

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/service/BookingService.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/service/BookingService.java
@@ -68,14 +68,15 @@ public class BookingService {
 
 	private List<Ticket> createTickets(TicketingResponse.SeatInfo seatInfo, Reservation reservation) {
 		return seatInfo.getSeats().stream().map(
-			seat -> Ticket.create(
-				reservation,
-				NumberGenerator.generateTicketNumber(),
-				seat.getGradeName(),
-				seat.getPrice(),
-				createSeatDetail(seat)
-			)
-		).toList();
+				seat -> Ticket.create(
+					reservation,
+					NumberGenerator.generateTicketNumber(),
+					seat.getGradeName(),
+					seat.getPrice(),
+					createSeatDetail(seat),
+					seat.getScheduledSeatId()
+				)
+			).toList();
 	}
 
 	private String createGradeSummary(TicketingResponse.SeatInfo seatInfo) {

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/service/BookingService.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/service/BookingService.java
@@ -175,6 +175,10 @@ public class BookingService {
 		Reservation reservation = reservationRepository.findByNumber(reservationNumber);
 
 		List<Long> ticketIds = request.getTicketIds();
+		List<Long> scheduledSeatIds = reservation.getTickets().stream()
+			.filter(ticket -> ticketIds.contains(ticket.getId()))
+			.map(Ticket::getScheduledSeatId)
+			.toList();
 		LocalDateTime canceledAt = LocalDateTime.now();
 
 		reservation.validateTicketId(ticketIds);
@@ -188,6 +192,7 @@ public class BookingService {
 		);
 
 		reservation.cancel(ticketIds, canceledAt);
+		ticketingPublisher.publish(TicketingEventCommand.HoldReleased.of(reservation, scheduledSeatIds));
 
 		return new BookingResponse.CanceledTickets(ticketIds);
 	}

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/service/BookingService.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/service/BookingService.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.truve.platform.ticketing.service.booking.domain.entity.Reservation;
@@ -23,6 +24,8 @@ import org.truve.platform.ticketing.service.booking.external.client.ticketing.Ti
 import org.truve.platform.ticketing.service.booking.external.kafka.BookingEventCommand;
 import org.truve.platform.ticketing.service.booking.external.kafka.PaymentEventCommand;
 import org.truve.platform.ticketing.service.booking.external.kafka.PaymentPublisher;
+import org.truve.platform.ticketing.service.booking.external.kafka.TicketingEventCommand;
+import org.truve.platform.ticketing.service.booking.external.kafka.TicketingPublisher;
 import org.truve.platform.ticketing.service.booking.repository.ReservationRepository;
 import org.truve.platform.ticketing.service.booking.util.NumberGenerator;
 
@@ -39,6 +42,7 @@ public class BookingService {
 	private final TicketingClient ticketingClient;
 	private final PaymentPublisher paymentPublisher;
 	private final PaymentClient paymentClient;
+	private final TicketingPublisher ticketingPublisher;
 
 	@Transactional
 	public BookingResponse.Create create(UUID userId, BookingRequest.Create request) {
@@ -49,6 +53,7 @@ public class BookingService {
 		reservation.addTickets(tickets);
 
 		reservationRepository.save(reservation);
+		ticketingPublisher.publish(TicketingEventCommand.HoldRequested.of(reservation, request.getSeatIds()));
 		return new BookingResponse.Create(reservation.getNumber());
 	}
 

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/ticketing/domain/entity/ScheduledSeat.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/ticketing/domain/entity/ScheduledSeat.java
@@ -59,7 +59,10 @@ public class ScheduledSeat extends BaseEntity {
 		this.status = SeatStatus.HOLD;
 	}
 
-	public void cancelSeat() {
+	public void releaseSeat() {
+		if (this.status == SeatStatus.SOLD) {
+			return;
+		}
 		this.status = SeatStatus.AVAILABLE;
 	}
 

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/ticketing/domain/entity/ScheduledSeat.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/ticketing/domain/entity/ScheduledSeat.java
@@ -52,6 +52,13 @@ public class ScheduledSeat extends BaseEntity {
 		return status == SeatStatus.AVAILABLE;
 	}
 
+	public void holdSeat() {
+		if (this.status == SeatStatus.SOLD || this.status == SeatStatus.HOLD) {
+			return;
+		}
+		this.status = SeatStatus.HOLD;
+	}
+
 	public void cancelSeat() {
 		this.status = SeatStatus.AVAILABLE;
 	}

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/ticketing/domain/entity/ScheduledSeat.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/ticketing/domain/entity/ScheduledSeat.java
@@ -13,7 +13,6 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -37,18 +36,17 @@ public class ScheduledSeat extends BaseEntity {
 	@Enumerated(EnumType.STRING)
 	private SeatStatus status;
 
-
 	@Builder
 	public ScheduledSeat(
 		Seat seat,
 		Long showScheduleId
-		) {
+	) {
 		this.showScheduleId = showScheduleId;
 		this.seat = seat;
 		this.status = SeatStatus.AVAILABLE;
 	}
 
-	public boolean  isAvailable() {
+	public boolean isAvailable() {
 		return status == SeatStatus.AVAILABLE;
 	}
 
@@ -60,9 +58,6 @@ public class ScheduledSeat extends BaseEntity {
 	}
 
 	public void releaseSeat() {
-		if (this.status == SeatStatus.SOLD) {
-			return;
-		}
 		this.status = SeatStatus.AVAILABLE;
 	}
 

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/ticketing/external/kafka/BookingConsumer.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/ticketing/external/kafka/BookingConsumer.java
@@ -1,0 +1,31 @@
+package org.truve.platform.ticketing.service.ticketing.external.kafka;
+
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.messaging.handler.annotation.Header;
+import org.springframework.stereotype.Component;
+import org.truve.platform.ticketing.service.booking.external.kafka.TicketingEventCommand;
+import org.truve.platform.ticketing.service.ticketing.service.ScheduledSeatStatusService;
+
+import com.truve.platform.common.support.JsonConverter;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class BookingConsumer {
+	public static final String TOPIC = "booking.ticketing";
+	public static final String GROUP = "booking-ticketing-group";
+
+	private final JsonConverter jsonConverter;
+	private final ScheduledSeatStatusService scheduledSeatStatusService;
+
+	@KafkaListener(topics = TOPIC, groupId = GROUP)
+	public void consume(String payload, @Header("event-type") String type) {
+		switch (type) {
+			case "HOLD_REQUESTED" ->
+				scheduledSeatStatusService.holdSeats(jsonConverter.convert(payload, TicketingEventCommand.HoldRequested.class));
+		}
+	}
+}

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/ticketing/external/kafka/BookingConsumer.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/ticketing/external/kafka/BookingConsumer.java
@@ -28,6 +28,8 @@ public class BookingConsumer {
 				scheduledSeatStatusService.holdSeats(jsonConverter.convert(payload, TicketingEventCommand.HoldRequested.class));
 			case "HOLD_RELEASED" ->
 				scheduledSeatStatusService.releaseSeats(jsonConverter.convert(payload, TicketingEventCommand.HoldReleased.class));
+			case "SOLD_CONFIRMED" ->
+				scheduledSeatStatusService.purchaseSeats(jsonConverter.convert(payload, TicketingEventCommand.SoldConfirmed.class));
 		}
 	}
 }

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/ticketing/external/kafka/BookingConsumer.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/ticketing/external/kafka/BookingConsumer.java
@@ -26,6 +26,8 @@ public class BookingConsumer {
 		switch (type) {
 			case "HOLD_REQUESTED" ->
 				scheduledSeatStatusService.holdSeats(jsonConverter.convert(payload, TicketingEventCommand.HoldRequested.class));
+			case "HOLD_RELEASED" ->
+				scheduledSeatStatusService.releaseSeats(jsonConverter.convert(payload, TicketingEventCommand.HoldReleased.class));
 		}
 	}
 }

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/ticketing/repository/ScheduledSeatRepository.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/ticketing/repository/ScheduledSeatRepository.java
@@ -34,17 +34,18 @@ public interface ScheduledSeatRepository extends JpaRepository<ScheduledSeat, Lo
 	List<SeatSectionsDto> findSeatSectionByScheduledSeatId(@Param("showScheduleId") Long showScheduleId);
 
 	@Query("""
-		SELECT 
-			shs.showId AS showId,
-			shs.title AS showTitle,
-			shs.venueName AS venueName,
-			shs.startAt AS startAt,
-			shs.posterImg AS posterImg,
-			sc.name AS sectionName,
-			sc.floor AS floor,
-			sc.gradeName AS gradeName,
-			s.seatRow AS seatRow,
-			s.seatNumber AS seatNumber,
+			SELECT 
+				shs.showId AS showId,
+				shs.title AS showTitle,
+				shs.venueName AS venueName,
+				shs.startAt AS startAt,
+				shs.posterImg AS posterImg,
+				ss.id AS scheduledSeatId,
+				sc.name AS sectionName,
+				sc.floor AS floor,
+				sc.gradeName AS gradeName,
+				s.seatRow AS seatRow,
+				s.seatNumber AS seatNumber,
 			sc.price AS price
 		FROM ScheduledSeat ss 
 		JOIN ss.seat s 

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/ticketing/service/ScheduledSeatStatusService.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/ticketing/service/ScheduledSeatStatusService.java
@@ -1,0 +1,28 @@
+package org.truve.platform.ticketing.service.ticketing.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.truve.platform.ticketing.service.booking.external.kafka.TicketingEventCommand;
+import org.truve.platform.ticketing.service.ticketing.domain.entity.ScheduledSeat;
+import org.truve.platform.ticketing.service.ticketing.repository.ScheduledSeatRepository;
+
+import com.truve.platform.common.exception.ErrorCode;
+import com.truve.platform.common.support.Preconditions;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class ScheduledSeatStatusService {
+
+	private final ScheduledSeatRepository scheduledSeatRepository;
+
+	@Transactional
+	public void holdSeats(TicketingEventCommand.HoldRequested event) {
+		List<ScheduledSeat> scheduledSeats = scheduledSeatRepository.findAllById(event.getScheduledSeatIds());
+		Preconditions.validate(scheduledSeats.size() == event.getScheduledSeatIds().size(), ErrorCode.NOT_CORRECT_SEAT);
+		scheduledSeats.forEach(ScheduledSeat::holdSeat);
+	}
+}

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/ticketing/service/ScheduledSeatStatusService.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/ticketing/service/ScheduledSeatStatusService.java
@@ -32,4 +32,11 @@ public class ScheduledSeatStatusService {
 		Preconditions.validate(scheduledSeats.size() == event.getScheduledSeatIds().size(), ErrorCode.NOT_CORRECT_SEAT);
 		scheduledSeats.forEach(ScheduledSeat::releaseSeat);
 	}
+
+	@Transactional
+	public void purchaseSeats(TicketingEventCommand.SoldConfirmed event) {
+		List<ScheduledSeat> scheduledSeats = scheduledSeatRepository.findAllById(event.getScheduledSeatIds());
+		Preconditions.validate(scheduledSeats.size() == event.getScheduledSeatIds().size(), ErrorCode.NOT_CORRECT_SEAT);
+		scheduledSeats.forEach(ScheduledSeat::purchaseSeat);
+	}
 }

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/ticketing/service/ScheduledSeatStatusService.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/ticketing/service/ScheduledSeatStatusService.java
@@ -25,4 +25,11 @@ public class ScheduledSeatStatusService {
 		Preconditions.validate(scheduledSeats.size() == event.getScheduledSeatIds().size(), ErrorCode.NOT_CORRECT_SEAT);
 		scheduledSeats.forEach(ScheduledSeat::holdSeat);
 	}
+
+	@Transactional
+	public void releaseSeats(TicketingEventCommand.HoldReleased event) {
+		List<ScheduledSeat> scheduledSeats = scheduledSeatRepository.findAllById(event.getScheduledSeatIds());
+		Preconditions.validate(scheduledSeats.size() == event.getScheduledSeatIds().size(), ErrorCode.NOT_CORRECT_SEAT);
+		scheduledSeats.forEach(ScheduledSeat::releaseSeat);
+	}
 }

--- a/ticketing/src/main/resources/application.yml
+++ b/ticketing/src/main/resources/application.yml
@@ -18,7 +18,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: validate
+      ddl-auto: update
     show-sql: false
 
   data:

--- a/ticketing/src/test/java/org/truve/platform/ticketing/service/booking/domain/entity/ReservationTest.java
+++ b/ticketing/src/test/java/org/truve/platform/ticketing/service/booking/domain/entity/ReservationTest.java
@@ -196,7 +196,7 @@ public class ReservationTest {
 
 	private List<Ticket> createTickets(Reservation reservation, int count) {
 		return IntStream.range(0, count)
-			.mapToObj(i -> Ticket.create(reservation, "T-00" + i, "VIP", 10000L, "1층 A구역 1열 " + i + "번"))
+			.mapToObj(i -> Ticket.create(reservation, "T-00" + i, "VIP", 10000L, "1층 A구역 1열 " + i + "번", (long)i))
 			.toList();
 	}
 }

--- a/ticketing/src/test/java/org/truve/platform/ticketing/service/booking/domain/policy/CancellationPolicyTest.java
+++ b/ticketing/src/test/java/org/truve/platform/ticketing/service/booking/domain/policy/CancellationPolicyTest.java
@@ -121,7 +121,7 @@ public class CancellationPolicyTest {
 				.build()
 		);
 
-		Ticket ticket1 = Ticket.create(reservation, "T-001", "VIP", price, "1층 A구역 1열 1번");
+		Ticket ticket1 = Ticket.create(reservation, "T-001", "VIP", price, "1층 A구역 1열 1번", 1L);
 		ReflectionTestUtils.setField(ticket1, "id", 1L);
 
 		reservation.addTickets(List.of(ticket1));

--- a/ticketing/src/test/java/org/truve/platform/ticketing/service/booking/service/BookingServiceTest.java
+++ b/ticketing/src/test/java/org/truve/platform/ticketing/service/booking/service/BookingServiceTest.java
@@ -24,6 +24,8 @@ import org.truve.platform.ticketing.service.booking.dto.BookingRequest;
 import org.truve.platform.ticketing.service.booking.dto.BookingResponse;
 import org.truve.platform.ticketing.service.booking.external.client.ticketing.TicketingClient;
 import org.truve.platform.ticketing.service.booking.external.client.ticketing.TicketingResponse;
+import org.truve.platform.ticketing.service.booking.external.kafka.TicketingEventCommand;
+import org.truve.platform.ticketing.service.booking.external.kafka.TicketingPublisher;
 import org.truve.platform.ticketing.service.booking.repository.ReservationRepository;
 
 @ExtendWith(MockitoExtension.class)
@@ -33,6 +35,8 @@ class BookingServiceTest {
 	private ReservationRepository reservationRepository;
 	@Mock
 	private TicketingClient ticketingClient;
+	@Mock
+	private TicketingPublisher ticketingPublisher;
 
 	@InjectMocks
 	private BookingService bookingService;
@@ -63,14 +67,22 @@ class BookingServiceTest {
 
 		// then
 		ArgumentCaptor<Reservation> captor = ArgumentCaptor.forClass(Reservation.class);
+		ArgumentCaptor<TicketingEventCommand.TicketingEvent> eventCaptor =
+			ArgumentCaptor.forClass(TicketingEventCommand.TicketingEvent.class);
 		verify(reservationRepository).save(captor.capture());
+		verify(ticketingPublisher).publish(eventCaptor.capture());
 		Reservation savedReservation = captor.getValue();
+		TicketingEventCommand.HoldRequested holdRequested =
+			(TicketingEventCommand.HoldRequested) eventCaptor.getValue();
 
 		assertAll(
 			() -> assertThat(savedReservation.calculateTicketAmount()).isEqualTo(60000L),
 			() -> assertThat(savedReservation.getGradeSummary()).isEqualTo("VIP석 2인\nS석 1인"),
 			() -> assertThat(savedReservation.getTickets()).hasSize(3),
 			() -> assertThat(savedReservation.getServiceFee()).isEqualTo(6000L),
+			() -> assertThat(holdRequested.getReservationNumber()).isEqualTo(savedReservation.getNumber()),
+			() -> assertThat(holdRequested.getUserId()).isEqualTo(userId),
+			() -> assertThat(holdRequested.getScheduledSeatIds()).containsExactlyElementsOf(seatIds),
 			() -> {
 				assertNotNull(savedReservation.getTickets());
 				assertThat(savedReservation.getTickets().get(1).getPriceSnapshot()).isEqualTo(20000L);

--- a/ticketing/src/test/java/org/truve/platform/ticketing/service/booking/service/BookingServiceTest.java
+++ b/ticketing/src/test/java/org/truve/platform/ticketing/service/booking/service/BookingServiceTest.java
@@ -49,9 +49,9 @@ class BookingServiceTest {
 		List<Long> seatIds = List.of(10L, 11L, 12L);
 		BookingRequest.Create request = new BookingRequest.Create(seatIds);
 
-		TicketingResponse.Seat seat1 = new TicketingResponse.Seat("Section1", 1L, "VIP", "A", 10L, 10000L);
-		TicketingResponse.Seat seat2 = new TicketingResponse.Seat("Section2", 2L, "S", "B", 20L, 20000L);
-		TicketingResponse.Seat seat3 = new TicketingResponse.Seat("Section3", 3L, "VIP", "C", 30L, 30000L);
+		TicketingResponse.Seat seat1 = new TicketingResponse.Seat(10L, "Section1", 1L, "VIP", "A", 10L, 10000L);
+		TicketingResponse.Seat seat2 = new TicketingResponse.Seat(11L, "Section2", 2L, "S", "B", 20L, 20000L);
+		TicketingResponse.Seat seat3 = new TicketingResponse.Seat(12L, "Section3", 3L, "VIP", "C", 30L, 30000L);
 		List<TicketingResponse.Seat> seats = List.of(seat1, seat2, seat3);
 		TicketingResponse.SeatInfo seatInfo = new TicketingResponse.SeatInfo(
 			1L,
@@ -77,12 +77,13 @@ class BookingServiceTest {
 
 		assertAll(
 			() -> assertThat(savedReservation.calculateTicketAmount()).isEqualTo(60000L),
-			() -> assertThat(savedReservation.getGradeSummary()).isEqualTo("VIP석 2인\nS석 1인"),
-			() -> assertThat(savedReservation.getTickets()).hasSize(3),
-			() -> assertThat(savedReservation.getServiceFee()).isEqualTo(6000L),
-			() -> assertThat(holdRequested.getReservationNumber()).isEqualTo(savedReservation.getNumber()),
-			() -> assertThat(holdRequested.getUserId()).isEqualTo(userId),
-			() -> assertThat(holdRequested.getScheduledSeatIds()).containsExactlyElementsOf(seatIds),
+				() -> assertThat(savedReservation.getGradeSummary()).isEqualTo("VIP석 2인\nS석 1인"),
+				() -> assertThat(savedReservation.getTickets()).hasSize(3),
+				() -> assertThat(savedReservation.getServiceFee()).isEqualTo(6000L),
+				() -> assertThat(savedReservation.getTickets().getFirst().getScheduledSeatId()).isEqualTo(10L),
+				() -> assertThat(holdRequested.getReservationNumber()).isEqualTo(savedReservation.getNumber()),
+				() -> assertThat(holdRequested.getUserId()).isEqualTo(userId),
+				() -> assertThat(holdRequested.getScheduledSeatIds()).containsExactlyElementsOf(seatIds),
 			() -> {
 				assertNotNull(savedReservation.getTickets());
 				assertThat(savedReservation.getTickets().get(1).getPriceSnapshot()).isEqualTo(20000L);
@@ -133,9 +134,9 @@ class BookingServiceTest {
 				.build()
 		);
 
-		Ticket ticket1 = Ticket.create(reservation, "T-001", "VIP", 120000L, "1층 A구역 1열 1번");
+		Ticket ticket1 = Ticket.create(reservation, "T-001", "VIP", 120000L, "1층 A구역 1열 1번", 1L);
 		ReflectionTestUtils.setField(ticket1, "id", 1L);
-		Ticket ticket2 = Ticket.create(reservation, "T-002", "VIP", 120000L, "1층 A구역 1열 2번");
+		Ticket ticket2 = Ticket.create(reservation, "T-002", "VIP", 120000L, "1층 A구역 1열 2번", 2L);
 		ReflectionTestUtils.setField(ticket2, "id", 2L);
 
 		List<Ticket> tickets = List.of(ticket1, ticket2);

--- a/ticketing/src/test/java/org/truve/platform/ticketing/service/booking/service/BookingServiceTest.java
+++ b/ticketing/src/test/java/org/truve/platform/ticketing/service/booking/service/BookingServiceTest.java
@@ -22,8 +22,10 @@ import org.truve.platform.ticketing.service.booking.domain.entity.Ticket;
 import org.truve.platform.ticketing.service.booking.domain.entity.embedded.ShowInfo;
 import org.truve.platform.ticketing.service.booking.dto.BookingRequest;
 import org.truve.platform.ticketing.service.booking.dto.BookingResponse;
+import org.truve.platform.ticketing.service.booking.external.client.payment.PaymentClient;
 import org.truve.platform.ticketing.service.booking.external.client.ticketing.TicketingClient;
 import org.truve.platform.ticketing.service.booking.external.client.ticketing.TicketingResponse;
+import org.truve.platform.ticketing.service.booking.external.kafka.PaymentPublisher;
 import org.truve.platform.ticketing.service.booking.external.kafka.TicketingEventCommand;
 import org.truve.platform.ticketing.service.booking.external.kafka.TicketingPublisher;
 import org.truve.platform.ticketing.service.booking.repository.ReservationRepository;
@@ -37,6 +39,10 @@ class BookingServiceTest {
 	private TicketingClient ticketingClient;
 	@Mock
 	private TicketingPublisher ticketingPublisher;
+	@Mock
+	private PaymentPublisher paymentPublisher;
+	@Mock
+	private PaymentClient paymentClient;
 
 	@InjectMocks
 	private BookingService bookingService;
@@ -120,6 +126,32 @@ class BookingServiceTest {
 
 		// then
 		assertThat(res.getTickets()).hasSize(2);
+	}
+
+	@Test
+	@DisplayName("예매 취소 시 결제 취소 후 HOLD_RELEASED 이벤트를 발행한다.")
+	void 예매취소_좌석해제이벤트발행_성공() {
+		Reservation reservation = createReservation();
+		BookingRequest.Cancel request = new BookingRequest.Cancel("단순변심", List.of(1L));
+		given(reservationRepository.findByNumber("R-001")).willReturn(reservation);
+
+		BookingResponse.CanceledTickets response = bookingService.cancel("R-001", request);
+
+		ArgumentCaptor<TicketingEventCommand.TicketingEvent> eventCaptor =
+			ArgumentCaptor.forClass(TicketingEventCommand.TicketingEvent.class);
+		verify(paymentClient).cancel(eq("R-001"), anyString(), any());
+		verify(ticketingPublisher).publish(eventCaptor.capture());
+
+		TicketingEventCommand.HoldReleased holdReleased =
+			(TicketingEventCommand.HoldReleased) eventCaptor.getValue();
+
+		assertAll(
+			() -> assertThat(response.getCanceledTicketIds()).containsExactly(1L),
+			() -> assertThat(holdReleased.getReservationNumber()).isEqualTo("R-001"),
+			() -> assertThat(holdReleased.getScheduledSeatIds()).containsExactly(1L),
+			() -> assertThat(reservation.getTickets().getFirst().isCanceled()).isTrue(),
+			() -> assertThat(reservation.getTickets().getLast().isCanceled()).isFalse()
+		);
 	}
 
 	private Reservation createReservation() {

--- a/ticketing/src/test/java/org/truve/platform/ticketing/service/booking/service/BookingServiceTest.java
+++ b/ticketing/src/test/java/org/truve/platform/ticketing/service/booking/service/BookingServiceTest.java
@@ -25,6 +25,7 @@ import org.truve.platform.ticketing.service.booking.dto.BookingResponse;
 import org.truve.platform.ticketing.service.booking.external.client.payment.PaymentClient;
 import org.truve.platform.ticketing.service.booking.external.client.ticketing.TicketingClient;
 import org.truve.platform.ticketing.service.booking.external.client.ticketing.TicketingResponse;
+import org.truve.platform.ticketing.service.booking.external.kafka.BookingEventCommand;
 import org.truve.platform.ticketing.service.booking.external.kafka.PaymentPublisher;
 import org.truve.platform.ticketing.service.booking.external.kafka.TicketingEventCommand;
 import org.truve.platform.ticketing.service.booking.external.kafka.TicketingPublisher;
@@ -79,17 +80,17 @@ class BookingServiceTest {
 		verify(ticketingPublisher).publish(eventCaptor.capture());
 		Reservation savedReservation = captor.getValue();
 		TicketingEventCommand.HoldRequested holdRequested =
-			(TicketingEventCommand.HoldRequested) eventCaptor.getValue();
+			(TicketingEventCommand.HoldRequested)eventCaptor.getValue();
 
 		assertAll(
 			() -> assertThat(savedReservation.calculateTicketAmount()).isEqualTo(60000L),
-				() -> assertThat(savedReservation.getGradeSummary()).isEqualTo("VIP석 2인\nS석 1인"),
-				() -> assertThat(savedReservation.getTickets()).hasSize(3),
-				() -> assertThat(savedReservation.getServiceFee()).isEqualTo(6000L),
-				() -> assertThat(savedReservation.getTickets().getFirst().getScheduledSeatId()).isEqualTo(10L),
-				() -> assertThat(holdRequested.getReservationNumber()).isEqualTo(savedReservation.getNumber()),
-				() -> assertThat(holdRequested.getUserId()).isEqualTo(userId),
-				() -> assertThat(holdRequested.getScheduledSeatIds()).containsExactlyElementsOf(seatIds),
+			() -> assertThat(savedReservation.getGradeSummary()).isEqualTo("VIP석 2인\nS석 1인"),
+			() -> assertThat(savedReservation.getTickets()).hasSize(3),
+			() -> assertThat(savedReservation.getServiceFee()).isEqualTo(6000L),
+			() -> assertThat(savedReservation.getTickets().getFirst().getScheduledSeatId()).isEqualTo(10L),
+			() -> assertThat(holdRequested.getReservationNumber()).isEqualTo(savedReservation.getNumber()),
+			() -> assertThat(holdRequested.getUserId()).isEqualTo(userId),
+			() -> assertThat(holdRequested.getScheduledSeatIds()).containsExactlyElementsOf(seatIds),
 			() -> {
 				assertNotNull(savedReservation.getTickets());
 				assertThat(savedReservation.getTickets().get(1).getPriceSnapshot()).isEqualTo(20000L);
@@ -97,6 +98,33 @@ class BookingServiceTest {
 				assertThat(savedReservation.getTickets().get(1).getUsedAt()).isNull();
 				assertThat(savedReservation.getTickets().getFirst().getSeatDetail()).isEqualTo("1층 Section1구역 A열 10번");
 			}
+		);
+	}
+
+	@Test
+	@DisplayName("결제가 확정되면 예약 상태를 업데이트하고 SOLD_CONFIRMED 이벤트를 발행한다.")
+	void 결제확정_SOLD_이벤트_발행() {
+		// given
+		Reservation reservation = createReservation();
+		given(reservationRepository.findByNumber("R-001")).willReturn(reservation);
+
+		BookingEventCommand.Confirmed event = new BookingEventCommand.Confirmed(
+			"R-001", LocalDateTime.now(), LocalDateTime.now(), "카드", null
+		);
+
+		// when
+		bookingService.confirm(event);
+
+		// then
+		ArgumentCaptor<TicketingEventCommand.TicketingEvent> eventCaptor =
+			ArgumentCaptor.forClass(TicketingEventCommand.TicketingEvent.class);
+		verify(ticketingPublisher).publish(eventCaptor.capture());
+
+		TicketingEventCommand.SoldConfirmed soldConfirmed =
+			(TicketingEventCommand.SoldConfirmed)eventCaptor.getValue();
+		assertAll(
+			() -> assertThat(soldConfirmed.getReservationNumber()).isEqualTo("R-001"),
+			() -> assertThat(soldConfirmed.getScheduledSeatIds()).containsExactly(1L, 2L)
 		);
 	}
 
@@ -143,7 +171,7 @@ class BookingServiceTest {
 		verify(ticketingPublisher).publish(eventCaptor.capture());
 
 		TicketingEventCommand.HoldReleased holdReleased =
-			(TicketingEventCommand.HoldReleased) eventCaptor.getValue();
+			(TicketingEventCommand.HoldReleased)eventCaptor.getValue();
 
 		assertAll(
 			() -> assertThat(response.getCanceledTicketIds()).containsExactly(1L),

--- a/ticketing/src/test/java/org/truve/platform/ticketing/service/ticketing/external/kafka/BookingConsumerTest.java
+++ b/ticketing/src/test/java/org/truve/platform/ticketing/service/ticketing/external/kafka/BookingConsumerTest.java
@@ -1,0 +1,56 @@
+package org.truve.platform.ticketing.service.ticketing.external.kafka;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.truve.platform.ticketing.service.booking.external.kafka.TicketingEventCommand;
+import org.truve.platform.ticketing.service.ticketing.service.ScheduledSeatStatusService;
+
+import com.truve.platform.common.support.JsonConverter;
+
+@ExtendWith(MockitoExtension.class)
+class BookingConsumerTest {
+
+	@Mock
+	private JsonConverter jsonConverter;
+
+	@Mock
+	private ScheduledSeatStatusService scheduledSeatStatusService;
+
+	@InjectMocks
+	private BookingConsumer bookingConsumer;
+
+	@Test
+	@DisplayName("HOLD_REQUESTED 이벤트면 좌석 점유 서비스에 위임한다.")
+	void hold이벤트_소비성공() {
+		TicketingEventCommand.HoldRequested event = new TicketingEventCommand.HoldRequested(
+			"R-001",
+			UUID.fromString("11111111-1111-1111-1111-111111111111"),
+			List.of(10L, 11L)
+		);
+		given(jsonConverter.convert("payload", TicketingEventCommand.HoldRequested.class)).willReturn(event);
+
+		bookingConsumer.consume("payload", "HOLD_REQUESTED");
+
+		verify(jsonConverter).convert("payload", TicketingEventCommand.HoldRequested.class);
+		verify(scheduledSeatStatusService).holdSeats(event);
+	}
+
+	@Test
+	@DisplayName("알 수 없는 이벤트 타입이면 아무 작업도 하지 않는다.")
+	void 알수없는이벤트_무시() {
+		bookingConsumer.consume("payload", "UNKNOWN");
+
+		verifyNoInteractions(jsonConverter, scheduledSeatStatusService);
+	}
+}

--- a/ticketing/src/test/java/org/truve/platform/ticketing/service/ticketing/external/kafka/BookingConsumerTest.java
+++ b/ticketing/src/test/java/org/truve/platform/ticketing/service/ticketing/external/kafka/BookingConsumerTest.java
@@ -63,6 +63,22 @@ class BookingConsumerTest {
 	}
 
 	@Test
+	@DisplayName("SOLD_CONFIRMED 이벤트면 좌석 구매 서비스에 위임한다.")
+	void sold이벤트_소비성공() {
+		TicketingEventCommand.SoldConfirmed event = new TicketingEventCommand.SoldConfirmed(
+			"R-001",
+			UUID.fromString("11111111-1111-1111-1111-111111111111"),
+			List.of(10L, 11L)
+		);
+		given(jsonConverter.convert("payload", TicketingEventCommand.SoldConfirmed.class)).willReturn(event);
+
+		bookingConsumer.consume("payload", "SOLD_CONFIRMED");
+
+		verify(jsonConverter).convert("payload", TicketingEventCommand.SoldConfirmed.class);
+		verify(scheduledSeatStatusService).purchaseSeats(event);
+	}
+
+	@Test
 	@DisplayName("알 수 없는 이벤트 타입이면 아무 작업도 하지 않는다.")
 	void 알수없는이벤트_무시() {
 		bookingConsumer.consume("payload", "UNKNOWN");

--- a/ticketing/src/test/java/org/truve/platform/ticketing/service/ticketing/external/kafka/BookingConsumerTest.java
+++ b/ticketing/src/test/java/org/truve/platform/ticketing/service/ticketing/external/kafka/BookingConsumerTest.java
@@ -47,6 +47,22 @@ class BookingConsumerTest {
 	}
 
 	@Test
+	@DisplayName("HOLD_RELEASED 이벤트면 좌석 해제 서비스에 위임한다.")
+	void release이벤트_소비성공() {
+		TicketingEventCommand.HoldReleased event = new TicketingEventCommand.HoldReleased(
+			"R-001",
+			UUID.fromString("11111111-1111-1111-1111-111111111111"),
+			List.of(10L, 11L)
+		);
+		given(jsonConverter.convert("payload", TicketingEventCommand.HoldReleased.class)).willReturn(event);
+
+		bookingConsumer.consume("payload", "HOLD_RELEASED");
+
+		verify(jsonConverter).convert("payload", TicketingEventCommand.HoldReleased.class);
+		verify(scheduledSeatStatusService).releaseSeats(event);
+	}
+
+	@Test
 	@DisplayName("알 수 없는 이벤트 타입이면 아무 작업도 하지 않는다.")
 	void 알수없는이벤트_무시() {
 		bookingConsumer.consume("payload", "UNKNOWN");

--- a/ticketing/src/test/java/org/truve/platform/ticketing/service/ticketing/service/ScheduledSeatStatusServiceTest.java
+++ b/ticketing/src/test/java/org/truve/platform/ticketing/service/ticketing/service/ScheduledSeatStatusServiceTest.java
@@ -87,6 +87,27 @@ class ScheduledSeatStatusServiceTest {
 		assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.NOT_CORRECT_SEAT);
 	}
 
+	@Test
+	@DisplayName("RELEASE 요청이면 HOLD 좌석을 AVAILABLE로 되돌리고 SOLD는 유지한다.")
+	void release요청_좌석해제_성공() {
+		TicketingEventCommand.HoldReleased event = new TicketingEventCommand.HoldReleased(
+			"R-001",
+			UUID.fromString("11111111-1111-1111-1111-111111111111"),
+			List.of(10L, 11L, 12L)
+		);
+		ScheduledSeat holdSeat = createScheduledSeat(10L, SeatStatus.HOLD);
+		ScheduledSeat availableSeat = createScheduledSeat(11L, SeatStatus.AVAILABLE);
+		ScheduledSeat soldSeat = createScheduledSeat(12L, SeatStatus.SOLD);
+		given(scheduledSeatRepository.findAllById(event.getScheduledSeatIds()))
+			.willReturn(List.of(holdSeat, availableSeat, soldSeat));
+
+		scheduledSeatStatusService.releaseSeats(event);
+
+		assertThat(holdSeat.getStatus()).isEqualTo(SeatStatus.AVAILABLE);
+		assertThat(availableSeat.getStatus()).isEqualTo(SeatStatus.AVAILABLE);
+		assertThat(soldSeat.getStatus()).isEqualTo(SeatStatus.SOLD);
+	}
+
 	private ScheduledSeat createScheduledSeat(Long scheduledSeatId, SeatStatus status) {
 		Seat seat = Seat.builder()
 			.seatRow("A")

--- a/ticketing/src/test/java/org/truve/platform/ticketing/service/ticketing/service/ScheduledSeatStatusServiceTest.java
+++ b/ticketing/src/test/java/org/truve/platform/ticketing/service/ticketing/service/ScheduledSeatStatusServiceTest.java
@@ -1,0 +1,105 @@
+package org.truve.platform.ticketing.service.ticketing.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.BDDMockito.given;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.truve.platform.ticketing.service.booking.external.kafka.TicketingEventCommand;
+import org.truve.platform.ticketing.service.ticketing.constant.SeatStatus;
+import org.truve.platform.ticketing.service.ticketing.domain.entity.ScheduledSeat;
+import org.truve.platform.ticketing.service.ticketing.domain.entity.Seat;
+import org.truve.platform.ticketing.service.ticketing.repository.ScheduledSeatRepository;
+
+import com.truve.platform.common.exception.CustomException;
+import com.truve.platform.common.exception.ErrorCode;
+
+@ExtendWith(MockitoExtension.class)
+class ScheduledSeatStatusServiceTest {
+
+	@Mock
+	private ScheduledSeatRepository scheduledSeatRepository;
+
+	@InjectMocks
+	private ScheduledSeatStatusService scheduledSeatStatusService;
+
+	@Test
+	@DisplayName("HOLD 요청이면 AVAILABLE 좌석을 HOLD 상태로 변경한다.")
+	void hold요청_좌석점유_성공() {
+		TicketingEventCommand.HoldRequested event = new TicketingEventCommand.HoldRequested(
+			"R-001",
+			UUID.fromString("11111111-1111-1111-1111-111111111111"),
+			List.of(10L, 11L)
+		);
+		ScheduledSeat seat1 = createScheduledSeat(10L, SeatStatus.AVAILABLE);
+		ScheduledSeat seat2 = createScheduledSeat(11L, SeatStatus.AVAILABLE);
+		given(scheduledSeatRepository.findAllById(event.getScheduledSeatIds())).willReturn(List.of(seat1, seat2));
+
+		scheduledSeatStatusService.holdSeats(event);
+
+		assertThat(seat1.getStatus()).isEqualTo(SeatStatus.HOLD);
+		assertThat(seat2.getStatus()).isEqualTo(SeatStatus.HOLD);
+	}
+
+	@Test
+	@DisplayName("이미 HOLD 또는 SOLD 인 좌석은 상태를 유지한다.")
+	void hold요청_기존상태유지() {
+		TicketingEventCommand.HoldRequested event = new TicketingEventCommand.HoldRequested(
+			"R-001",
+			UUID.fromString("11111111-1111-1111-1111-111111111111"),
+			List.of(10L, 11L)
+		);
+		ScheduledSeat holdSeat = createScheduledSeat(10L, SeatStatus.HOLD);
+		ScheduledSeat soldSeat = createScheduledSeat(11L, SeatStatus.SOLD);
+		given(scheduledSeatRepository.findAllById(event.getScheduledSeatIds())).willReturn(List.of(holdSeat, soldSeat));
+
+		scheduledSeatStatusService.holdSeats(event);
+
+		assertThat(holdSeat.getStatus()).isEqualTo(SeatStatus.HOLD);
+		assertThat(soldSeat.getStatus()).isEqualTo(SeatStatus.SOLD);
+	}
+
+	@Test
+	@DisplayName("좌석 개수가 맞지 않으면 NOT_CORRECT_SEAT 예외가 발생한다.")
+	void hold요청_좌석개수불일치() {
+		TicketingEventCommand.HoldRequested event = new TicketingEventCommand.HoldRequested(
+			"R-001",
+			UUID.fromString("11111111-1111-1111-1111-111111111111"),
+			List.of(10L, 11L)
+		);
+		given(scheduledSeatRepository.findAllById(event.getScheduledSeatIds()))
+			.willReturn(List.of(createScheduledSeat(10L, SeatStatus.AVAILABLE)));
+
+		CustomException exception = assertThrows(
+			CustomException.class,
+			() -> scheduledSeatStatusService.holdSeats(event)
+		);
+
+		assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.NOT_CORRECT_SEAT);
+	}
+
+	private ScheduledSeat createScheduledSeat(Long scheduledSeatId, SeatStatus status) {
+		Seat seat = Seat.builder()
+			.seatRow("A")
+			.seatNumber(scheduledSeatId)
+			.build();
+		ReflectionTestUtils.setField(seat, "id", scheduledSeatId);
+
+		ScheduledSeat scheduledSeat = ScheduledSeat.builder()
+			.seat(seat)
+			.showScheduleId(1L)
+			.build();
+		ReflectionTestUtils.setField(scheduledSeat, "id", scheduledSeatId);
+		ReflectionTestUtils.setField(scheduledSeat, "status", status);
+		return scheduledSeat;
+	}
+}

--- a/ticketing/src/test/java/org/truve/platform/ticketing/service/ticketing/service/ScheduledSeatStatusServiceTest.java
+++ b/ticketing/src/test/java/org/truve/platform/ticketing/service/ticketing/service/ScheduledSeatStatusServiceTest.java
@@ -1,8 +1,8 @@
 package org.truve.platform.ticketing.service.ticketing.service;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.BDDMockito.given;
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
 
 import java.util.List;
 import java.util.UUID;
@@ -88,7 +88,7 @@ class ScheduledSeatStatusServiceTest {
 	}
 
 	@Test
-	@DisplayName("RELEASE 요청이면 HOLD 좌석을 AVAILABLE로 되돌리고 SOLD는 유지한다.")
+	@DisplayName("RELEASE 요청이면 좌석 상태를 AVAILABLE로 되돌린다.")
 	void release요청_좌석해제_성공() {
 		TicketingEventCommand.HoldReleased event = new TicketingEventCommand.HoldReleased(
 			"R-001",
@@ -105,7 +105,7 @@ class ScheduledSeatStatusServiceTest {
 
 		assertThat(holdSeat.getStatus()).isEqualTo(SeatStatus.AVAILABLE);
 		assertThat(availableSeat.getStatus()).isEqualTo(SeatStatus.AVAILABLE);
-		assertThat(soldSeat.getStatus()).isEqualTo(SeatStatus.SOLD);
+		assertThat(soldSeat.getStatus()).isEqualTo(SeatStatus.AVAILABLE);
 	}
 
 	@Test

--- a/ticketing/src/test/java/org/truve/platform/ticketing/service/ticketing/service/ScheduledSeatStatusServiceTest.java
+++ b/ticketing/src/test/java/org/truve/platform/ticketing/service/ticketing/service/ScheduledSeatStatusServiceTest.java
@@ -108,6 +108,62 @@ class ScheduledSeatStatusServiceTest {
 		assertThat(soldSeat.getStatus()).isEqualTo(SeatStatus.SOLD);
 	}
 
+	@Test
+	@DisplayName("SOLD_CONFIRMED 요청이면 HOLD 좌석을 SOLD 상태로 변경한다.")
+	void sold요청_좌석구매_성공() {
+		TicketingEventCommand.SoldConfirmed event = new TicketingEventCommand.SoldConfirmed(
+			"R-001",
+			UUID.fromString("11111111-1111-1111-1111-111111111111"),
+			List.of(10L, 11L)
+		);
+		ScheduledSeat seat1 = createScheduledSeat(10L, SeatStatus.HOLD);
+		ScheduledSeat seat2 = createScheduledSeat(11L, SeatStatus.HOLD);
+		given(scheduledSeatRepository.findAllById(event.getScheduledSeatIds())).willReturn(List.of(seat1, seat2));
+
+		scheduledSeatStatusService.purchaseSeats(event);
+
+		assertThat(seat1.getStatus()).isEqualTo(SeatStatus.SOLD);
+		assertThat(seat2.getStatus()).isEqualTo(SeatStatus.SOLD);
+	}
+
+	@Test
+	@DisplayName("이미 SOLD인 좌석에 SOLD_CONFIRMED 요청이 오면 예외가 발생한다.")
+	void sold요청_이미SOLD_예외발생() {
+		TicketingEventCommand.SoldConfirmed event = new TicketingEventCommand.SoldConfirmed(
+			"R-001",
+			UUID.fromString("11111111-1111-1111-1111-111111111111"),
+			List.of(10L)
+		);
+		ScheduledSeat soldSeat = createScheduledSeat(10L, SeatStatus.SOLD);
+		given(scheduledSeatRepository.findAllById(event.getScheduledSeatIds())).willReturn(List.of(soldSeat));
+
+		CustomException exception = assertThrows(
+			CustomException.class,
+			() -> scheduledSeatStatusService.purchaseSeats(event)
+		);
+
+		assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.ALREADY_SOLD_SEAT);
+	}
+
+	@Test
+	@DisplayName("좌석 개수가 맞지 않으면 NOT_CORRECT_SEAT 예외가 발생한다.")
+	void sold요청_좌석개수불일치() {
+		TicketingEventCommand.SoldConfirmed event = new TicketingEventCommand.SoldConfirmed(
+			"R-001",
+			UUID.fromString("11111111-1111-1111-1111-111111111111"),
+			List.of(10L, 11L)
+		);
+		given(scheduledSeatRepository.findAllById(event.getScheduledSeatIds()))
+			.willReturn(List.of(createScheduledSeat(10L, SeatStatus.HOLD)));
+
+		CustomException exception = assertThrows(
+			CustomException.class,
+			() -> scheduledSeatStatusService.purchaseSeats(event)
+		);
+
+		assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.NOT_CORRECT_SEAT);
+	}
+
 	private ScheduledSeat createScheduledSeat(Long scheduledSeatId, SeatStatus status) {
 		Seat seat = Seat.builder()
 			.seatRow("A")


### PR DESCRIPTION
## 변경 사항

추가/변경 사항과 사유를 작성해 주세요.

- [x] 전체 테스트 코드 성공 여부

### 티켓 내 공연 회차별 좌석 id 추가
티켓이 생성되고 좌석이 어딘지를 기존에는 문자열로만 갖고 있었는데,
hold, sold 등 상태 전환을 위해 추가했습니다!

### Booking create 시 이벤트 전파
티켓팅 서버 측에서 이벤트를 소비해 좌석을 점유상태로 전환합니다.

### Booking cancel 시 이벤트 전파
티켓팅 서버 측에서 이벤트를 소비해 좌석을 예매가능 상태로 전환합니다.

## 관련 이슈

- Notion Ticket: #93

## 참고사항 (선택)

저희 원래 문자열로만 좌석 정보 가져가려했는데, 상태전환 하려니 id 추가가 필수적이네요..
ss.id 티켓에서 다 추가되었습니다!