### PR TITLE
feat(payment): 아웃박스 패턴 도입

### DIFF
--- a/common/src/main/java/com/truve/platform/common/event/KafkaEventPublisher.java
+++ b/common/src/main/java/com/truve/platform/common/event/KafkaEventPublisher.java
@@ -4,10 +4,7 @@ import org.apache.kafka.clients.producer.ProducerRecord;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Component;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.truve.platform.common.exception.CustomException;
-import com.truve.platform.common.exception.ErrorCode;
+import com.truve.platform.common.support.JsonConverter;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -18,34 +15,24 @@ import lombok.extern.slf4j.Slf4j;
 public class KafkaEventPublisher implements EventPublisher {
 
 	private final KafkaTemplate<String, String> kafkaTemplate;
-	private final ObjectMapper objectMapper;
+	private final JsonConverter jsonConverter;
 
 	@Override
 	public void publish(String topic, String key, Object event) {
-		try {
-			String payload = objectMapper.writeValueAsString(event);
-			log.info("[Kafka Publish] Start - Topic: {}, Key: {}, Payload: {}", topic, key, payload);
-			
-			kafkaTemplate.send(topic, key, payload);
-		} catch (JsonProcessingException exception) {
-			throw new CustomException(ErrorCode.EVENT_SERIALIZATION_FAILED);
-		} catch (Exception exception) {
-			throw new CustomException(ErrorCode.EVENT_PUBLISH_FAILED);
-		}
+		String payload = jsonConverter.serialize(event);
+		log.info("[Kafka Publish] Start - Topic: {}, Key: {}, Payload: {}", topic, key, payload);
+
+		kafkaTemplate.send(topic, key, payload);
 	}
 
 	@Override
 	public void publish(String topic, String key, String type, Object event) {
-		try {
-			String payload = objectMapper.writeValueAsString(event);
-			log.info("[Kafka Publish With Header] Topic: {}, event-type: {}, Payload: {}", topic, type, payload);
+		String payload = jsonConverter.serialize(event);
+		log.info("[Kafka Publish With Header] Topic: {}, event-type: {}, Payload: {}", topic, type, payload);
 
-			ProducerRecord<String, String> record = new ProducerRecord<>(topic, key, payload);
-			record.headers().add("event-type", type.getBytes());
+		ProducerRecord<String, String> record = new ProducerRecord<>(topic, key, payload);
+		record.headers().add("event-type", type.getBytes());
 
-			kafkaTemplate.send(record);
-		} catch (JsonProcessingException e) {
-			throw new CustomException(ErrorCode.EVENT_SERIALIZATION_FAILED);
-		}
+		kafkaTemplate.send(record);
 	}
 }

--- a/common/src/main/java/com/truve/platform/common/outbox/OutboxEvent.java
+++ b/common/src/main/java/com/truve/platform/common/outbox/OutboxEvent.java
@@ -1,0 +1,54 @@
+package com.truve.platform.common.outbox;
+
+import com.truve.platform.common.support.BaseEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.MappedSuperclass;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@MappedSuperclass
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public abstract class OutboxEvent extends BaseEntity {
+
+	@Column(nullable = false)
+	protected String topic;
+
+	@Column(name = "message_key", nullable = false)
+	protected String messageKey;
+
+	@Column(columnDefinition = "TEXT", nullable = false)
+	protected String payload;
+
+	@Column(name = "event_type", nullable = false)
+	protected String eventType;
+
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false)
+	protected OutboxStatus status;
+
+	@Column(name = "retry_count", nullable = false)
+	protected int retryCount;
+
+	protected OutboxEvent(String topic, String messageKey, String payload, String eventType) {
+		this.topic = topic;
+		this.messageKey = messageKey;
+		this.payload = payload;
+		this.eventType = eventType;
+		this.status = OutboxStatus.PENDING;
+		this.retryCount = 0;
+	}
+
+	public void markPublished() {
+		this.status = OutboxStatus.PUBLISHED;
+	}
+
+	public void markFailed() {
+		this.status = OutboxStatus.FAILED;
+		this.retryCount++;
+	}
+}

--- a/common/src/main/java/com/truve/platform/common/outbox/OutboxEventRepository.java
+++ b/common/src/main/java/com/truve/platform/common/outbox/OutboxEventRepository.java
@@ -1,0 +1,11 @@
+package com.truve.platform.common.outbox;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.NoRepositoryBean;
+
+@NoRepositoryBean
+public interface OutboxEventRepository<T extends OutboxEvent> extends JpaRepository<T, Long> {
+	List<T> findByStatus(OutboxStatus status);
+}

--- a/common/src/main/java/com/truve/platform/common/outbox/OutboxEventRepository.java
+++ b/common/src/main/java/com/truve/platform/common/outbox/OutboxEventRepository.java
@@ -8,4 +8,6 @@ import org.springframework.data.repository.NoRepositoryBean;
 @NoRepositoryBean
 public interface OutboxEventRepository<T extends OutboxEvent> extends JpaRepository<T, Long> {
 	List<T> findByStatus(OutboxStatus status);
+
+	void deleteByStatus(OutboxStatus status);
 }

--- a/common/src/main/java/com/truve/platform/common/outbox/OutboxRelayExecutor.java
+++ b/common/src/main/java/com/truve/platform/common/outbox/OutboxRelayExecutor.java
@@ -1,0 +1,38 @@
+package com.truve.platform.common.outbox;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OutboxRelayExecutor {
+
+	private final KafkaTemplate<String, String> kafkaTemplate;
+
+	public void execute(List<? extends OutboxEvent> pendingEvents) {
+		for (OutboxEvent event : pendingEvents) {
+			try {
+				ProducerRecord<String, String> record =
+					new ProducerRecord<>(event.getTopic(), event.getMessageKey(), event.getPayload());
+				record.headers().add("event-type", event.getEventType().getBytes(StandardCharsets.UTF_8));
+
+				kafkaTemplate.send(record).get();
+
+				event.markPublished();
+				log.info("[Outbox Relay] Published - topic: {}, key: {}, eventType: {}",
+					event.getTopic(), event.getMessageKey(), event.getEventType());
+			} catch (Exception e) {
+				event.markFailed();
+				log.error("[Outbox Relay] Failed - id: {}, retryCount: {}", event.getId(), event.getRetryCount(), e);
+			}
+		}
+	}
+}

--- a/common/src/main/java/com/truve/platform/common/outbox/OutboxRelayExecutor.java
+++ b/common/src/main/java/com/truve/platform/common/outbox/OutboxRelayExecutor.java
@@ -27,8 +27,8 @@ public class OutboxRelayExecutor {
 				kafkaTemplate.send(record).get();
 
 				event.markPublished();
-				log.info("[Outbox Relay] Published - topic: {}, key: {}, eventType: {}",
-					event.getTopic(), event.getMessageKey(), event.getEventType());
+				log.info("[Outbox Relay] Published - topic: {}, key: {}, eventType: {}, payload: {}",
+					event.getTopic(), event.getMessageKey(), event.getEventType(), event.getPayload());
 			} catch (Exception e) {
 				event.markFailed();
 				log.error("[Outbox Relay] Failed - id: {}, retryCount: {}", event.getId(), event.getRetryCount(), e);

--- a/common/src/main/java/com/truve/platform/common/outbox/OutboxStatus.java
+++ b/common/src/main/java/com/truve/platform/common/outbox/OutboxStatus.java
@@ -1,0 +1,5 @@
+package com.truve.platform.common.outbox;
+
+public enum OutboxStatus {
+	PENDING, PUBLISHED, FAILED
+}

--- a/common/src/main/java/com/truve/platform/common/support/JsonConverter.java
+++ b/common/src/main/java/com/truve/platform/common/support/JsonConverter.java
@@ -23,4 +23,12 @@ public class JsonConverter {
 			throw new CustomException(ErrorCode.EVENT_DESERIALIZATION_FAILED);
 		}
 	}
+
+	public String serialize(Object object) {
+		try {
+			return objectMapper.writeValueAsString(object);
+		} catch (IOException e) {
+			throw new CustomException(ErrorCode.EVENT_SERIALIZATION_FAILED);
+		}
+	}
 }

--- a/payment/src/main/java/com/truve/platform/payment/service/PaymentApplication.java
+++ b/payment/src/main/java/com/truve/platform/payment/service/PaymentApplication.java
@@ -4,10 +4,12 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication(scanBasePackages = "com.truve.platform")
 @ConfigurationPropertiesScan
 @EnableAsync
+@EnableScheduling
 public class PaymentApplication {
 	public static void main(String[] args) {
 		SpringApplication.run(PaymentApplication.class, args);

--- a/payment/src/main/java/com/truve/platform/payment/service/domain/entity/PaymentOutboxEvent.java
+++ b/payment/src/main/java/com/truve/platform/payment/service/domain/entity/PaymentOutboxEvent.java
@@ -1,0 +1,27 @@
+package com.truve.platform.payment.service.domain.entity;
+
+import com.truve.platform.common.outbox.OutboxEvent;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "payment_outbox_events")
+public class PaymentOutboxEvent extends OutboxEvent {
+
+	@Builder
+	public static PaymentOutboxEvent create(String topic, String messageKey, String payload, String eventType) {
+		return new PaymentOutboxEvent(topic, messageKey, payload, eventType);
+	}
+
+	private PaymentOutboxEvent(String topic, String messageKey, String payload, String eventType) {
+		super(topic, messageKey, payload, eventType);
+	}
+}
+

--- a/payment/src/main/java/com/truve/platform/payment/service/event/PaymentUpdatedListener.java
+++ b/payment/src/main/java/com/truve/platform/payment/service/event/PaymentUpdatedListener.java
@@ -19,7 +19,7 @@ public class PaymentUpdatedListener {
 	private final BookingPublisher bookingPublisher;
 	private final MembershipPublisher membershipPublisher;
 
-	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+	@TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
 	public void onConfirmed(PaymentUpdated.Confirmed event) {
 		if (isMembershipOrder(event.getOrderId())) {
 			if (event.getStatus() == com.truve.platform.payment.service.domain.constant.PaymentStatus.DONE) {
@@ -44,7 +44,7 @@ public class PaymentUpdatedListener {
 			));
 	}
 
-	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+	@TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
 	public void onDepositReceived(PaymentUpdated.DepositReceived event) {
 		if (isMembershipOrder(event.getOrderId())) {
 			membershipPublisher.publish(new MembershipEventCommand.DepositReceived(event.getOrderId()));

--- a/payment/src/main/java/com/truve/platform/payment/service/external/kafka/OutboxRelayScheduler.java
+++ b/payment/src/main/java/com/truve/platform/payment/service/external/kafka/OutboxRelayScheduler.java
@@ -28,4 +28,10 @@ public class OutboxRelayScheduler {
 			outboxRelayExecutor.execute(pending);
 		}
 	}
+
+	@Scheduled(cron = "0 0 3 * * *")
+	@Transactional
+	public void deletePublished() {
+		outboxRepository.deleteByStatus(OutboxStatus.PUBLISHED);
+	}
 }

--- a/payment/src/main/java/com/truve/platform/payment/service/external/kafka/OutboxRelayScheduler.java
+++ b/payment/src/main/java/com/truve/platform/payment/service/external/kafka/OutboxRelayScheduler.java
@@ -1,0 +1,31 @@
+package com.truve.platform.payment.service.external.kafka;
+
+import java.util.List;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.truve.platform.common.outbox.OutboxRelayExecutor;
+import com.truve.platform.common.outbox.OutboxStatus;
+import com.truve.platform.payment.service.domain.entity.PaymentOutboxEvent;
+import com.truve.platform.payment.service.repository.PaymentOutboxEventRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class OutboxRelayScheduler {
+
+	private final PaymentOutboxEventRepository outboxRepository;
+	private final OutboxRelayExecutor outboxRelayExecutor;
+
+	@Scheduled(fixedDelay = 3000)
+	@Transactional
+	public void relay() {
+		List<PaymentOutboxEvent> pending = outboxRepository.findByStatus(OutboxStatus.PENDING);
+		if (!pending.isEmpty()) {
+			outboxRelayExecutor.execute(pending);
+		}
+	}
+}

--- a/payment/src/main/java/com/truve/platform/payment/service/external/kafka/booking/BookingConsumer.java
+++ b/payment/src/main/java/com/truve/platform/payment/service/external/kafka/booking/BookingConsumer.java
@@ -23,17 +23,13 @@ public class BookingConsumer {
 
 	@KafkaListener(topics = TOPIC, groupId = GROUP)
 	public void consume(String payload, @Header("event-type") String type) {
-		switch (type) {
-			case "CREATE" -> handleCreate(payload);
-			case "CANCEL" -> handleCancel(payload);
+		if (type.equals("CREATE")) {
+			handleCreate(payload);
 		}
 	}
 
 	private void handleCreate(String payload) {
 		PaymentEventCommand.Create request = jsonConverter.convert(payload, PaymentEventCommand.Create.class);
 		paymentService.create(request);
-	}
-
-	private void handleCancel(String payload) {
 	}
 }

--- a/payment/src/main/java/com/truve/platform/payment/service/external/kafka/booking/BookingPublisher.java
+++ b/payment/src/main/java/com/truve/platform/payment/service/external/kafka/booking/BookingPublisher.java
@@ -2,7 +2,9 @@ package com.truve.platform.payment.service.external.kafka.booking;
 
 import org.springframework.stereotype.Component;
 
-import com.truve.platform.common.event.EventPublisher;
+import com.truve.platform.common.support.JsonConverter;
+import com.truve.platform.payment.service.domain.entity.PaymentOutboxEvent;
+import com.truve.platform.payment.service.repository.PaymentOutboxEventRepository;
 
 import lombok.RequiredArgsConstructor;
 
@@ -11,9 +13,15 @@ import lombok.RequiredArgsConstructor;
 public class BookingPublisher {
 	private static final String TOPIC = "payment.booking";
 
-	private final EventPublisher eventPublisher;
+	private final JsonConverter jsonConverter;
+	private final PaymentOutboxEventRepository outboxEventRepository;
 
 	public void publish(BookingEventCommand.BookingEvent command) {
-		eventPublisher.publish(TOPIC, command.getReservationNumber(), command.getEventType(), command);
+		outboxEventRepository.save(PaymentOutboxEvent.create(
+			TOPIC,
+			command.getReservationNumber(),
+			jsonConverter.serialize(command),
+			command.getEventType()
+		));
 	}
 }

--- a/payment/src/main/java/com/truve/platform/payment/service/external/kafka/membership/MembershipPublisher.java
+++ b/payment/src/main/java/com/truve/platform/payment/service/external/kafka/membership/MembershipPublisher.java
@@ -2,7 +2,9 @@ package com.truve.platform.payment.service.external.kafka.membership;
 
 import org.springframework.stereotype.Component;
 
-import com.truve.platform.common.event.EventPublisher;
+import com.truve.platform.common.support.JsonConverter;
+import com.truve.platform.payment.service.domain.entity.PaymentOutboxEvent;
+import com.truve.platform.payment.service.repository.PaymentOutboxEventRepository;
 
 import lombok.RequiredArgsConstructor;
 
@@ -11,9 +13,15 @@ import lombok.RequiredArgsConstructor;
 public class MembershipPublisher {
 	private static final String TOPIC = "payment.membership";
 
-	private final EventPublisher eventPublisher;
+	private final JsonConverter jsonConverter;
+	private final PaymentOutboxEventRepository outboxEventRepository;
 
 	public void publish(MembershipEventCommand.MembershipEvent command) {
-		eventPublisher.publish(TOPIC, command.getOrderId(), command.getEventType(), command);
+		outboxEventRepository.save(PaymentOutboxEvent.create(
+			TOPIC,
+			command.getOrderId(),
+			jsonConverter.serialize(command),
+			command.getEventType()
+		));
 	}
 }

--- a/payment/src/main/java/com/truve/platform/payment/service/repository/PaymentOutboxEventRepository.java
+++ b/payment/src/main/java/com/truve/platform/payment/service/repository/PaymentOutboxEventRepository.java
@@ -1,0 +1,7 @@
+package com.truve.platform.payment.service.repository;
+
+import com.truve.platform.common.outbox.OutboxEventRepository;
+import com.truve.platform.payment.service.domain.entity.PaymentOutboxEvent;
+
+public interface PaymentOutboxEventRepository extends OutboxEventRepository<PaymentOutboxEvent> {
+}

--- a/payment/src/main/resources/application.yml
+++ b/payment/src/main/resources/application.yml
@@ -16,7 +16,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: validate
+      ddl-auto: update
     show-sql: false
 
   kafka:


### PR DESCRIPTION
## 변경 사항

---
```mermaid                                                                                                                                                                   
  sequenceDiagram                                                                                                                                                              
      participant PS as PaymentService                                                                                                                                         
      participant EP as ApplicationEventPublisher                                                                                                                              
      participant PUL as PaymentUpdatedListener<br/>(BEFORE_COMMIT)                                                                                                            
      participant PUB as BookingPublisher /<br/>MembershipPublisher                                                                                                            
      participant DB as payment_outbox_events                                                                                                                                  
      participant SCH as OutboxRelayScheduler                                                                                                                                  
      participant EX as OutboxRelayExecutor                                                                                                                                    
      participant K as Kafka                                                                                                                                                   
                                                                                                                                                                               
      rect rgb(220, 240, 255)                                                                                                                                                  
          note over PS, DB: 하나의 트랜잭션                                                                                                                                    
          PS->>EP: publishEvent()                                                                                                                                              
          EP->>PUL: onConfirmed() / onDepositReceived()                                                                                                                        
          PUL->>PUB: publish(command)                                                                                                                                          
          PUB->>DB: save(PaymentOutboxEvent) [PENDING]                                                                                                                         
      end                                                                                                                                                                      
                                                                                                                                                                               
      loop 3초마다                                                                                                                                                             
          SCH->>DB: findByStatus(PENDING)                                                                                                                                      
          DB-->>SCH: pending events                                                                                                                                            
          SCH->>EX: execute(pendingEvents)                                                                                                                                     
          EX->>K: kafkaTemplate.send().get()                                                                                                                                   
          alt 성공                                                                                                                                                             
              EX->>DB: markPublished() [PUBLISHED]                                                                                                                             
          else 실패                                                                                                                                                            
              EX->>DB: markFailed() [FAILED, retryCount++]                                                                                                                     
          end                                                                                                                                                                  
      end                                                                                                                                                                      
                                                                                                                                                                               
      loop 매일 새벽 3시                                                                                                                                                       
          SCH->>DB: deleteByStatus(PUBLISHED)                                                                                                                                  
      end                                                                                                                                                                      
  ```    

## Payment 서비스에 아웃박스 패턴 도입

[기존] Publisher에서 즉시 카프카 이벤트 발행 
[변경] Publisher에서는 Outbox 테이블에 이벤트를 저장만 하고, 스케쥴러(`OutboxRelayScheduler`)를 통해 3초마다 Outbox 테이블에 저장된 미발행 이벤트를 카프카로 발행

발행된 이벤트는 새벽 3시마다 Outbox 테이블에서 삭제

## JsonConverter에 직렬화 메서드 추가

Json으로 직렬화하고 에러를 캐치하는 메서드를 추가했으며, KafkaEventPublisher와 각 서비스 코드에서 이를 사용하도록 변경

- [X] 전체 테스트 코드 성공 여부

## 관련 이슈

---
- Notion Ticket: #

## 참고사항 (선택)

---

(별 내용은 없지만 포트폴리오 쓰실 때 참고하세요 . . .)

## Outbox Pattern 도입 배경

기존에는 트랜잭션 커밋 후(AFTER_COMMIT) 내부 이벤트를 통해 Kafka 이벤트를 발행하도록 구현했으나, Kafka 발행 실패 시 데이터 불일치가 보장되지 않는다는 문제를 발견해 Outbox Pattern 도입

Outbox Pattern 도입 후, **Payment 엔티티 변경과 Outbox 이벤트 저장이 같은 트랜잭션에서 원자적으로 처리됨**

 1. 커밋 롤백 시 데이터 불일치 방지 
 2. 이벤트 발행 실패 시 재시도 로직 실행 
 3. 실패한 이벤트 모니터링/추적 용이

위의 세 가지 이점을 가지게 됨

## 고민 과정 

### Outbox 테이블은 어디에 위치해야 하는가? / 내부 이벤트 처리 시점 ( BEFORE_COMMIT vs AFTER_COMMIT )

**Payment 엔티티 변경과 Outbox 이벤트 저장이 같은 트랜잭션에서 원자적으로 처리되어야 하기 때문에** 각 서비스의 DB에 두어야 하며, BEFORE_COMMIT이어야 함.

### `OutboxRelayExecutor`에서 kafkaTemplate.send().get()을 사용한 이유

kafkaTemplate.send()는 비동기로 작동하기 때문에 이벤트 발행 성공 여부를 알 수 없음. 동기 블로킹으로 성공/실패 여부를 즉시 확인해 상태를 업데이트

### Outbox Relay Executor 성능

현재 지정한 시간(3초)마다 Outbox 테이블을 조회하고, PENDING 상태인 이벤트를 찾아 발행
-> DB를 3초마다 조회하는데 성능상 괜찮은가?

: 새벽마다 이미 발행한 이벤트를 삭제하는 스케쥴러가 있기 때문에 Outbox 테이블 자체의 크기가 크지 않아 괜찮을 것으로 판단.
PENDING인 이벤트가 없으면 조회만 하고 끝나기 때문에 부하가 미미함
트래픽이 많은 서비스라면, status에 인덱스를 걸거나 조회 간격을 늘리는 것을 고려

### 이벤트 중복 발행 문제

kafkaTemplate.send.get -> markPublished 사이에 서버가 재시작되면 이벤트가 중복으로 발행될 수 있음 (이론상..)

서비스단에서 멱등성을 보장하도록 구현할 필요가 있다.

