### PR TITLE
feat(secure): 결제 진입 시 BE모델 결과 확인

### DIFF
--- a/common/src/main/java/com/truve/platform/common/exception/ErrorCode.java
+++ b/common/src/main/java/com/truve/platform/common/exception/ErrorCode.java
@@ -60,6 +60,7 @@ public enum ErrorCode {
 	INVALID_TICKET_ID(HttpStatus.BAD_REQUEST, "유효하지 않는 티켓 ID입니다.", "B03"),
 	ALREADY_CANCELED_OR_COMPLETED(HttpStatus.BAD_REQUEST, "이미 취소됐거나 관람이 완료된 예매입니다.", "B04"),
 	ALREADY_CANCELED_TICKET(HttpStatus.BAD_REQUEST, "이미 취소된 티켓입니다.", "B05"),
+	PAYMENT_RESTRICTED_BY_RISK(HttpStatus.BAD_REQUEST, "비정상 결제 시도가 감지되어 현재 결제를 진행할 수 없습니다. 잠시 후 다시 시도해 주세요.", "B06"),
 
 	NOT_FOUND_SHOW(HttpStatus.NOT_FOUND, "존재하지 않는 공연입니다.", "M01"),
 	NOT_FOUND_ARTIST(HttpStatus.NOT_FOUND, "존재하지 않는 배우입니다.", "M02"),

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/risk/controller/BotRiskInternalController.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/risk/controller/BotRiskInternalController.java
@@ -1,0 +1,28 @@
+package org.truve.platform.ticketing.service.booking.risk.controller;
+
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.truve.platform.ticketing.service.booking.risk.dto.BeBotRiskReportRequest;
+import org.truve.platform.ticketing.service.booking.risk.service.BookingBotRiskService;
+
+import com.truve.platform.common.response.ApiResult;
+
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/bookings/internal/bot-risk")
+public class BotRiskInternalController {
+
+	private final BookingBotRiskService bookingBotRiskService;
+
+	@Operation(summary = "BE 봇 탐지 결과 반영", description = "결제 이후 판정된 BE 봇 탐지 결과를 사용자 요약 정보에 반영합니다.")
+	@PostMapping("/be")
+	public ApiResult<Void> reportBeRisk(@RequestBody BeBotRiskReportRequest request) {
+		bookingBotRiskService.reportBeRisk(request);
+		return ApiResult.ok();
+	}
+}

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/risk/domain/entity/BookingBotRiskSummary.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/risk/domain/entity/BookingBotRiskSummary.java
@@ -1,0 +1,84 @@
+package org.truve.platform.ticketing.service.booking.risk.domain.entity;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import org.truve.platform.ticketing.service.booking.risk.dto.BeBotRiskReportRequest;
+
+import com.truve.platform.common.support.BaseEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "booking_bot_risk_summary")
+public class BookingBotRiskSummary extends BaseEntity {
+
+	@Column(nullable = false, unique = true)
+	private UUID userId;
+
+	@Column(nullable = false)
+	private Integer riskCount;
+
+	@Column
+	private String lastOrderId;
+
+	@Column
+	private LocalDateTime blockedUntil;
+
+	@Column(nullable = false)
+	private Boolean extraAuthRequired;
+
+	@Builder
+	private BookingBotRiskSummary(
+		UUID userId,
+		Integer riskCount,
+		String lastOrderId,
+		LocalDateTime blockedUntil,
+		Boolean extraAuthRequired
+	) {
+		this.userId = userId;
+		this.riskCount = riskCount;
+		this.lastOrderId = lastOrderId;
+		this.blockedUntil = blockedUntil;
+		this.extraAuthRequired = extraAuthRequired;
+	}
+
+	public static BookingBotRiskSummary create(UUID userId) {
+		return BookingBotRiskSummary.builder()
+			.userId(userId)
+			.riskCount(0)
+			.extraAuthRequired(false)
+			.build();
+	}
+
+	public boolean isDuplicateOrder(String orderId) {
+		return orderId != null && orderId.equals(lastOrderId);
+	}
+
+	public boolean isBlocked(LocalDateTime now) {
+		return blockedUntil != null && blockedUntil.isAfter(now);
+	}
+
+	public void applyBotDetection(BeBotRiskReportRequest request, LocalDateTime now) {
+		riskCount += 1;
+		lastOrderId = request.getOrderId();
+
+		if (riskCount >= 3) {
+			extraAuthRequired = true;
+		}
+
+		if (riskCount == 4) {
+			blockedUntil = now.plusHours(24);
+		} else if (riskCount >= 5) {
+			blockedUntil = now.plusDays(7);
+		}
+	}
+}

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/risk/dto/BeBotRiskReportRequest.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/risk/dto/BeBotRiskReportRequest.java
@@ -1,0 +1,41 @@
+package org.truve.platform.ticketing.service.booking.risk.dto;
+
+import java.util.UUID;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class BeBotRiskReportRequest {
+
+	@JsonProperty("X-User-Id")
+	private UUID userId;
+
+	@JsonProperty("orderId")
+	private String orderId;
+
+	@JsonProperty("label")
+	private String label;
+
+	@JsonProperty("bot_score")
+	private Double botScore;
+
+	@JsonProperty("model_type")
+	private String modelType;
+
+	@JsonProperty("model_name")
+	private String modelName;
+
+	@JsonProperty("policy_action")
+	private String policyAction;
+
+	@JsonProperty("risk_count")
+	private Integer riskCount;
+
+	public boolean isBot() {
+		return label != null && "bot".equalsIgnoreCase(label);
+	}
+}

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/risk/repository/BookingBotRiskSummaryRepository.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/risk/repository/BookingBotRiskSummaryRepository.java
@@ -1,0 +1,11 @@
+package org.truve.platform.ticketing.service.booking.risk.repository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.truve.platform.ticketing.service.booking.risk.domain.entity.BookingBotRiskSummary;
+
+public interface BookingBotRiskSummaryRepository extends JpaRepository<BookingBotRiskSummary, Long> {
+	Optional<BookingBotRiskSummary> findByUserId(UUID userId);
+}

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/risk/service/BookingBotRiskService.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/risk/service/BookingBotRiskService.java
@@ -1,0 +1,48 @@
+package org.truve.platform.ticketing.service.booking.risk.service;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.truve.platform.ticketing.service.booking.risk.domain.entity.BookingBotRiskSummary;
+import org.truve.platform.ticketing.service.booking.risk.dto.BeBotRiskReportRequest;
+import org.truve.platform.ticketing.service.booking.risk.repository.BookingBotRiskSummaryRepository;
+
+import com.truve.platform.common.exception.CustomException;
+import com.truve.platform.common.exception.ErrorCode;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class BookingBotRiskService {
+
+	private final BookingBotRiskSummaryRepository bookingBotRiskSummaryRepository;
+
+	@Transactional
+	public void reportBeRisk(BeBotRiskReportRequest request) {
+		if (!request.isBot() || request.getUserId() == null) {
+			return;
+		}
+
+		BookingBotRiskSummary summary = bookingBotRiskSummaryRepository.findByUserId(request.getUserId())
+			.orElseGet(() -> BookingBotRiskSummary.create(request.getUserId()));
+
+		if (summary.isDuplicateOrder(request.getOrderId())) {
+			return;
+		}
+
+		summary.applyBotDetection(request, LocalDateTime.now());
+		bookingBotRiskSummaryRepository.save(summary);
+	}
+
+	@Transactional(readOnly = true)
+	public void validatePaymentReady(UUID userId) {
+		bookingBotRiskSummaryRepository.findByUserId(userId)
+			.filter(summary -> summary.isBlocked(LocalDateTime.now()))
+			.ifPresent(summary -> {
+				throw new CustomException(ErrorCode.PAYMENT_RESTRICTED_BY_RISK);
+			});
+	}
+}

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/risk/service/BookingBotRiskService.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/risk/service/BookingBotRiskService.java
@@ -1,5 +1,6 @@
 package org.truve.platform.ticketing.service.booking.risk.service;
 
+import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
@@ -39,10 +40,42 @@ public class BookingBotRiskService {
 
 	@Transactional(readOnly = true)
 	public void validatePaymentReady(UUID userId) {
+		LocalDateTime now = LocalDateTime.now();
+
 		bookingBotRiskSummaryRepository.findByUserId(userId)
-			.filter(summary -> summary.isBlocked(LocalDateTime.now()))
+			.filter(summary -> summary.isBlocked(now))
 			.ifPresent(summary -> {
-				throw new CustomException(ErrorCode.PAYMENT_RESTRICTED_BY_RISK);
+				throw new CustomException(
+					ErrorCode.PAYMENT_RESTRICTED_BY_RISK,
+					buildBlockedMessage(now, summary.getBlockedUntil())
+				);
 			});
+	}
+
+	private String buildBlockedMessage(LocalDateTime now, LocalDateTime blockedUntil) {
+		if (blockedUntil == null) {
+			return ErrorCode.PAYMENT_RESTRICTED_BY_RISK.getMessage();
+		}
+
+		Duration duration = Duration.between(now, blockedUntil);
+		long totalMinutes = Math.max(1, duration.toMinutes());
+		long days = totalMinutes / (24 * 60);
+		long hours = (totalMinutes % (24 * 60)) / 60;
+		long minutes = totalMinutes % 60;
+
+		StringBuilder remaining = new StringBuilder();
+		if (days > 0) {
+			remaining.append(days).append("일 ");
+		}
+		if (hours > 0) {
+			remaining.append(hours).append("시간 ");
+		}
+		if (minutes > 0 || remaining.length() == 0) {
+			remaining.append(minutes).append("분 ");
+		}
+
+		return "비정상 결제 시도가 감지되어 현재 결제를 진행할 수 없습니다. "
+			+ remaining.toString().trim()
+			+ " 후 다시 시도해 주세요.";
 	}
 }

--- a/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/service/BookingService.java
+++ b/ticketing/src/main/java/org/truve/platform/ticketing/service/booking/service/BookingService.java
@@ -8,7 +8,6 @@ import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
-
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.truve.platform.ticketing.service.booking.domain.entity.Reservation;
@@ -26,6 +25,7 @@ import org.truve.platform.ticketing.service.booking.external.kafka.PaymentEventC
 import org.truve.platform.ticketing.service.booking.external.kafka.PaymentPublisher;
 import org.truve.platform.ticketing.service.booking.external.kafka.TicketingEventCommand;
 import org.truve.platform.ticketing.service.booking.external.kafka.TicketingPublisher;
+import org.truve.platform.ticketing.service.booking.risk.service.BookingBotRiskService;
 import org.truve.platform.ticketing.service.booking.repository.ReservationRepository;
 import org.truve.platform.ticketing.service.booking.util.NumberGenerator;
 
@@ -43,6 +43,7 @@ public class BookingService {
 	private final PaymentPublisher paymentPublisher;
 	private final PaymentClient paymentClient;
 	private final TicketingPublisher ticketingPublisher;
+	private final BookingBotRiskService bookingBotRiskService;
 
 	@Transactional
 	public BookingResponse.Create create(UUID userId, BookingRequest.Create request) {
@@ -135,6 +136,7 @@ public class BookingService {
 	@Transactional
 	public void paymentReady(String reservationNumber, BookingRequest.ApplicantInfo request) {
 		Reservation reservation = reservationRepository.findByNumber(reservationNumber);
+		bookingBotRiskService.validatePaymentReady(reservation.getUserId());
 
 		reservation.readyForPayment(request.toEntity());
 

--- a/ticketing/src/test/java/org/truve/platform/ticketing/service/booking/risk/service/BookingBotRiskServiceTest.java
+++ b/ticketing/src/test/java/org/truve/platform/ticketing/service/booking/risk/service/BookingBotRiskServiceTest.java
@@ -71,6 +71,9 @@ class BookingBotRiskServiceTest {
 		);
 
 		// then
-		assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.PAYMENT_RESTRICTED_BY_RISK);
+		assertAll(
+			() -> assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.PAYMENT_RESTRICTED_BY_RISK),
+			() -> assertThat(exception.getMessage()).contains("후 다시 시도해 주세요")
+		);
 	}
 }

--- a/ticketing/src/test/java/org/truve/platform/ticketing/service/booking/risk/service/BookingBotRiskServiceTest.java
+++ b/ticketing/src/test/java/org/truve/platform/ticketing/service/booking/risk/service/BookingBotRiskServiceTest.java
@@ -1,0 +1,76 @@
+package org.truve.platform.ticketing.service.booking.risk.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+import static org.mockito.Mockito.*;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.truve.platform.ticketing.service.booking.risk.domain.entity.BookingBotRiskSummary;
+import org.truve.platform.ticketing.service.booking.risk.dto.BeBotRiskReportRequest;
+import org.truve.platform.ticketing.service.booking.risk.repository.BookingBotRiskSummaryRepository;
+
+import com.truve.platform.common.exception.CustomException;
+import com.truve.platform.common.exception.ErrorCode;
+
+@ExtendWith(MockitoExtension.class)
+class BookingBotRiskServiceTest {
+
+	@Mock
+	private BookingBotRiskSummaryRepository bookingBotRiskSummaryRepository;
+
+	@InjectMocks
+	private BookingBotRiskService bookingBotRiskService;
+
+	@Test
+	@DisplayName("같은 orderId로 들어온 BE bot 판정은 중복 집계하지 않는다.")
+	void 같은주문번호는_중복집계하지않는다() {
+		// given
+		UUID userId = UUID.fromString("11111111-1111-1111-1111-111111111111");
+		BookingBotRiskSummary summary = BookingBotRiskSummary.create(userId);
+		ReflectionTestUtils.setField(summary, "lastOrderId", "order-1");
+
+		BeBotRiskReportRequest request = new BeBotRiskReportRequest();
+		ReflectionTestUtils.setField(request, "userId", userId);
+		ReflectionTestUtils.setField(request, "orderId", "order-1");
+		ReflectionTestUtils.setField(request, "label", "bot");
+
+		given(bookingBotRiskSummaryRepository.findByUserId(userId)).willReturn(Optional.of(summary));
+
+		// when
+		bookingBotRiskService.reportBeRisk(request);
+
+		// then
+		verify(bookingBotRiskSummaryRepository, never()).save(any());
+	}
+
+	@Test
+	@DisplayName("차단 기간 안의 유저는 paymentReady 전에 PAYMENT_RESTRICTED_BY_RISK 예외가 발생한다.")
+	void 차단유저는_paymentReady전에_예외가발생한다() {
+		// given
+		UUID userId = UUID.fromString("11111111-1111-1111-1111-111111111111");
+		BookingBotRiskSummary summary = BookingBotRiskSummary.create(userId);
+		ReflectionTestUtils.setField(summary, "blockedUntil", LocalDateTime.now().plusHours(1));
+
+		given(bookingBotRiskSummaryRepository.findByUserId(userId)).willReturn(Optional.of(summary));
+
+		// when
+		CustomException exception = assertThrows(
+			CustomException.class,
+			() -> bookingBotRiskService.validatePaymentReady(userId)
+		);
+
+		// then
+		assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.PAYMENT_RESTRICTED_BY_RISK);
+	}
+}

--- a/ticketing/src/test/java/org/truve/platform/ticketing/service/booking/service/BookingServiceTest.java
+++ b/ticketing/src/test/java/org/truve/platform/ticketing/service/booking/service/BookingServiceTest.java
@@ -26,9 +26,11 @@ import org.truve.platform.ticketing.service.booking.external.client.payment.Paym
 import org.truve.platform.ticketing.service.booking.external.client.ticketing.TicketingClient;
 import org.truve.platform.ticketing.service.booking.external.client.ticketing.TicketingResponse;
 import org.truve.platform.ticketing.service.booking.external.kafka.BookingEventCommand;
+import org.truve.platform.ticketing.service.booking.external.kafka.PaymentEventCommand;
 import org.truve.platform.ticketing.service.booking.external.kafka.PaymentPublisher;
 import org.truve.platform.ticketing.service.booking.external.kafka.TicketingEventCommand;
 import org.truve.platform.ticketing.service.booking.external.kafka.TicketingPublisher;
+import org.truve.platform.ticketing.service.booking.risk.service.BookingBotRiskService;
 import org.truve.platform.ticketing.service.booking.repository.ReservationRepository;
 
 @ExtendWith(MockitoExtension.class)
@@ -44,6 +46,8 @@ class BookingServiceTest {
 	private PaymentPublisher paymentPublisher;
 	@Mock
 	private PaymentClient paymentClient;
+	@Mock
+	private BookingBotRiskService bookingBotRiskService;
 
 	@InjectMocks
 	private BookingService bookingService;
@@ -125,6 +129,35 @@ class BookingServiceTest {
 		assertAll(
 			() -> assertThat(soldConfirmed.getReservationNumber()).isEqualTo("R-001"),
 			() -> assertThat(soldConfirmed.getScheduledSeatIds()).containsExactly(1L, 2L)
+		);
+	}
+
+	@Test
+	@DisplayName("위험 사용자 차단이 없으면 paymentReady는 정상적으로 결제 생성 이벤트를 발행한다.")
+	void 결제준비_정상통과() {
+		// given
+		Reservation reservation = createReservation();
+		BookingRequest.ApplicantInfo request = new BookingRequest.ApplicantInfo(
+			"홍길동",
+			"19900101",
+			"test@test.com",
+			"01012341234"
+		);
+		given(reservationRepository.findByNumber("R-001")).willReturn(reservation);
+
+		// when
+		bookingService.paymentReady("R-001", request);
+
+		// then
+		ArgumentCaptor<PaymentEventCommand.Create> paymentEventCaptor =
+			ArgumentCaptor.forClass(PaymentEventCommand.Create.class);
+		verify(paymentPublisher).publish(paymentEventCaptor.capture());
+
+		assertAll(
+			() -> verify(bookingBotRiskService).validatePaymentReady(reservation.getUserId()),
+			() -> assertThat(paymentEventCaptor.getValue().getOrderId()).isEqualTo(reservation.getNumber()),
+			() -> assertThat(paymentEventCaptor.getValue().getAmount()).isEqualTo(reservation.getTotalAmount()),
+			() -> assertThat(reservation.getStatus()).isEqualTo(org.truve.platform.ticketing.service.booking.domain.constant.ReservationStatus.PENDING_PAYMENT)
 		);
 	}
 


### PR DESCRIPTION
## 변경 사항

추가/변경 사항과 사유를 작성해 주세요.

- [x] 전체 테스트 코드 성공 여부

### /api/bookings/internal/bot-risk
보안 서버에서 저희쪽으로 BE모델 결과를 찔러줍니다.
해당 결과는 BookingBotRiskSummary 엔티티에서 관리하고,
결제 진입시 체크합니다!


## 관련 이슈

---
- Notion Ticket: #

## 참고사항 (선택)

---