### PR TITLE
refactor(payment): /external/kafka 패키지 정리

### DIFF
--- a/payment/src/main/java/com/truve/platform/payment/service/event/PaymentUpdatedListener.java
+++ b/payment/src/main/java/com/truve/platform/payment/service/event/PaymentUpdatedListener.java
@@ -4,10 +4,10 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 
-import com.truve.platform.payment.service.external.kafka.BookingEventCommand;
-import com.truve.platform.payment.service.external.kafka.BookingPublisher;
-import com.truve.platform.payment.service.external.kafka.MembershipEventCommand;
-import com.truve.platform.payment.service.external.kafka.MembershipPublisher;
+import com.truve.platform.payment.service.external.kafka.booking.BookingEventCommand;
+import com.truve.platform.payment.service.external.kafka.booking.BookingPublisher;
+import com.truve.platform.payment.service.external.kafka.membership.MembershipEventCommand;
+import com.truve.platform.payment.service.external.kafka.membership.MembershipPublisher;
 
 import lombok.RequiredArgsConstructor;
 

--- a/payment/src/main/java/com/truve/platform/payment/service/external/kafka/booking/BookingConsumer.java
+++ b/payment/src/main/java/com/truve/platform/payment/service/external/kafka/booking/BookingConsumer.java
@@ -1,10 +1,11 @@
-package com.truve.platform.payment.service.external.kafka;
+package com.truve.platform.payment.service.external.kafka.booking;
 
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.messaging.handler.annotation.Header;
 import org.springframework.stereotype.Component;
 
 import com.truve.platform.common.support.JsonConverter;
+import com.truve.platform.payment.service.external.kafka.PaymentEventCommand;
 import com.truve.platform.payment.service.service.PaymentService;
 
 import lombok.RequiredArgsConstructor;
@@ -13,9 +14,9 @@ import lombok.extern.slf4j.Slf4j;
 @Component
 @RequiredArgsConstructor
 @Slf4j
-public class MembershipConsumer {
-	public static final String TOPIC = "membership.payment";
-	public static final String GROUP = "membership-payment-group";
+public class BookingConsumer {
+	public static final String TOPIC = "booking.payment";
+	public static final String GROUP = "booking-payment-group";
 
 	private final JsonConverter jsonConverter;
 	private final PaymentService paymentService;

--- a/payment/src/main/java/com/truve/platform/payment/service/external/kafka/booking/BookingEventCommand.java
+++ b/payment/src/main/java/com/truve/platform/payment/service/external/kafka/booking/BookingEventCommand.java
@@ -1,4 +1,4 @@
-package com.truve.platform.payment.service.external.kafka;
+package com.truve.platform.payment.service.external.kafka.booking;
 
 import java.time.LocalDateTime;
 

--- a/payment/src/main/java/com/truve/platform/payment/service/external/kafka/booking/BookingPublisher.java
+++ b/payment/src/main/java/com/truve/platform/payment/service/external/kafka/booking/BookingPublisher.java
@@ -1,4 +1,4 @@
-package com.truve.platform.payment.service.external.kafka;
+package com.truve.platform.payment.service.external.kafka.booking;
 
 import org.springframework.stereotype.Component;
 

--- a/payment/src/main/java/com/truve/platform/payment/service/external/kafka/membership/MembershipConsumer.java
+++ b/payment/src/main/java/com/truve/platform/payment/service/external/kafka/membership/MembershipConsumer.java
@@ -1,10 +1,11 @@
-package com.truve.platform.payment.service.external.kafka;
+package com.truve.platform.payment.service.external.kafka.membership;
 
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.messaging.handler.annotation.Header;
 import org.springframework.stereotype.Component;
 
 import com.truve.platform.common.support.JsonConverter;
+import com.truve.platform.payment.service.external.kafka.PaymentEventCommand;
 import com.truve.platform.payment.service.service.PaymentService;
 
 import lombok.RequiredArgsConstructor;
@@ -13,9 +14,9 @@ import lombok.extern.slf4j.Slf4j;
 @Component
 @RequiredArgsConstructor
 @Slf4j
-public class BookingConsumer {
-	public static final String TOPIC = "booking.payment";
-	public static final String GROUP = "booking-payment-group";
+public class MembershipConsumer {
+	public static final String TOPIC = "membership.payment";
+	public static final String GROUP = "membership-payment-group";
 
 	private final JsonConverter jsonConverter;
 	private final PaymentService paymentService;

--- a/payment/src/main/java/com/truve/platform/payment/service/external/kafka/membership/MembershipEventCommand.java
+++ b/payment/src/main/java/com/truve/platform/payment/service/external/kafka/membership/MembershipEventCommand.java
@@ -1,4 +1,4 @@
-package com.truve.platform.payment.service.external.kafka;
+package com.truve.platform.payment.service.external.kafka.membership;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 

--- a/payment/src/main/java/com/truve/platform/payment/service/external/kafka/membership/MembershipPublisher.java
+++ b/payment/src/main/java/com/truve/platform/payment/service/external/kafka/membership/MembershipPublisher.java
@@ -1,4 +1,4 @@
-package com.truve.platform.payment.service.external.kafka;
+package com.truve.platform.payment.service.external.kafka.membership;
 
 import org.springframework.stereotype.Component;
 

--- a/payment/src/test/java/com/truve/platform/payment/service/event/PaymentUpdatedListenerTest.java
+++ b/payment/src/test/java/com/truve/platform/payment/service/event/PaymentUpdatedListenerTest.java
@@ -15,9 +15,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.truve.platform.payment.service.domain.constant.PaymentMethod;
 import com.truve.platform.payment.service.domain.constant.PaymentStatus;
-import com.truve.platform.payment.service.external.kafka.BookingPublisher;
-import com.truve.platform.payment.service.external.kafka.MembershipEventCommand;
-import com.truve.platform.payment.service.external.kafka.MembershipPublisher;
+import com.truve.platform.payment.service.external.kafka.booking.BookingPublisher;
+import com.truve.platform.payment.service.external.kafka.membership.MembershipEventCommand;
+import com.truve.platform.payment.service.external.kafka.membership.MembershipPublisher;
 
 @ExtendWith(MockitoExtension.class)
 class PaymentUpdatedListenerTest {


### PR DESCRIPTION
## 변경 사항

---
/external/kafka 패키지의 파일을 도메인 별(booking, membership)로 패키지를 생성해 정리했습니다.

- [X] 전체 테스트 코드 성공 여부

## 관련 이슈

---
- Notion Ticket: #

## 참고사항 (선택)

---
아웃박스 작업 중 PR이 너무 길어질 것 같아서 분리해 올립니다!